### PR TITLE
Fix scrollbar overlapping rounded border corners

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -458,13 +458,19 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         .scroll((scroll_y as u16, 0));
     frame.render_widget(paragraph, inner);
 
-    // Scrollbar (only when content overflows)
+    // Scrollbar on right border, inset to preserve rounded corners
     if content_height > available_height {
+        let scrollbar_area = Rect::new(
+            area.x + area.width.saturating_sub(1),
+            area.y + 1,
+            1,
+            area.height.saturating_sub(2),
+        );
         let mut scrollbar_state = ScrollbarState::new(base_scroll).position(scroll_y);
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
             .end_symbol(None);
-        frame.render_stateful_widget(scrollbar, area, &mut scrollbar_state);
+        frame.render_stateful_widget(scrollbar, scrollbar_area, &mut scrollbar_state);
     }
 }
 


### PR DESCRIPTION
## Summary
- Render scrollbar on a custom 1-column rect along the right border, inset by one row at top and bottom to preserve the rounded corners of the message pane.

## Test plan
- [x] Visual: scrollbar sits on the border line without covering the rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)