### PR TITLE
Add CI/CD workflows and install scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        run: cargo clippy --tests -- -D warnings
+
+      - name: Test
+        run: cargo test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  check:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Clippy
+        run: cargo clippy --tests -- -D warnings
+
+      - name: Test
+        run: cargo test
+
+  build:
+    name: Build (${{ matrix.target }})
+    needs: check
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            runner: macos-13
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            archive: tar.gz
+          - target: x86_64-pc-windows-msvc
+            runner: windows-latest
+            archive: zip
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: matrix.archive == 'tar.gz'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../signal-tui-${{ github.ref_name }}-${{ matrix.target }}.tar.gz signal-tui
+          cd ../../..
+
+      - name: Package (Windows)
+        if: matrix.archive == 'zip'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path "target/${{ matrix.target }}/release/signal-tui.exe" -DestinationPath "signal-tui-${{ github.ref_name }}-${{ matrix.target }}.zip"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: signal-tui-${{ matrix.target }}
+          path: signal-tui-${{ github.ref_name }}-${{ matrix.target }}.*
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: signal-tui-*

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,115 @@
+$ErrorActionPreference = "Stop"
+
+$Repo = "johnsideserf/signal-tui"
+$SignalCliRepo = "AsamK/signal-cli"
+$Target = "x86_64-pc-windows-msvc"
+$InstallDir = "$env:LOCALAPPDATA\signal-tui"
+
+function Info($msg) { Write-Host ":: $msg" -ForegroundColor Blue }
+function Err($msg) { Write-Host "error: $msg" -ForegroundColor Red; exit 1 }
+
+# --- Get latest release ---
+Info "Fetching latest release..."
+try {
+    $Release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest"
+} catch {
+    Err "Failed to fetch release info. Check your internet connection."
+}
+
+$Tag = $Release.tag_name
+if (-not $Tag) { Err "Could not determine latest release tag" }
+Info "Latest release: $Tag"
+
+# --- Download and install signal-tui ---
+$Archive = "signal-tui-$Tag-$Target.zip"
+$DownloadUrl = "https://github.com/$Repo/releases/download/$Tag/$Archive"
+$TmpDir = Join-Path $env:TEMP "signal-tui-install"
+
+if (Test-Path $TmpDir) { Remove-Item -Recurse -Force $TmpDir }
+New-Item -ItemType Directory -Path $TmpDir | Out-Null
+
+Info "Downloading $Archive..."
+try {
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile "$TmpDir\$Archive" -UseBasicParsing
+} catch {
+    Err "Download failed: $DownloadUrl"
+}
+
+if (-not (Test-Path $InstallDir)) {
+    New-Item -ItemType Directory -Path $InstallDir | Out-Null
+}
+
+Info "Extracting..."
+Expand-Archive -Path "$TmpDir\$Archive" -DestinationPath $TmpDir -Force
+Copy-Item "$TmpDir\signal-tui.exe" "$InstallDir\signal-tui.exe" -Force
+
+Info "Installed signal-tui to $InstallDir\signal-tui.exe"
+
+# --- Add to PATH ---
+$UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($UserPath -notlike "*$InstallDir*") {
+    [Environment]::SetEnvironmentVariable("Path", "$InstallDir;$UserPath", "User")
+    Info "Added $InstallDir to user PATH"
+} else {
+    Info "$InstallDir already in PATH"
+}
+
+# --- Check for signal-cli ---
+$SignalCli = Get-Command signal-cli -ErrorAction SilentlyContinue
+if ($SignalCli) {
+    Info "signal-cli found: $($SignalCli.Source)"
+} else {
+    Info "signal-cli not found"
+
+    # Check for Java
+    $Java = Get-Command java -ErrorAction SilentlyContinue
+    if ($Java) {
+        Info "Java found, installing signal-cli..."
+
+        try {
+            $ScliRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/$SignalCliRepo/releases/latest"
+        } catch {
+            Err "Failed to fetch signal-cli release info"
+        }
+
+        $ScliTag = $ScliRelease.tag_name
+        $ScliVersion = $ScliTag.TrimStart("v")
+        $ScliArchive = "signal-cli-$ScliVersion.tar.gz"
+        $ScliUrl = "https://github.com/$SignalCliRepo/releases/download/$ScliTag/$ScliArchive"
+
+        Info "Downloading signal-cli $ScliTag..."
+        try {
+            Invoke-WebRequest -Uri $ScliUrl -OutFile "$TmpDir\$ScliArchive" -UseBasicParsing
+        } catch {
+            Err "signal-cli download failed: $ScliUrl"
+        }
+
+        Info "Extracting signal-cli..."
+        tar xzf "$TmpDir\$ScliArchive" -C $TmpDir
+
+        $ScliDir = "$InstallDir\signal-cli"
+        if (Test-Path $ScliDir) { Remove-Item -Recurse -Force $ScliDir }
+        Copy-Item "$TmpDir\signal-cli-$ScliVersion" $ScliDir -Recurse
+
+        # Create a wrapper batch file
+        $WrapperContent = "@echo off`r`njava -jar `"%~dp0signal-cli\lib\signal-cli.jar`" %*"
+        Set-Content -Path "$InstallDir\signal-cli.bat" -Value $WrapperContent
+
+        Info "Installed signal-cli to $ScliDir"
+    } else {
+        Write-Host ""
+        Info "signal-cli requires Java 21+. Install Java from:"
+        Write-Host ""
+        Write-Host "  https://adoptium.net/"
+        Write-Host ""
+        Info "Then re-run this script to install signal-cli."
+        Write-Host ""
+    }
+}
+
+# --- Cleanup ---
+Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue
+
+# --- Done ---
+Write-Host ""
+Info "Done! Restart your terminal, then run 'signal-tui' to get started."

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="johnsideserf/signal-tui"
+INSTALL_DIR="$HOME/.local/bin"
+SIGNAL_CLI_REPO="AsamK/signal-cli"
+
+# Cleanup on exit
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+info()  { printf '\033[1;34m::\033[0m %s\n' "$*"; }
+error() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# --- Detect platform ---
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)
+    case "$ARCH" in
+      x86_64)  TARGET="x86_64-unknown-linux-gnu" ;;
+      *)       error "Unsupported Linux architecture: $ARCH" ;;
+    esac
+    ;;
+  Darwin)
+    case "$ARCH" in
+      x86_64)  TARGET="x86_64-apple-darwin" ;;
+      arm64)   TARGET="aarch64-apple-darwin" ;;
+      *)       error "Unsupported macOS architecture: $ARCH" ;;
+    esac
+    ;;
+  *)
+    error "Unsupported OS: $OS (use install.ps1 for Windows)"
+    ;;
+esac
+
+info "Detected platform: $TARGET"
+
+# --- Get latest release tag ---
+info "Fetching latest release..."
+LATEST_URL="https://api.github.com/repos/$REPO/releases/latest"
+RELEASE_JSON="$(curl -fsSL "$LATEST_URL")" || error "Failed to fetch release info. Check your internet connection."
+TAG="$(printf '%s' "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+
+if [ -z "$TAG" ]; then
+  error "Could not determine latest release tag"
+fi
+
+info "Latest release: $TAG"
+
+# --- Download and install signal-tui ---
+ARCHIVE="signal-tui-${TAG}-${TARGET}.tar.gz"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/$TAG/$ARCHIVE"
+
+info "Downloading $ARCHIVE..."
+curl -fsSL -o "$TMPDIR/$ARCHIVE" "$DOWNLOAD_URL" || error "Download failed: $DOWNLOAD_URL"
+
+mkdir -p "$INSTALL_DIR"
+tar xzf "$TMPDIR/$ARCHIVE" -C "$INSTALL_DIR"
+chmod +x "$INSTALL_DIR/signal-tui"
+
+info "Installed signal-tui to $INSTALL_DIR/signal-tui"
+
+# --- Check for signal-cli ---
+if command -v signal-cli >/dev/null 2>&1; then
+  info "signal-cli found: $(command -v signal-cli)"
+else
+  info "signal-cli not found"
+
+  if [ "$OS" = "Linux" ]; then
+    info "Installing signal-cli native build (no Java required)..."
+
+    # Get latest signal-cli release tag
+    SCLI_JSON="$(curl -fsSL "https://api.github.com/repos/$SIGNAL_CLI_REPO/releases/latest")" || error "Failed to fetch signal-cli release info"
+    SCLI_TAG="$(printf '%s' "$SCLI_JSON" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')"
+
+    if [ -z "$SCLI_TAG" ]; then
+      error "Could not determine latest signal-cli release tag"
+    fi
+
+    SCLI_VERSION="${SCLI_TAG#v}"
+    SCLI_ARCHIVE="signal-cli-native-${SCLI_VERSION}-Linux-x86-64.tar.gz"
+    SCLI_URL="https://github.com/$SIGNAL_CLI_REPO/releases/download/$SCLI_TAG/$SCLI_ARCHIVE"
+
+    info "Downloading signal-cli $SCLI_TAG native build..."
+    curl -fsSL -o "$TMPDIR/$SCLI_ARCHIVE" "$SCLI_URL" || error "signal-cli download failed: $SCLI_URL"
+
+    tar xzf "$TMPDIR/$SCLI_ARCHIVE" -C "$TMPDIR"
+    cp "$TMPDIR/signal-cli-native-${SCLI_VERSION}/bin/signal-cli" "$INSTALL_DIR/signal-cli"
+    chmod +x "$INSTALL_DIR/signal-cli"
+
+    info "Installed signal-cli to $INSTALL_DIR/signal-cli"
+
+  elif [ "$OS" = "Darwin" ]; then
+    echo ""
+    info "signal-cli is required. Install it with one of:"
+    echo ""
+    if command -v brew >/dev/null 2>&1; then
+      echo "  brew install signal-cli"
+    else
+      echo "  # Install Homebrew first: https://brew.sh"
+      echo "  brew install signal-cli"
+    fi
+    echo ""
+    echo "  Or download manually from:"
+    echo "  https://github.com/AsamK/signal-cli/releases"
+    echo "  (Requires Java 21+)"
+    echo ""
+  fi
+fi
+
+# --- Check PATH ---
+case ":$PATH:" in
+  *":$INSTALL_DIR:"*) ;;
+  *)
+    echo ""
+    info "$INSTALL_DIR is not in your PATH. Add it with:"
+    echo ""
+    echo "  export PATH=\"$INSTALL_DIR:\$PATH\""
+    echo ""
+    echo "  Add that line to your ~/.bashrc or ~/.zshrc to make it permanent."
+    echo ""
+    ;;
+esac
+
+# --- Done ---
+echo ""
+info "Done! Run 'signal-tui' to get started."


### PR DESCRIPTION
## Summary
- **CI workflow** (`.github/workflows/ci.yml`): Runs clippy + tests on every push and PR to master
- **Release workflow** (`.github/workflows/release.yml`): On tag push (`v*`), builds binaries for Linux x86_64, macOS x86_64/arm64, and Windows x86_64, then creates a GitHub Release with auto-generated changelog
- **install.sh**: One-liner install for Linux/macOS — downloads signal-tui binary, and on Linux also installs the signal-cli native build (no Java required)
- **install.ps1**: One-liner install for Windows — downloads signal-tui binary, installs signal-cli if Java is available

### Install usage
```bash
# Linux/macOS
curl -fsSL https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.sh | bash

# Windows
irm https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.ps1 | iex
```

## Test plan
- [ ] CI workflow runs on this PR (self-validates)
- [ ] After merge: `git tag v0.1.0 && git push --tags` triggers release build
- [ ] Test `install.sh` on Linux/WSL
- [ ] Test `install.ps1` on Windows
- [ ] Verify downloaded binary runs: `signal-tui --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)