### PR TITLE
Add mdBook documentation site with IRC theme

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+    paths: ["docs/**"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: peaceiris/actions-mdbook@v2
+        with:
+          mdbook-version: latest
+
+      - name: Build
+        run: mdbook build docs
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/book
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 *.swo
 *~
 .DS_Store
+docs/book/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/johnsideserf/signal-tui/actions/workflows/ci.yml/badge.svg)](https://github.com/johnsideserf/signal-tui/actions/workflows/ci.yml)
 [![Release](https://img.shields.io/github/v/release/johnsideserf/signal-tui)](https://github.com/johnsideserf/signal-tui/releases/latest)
 [![License: GPL-3.0](https://img.shields.io/github/license/johnsideserf/signal-tui)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-signal--tui-blue)](https://johnsideserf.github.io/signal-tui/)
 
 A terminal-based Signal messenger client with an IRC aesthetic. Wraps [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC for the messaging backend.
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,21 @@
+[book]
+title = "signal-tui"
+description = "Terminal-based Signal messenger client"
+authors = ["johnsideserf"]
+language = "en"
+src = "src"
+
+[build]
+build-dir = "book"
+
+[output.html]
+default-theme = "coal"
+preferred-dark-theme = "coal"
+additional-css = ["theme/css/irc-theme.css"]
+site-url = "/signal-tui/"
+git-repository-url = "https://github.com/johnsideserf/signal-tui"
+edit-url-template = "https://github.com/johnsideserf/signal-tui/edit/master/docs/{path}"
+
+[output.html.fold]
+enable = true
+level = 1

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,30 @@
+# Summary
+
+[Introduction](introduction.md)
+
+---
+
+# User Guide
+
+- [Installation](user-guide/installation.md)
+- [Getting Started](user-guide/getting-started.md)
+- [Configuration](user-guide/configuration.md)
+- [Commands](user-guide/commands.md)
+- [Keybindings](user-guide/keybindings.md)
+- [Features](user-guide/features.md)
+- [Troubleshooting](user-guide/troubleshooting.md)
+- [FAQ](user-guide/faq.md)
+
+---
+
+# Developer Guide
+
+- [Architecture](dev-guide/architecture.md)
+- [Module Reference](dev-guide/modules.md)
+- [Data Flow](dev-guide/data-flow.md)
+- [Database Schema](dev-guide/database.md)
+- [signal-cli Protocol](dev-guide/protocol.md)
+- [Testing](dev-guide/testing.md)
+- [Contributing](dev-guide/contributing.md)
+- [CI & Releases](dev-guide/ci-releases.md)
+- [Roadmap](dev-guide/roadmap.md)

--- a/docs/src/dev-guide/architecture.md
+++ b/docs/src/dev-guide/architecture.md
@@ -1,0 +1,66 @@
+# Architecture
+
+## Overview
+
+signal-tui is a terminal Signal client that wraps
+[signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC over stdin/stdout.
+It is built on a Tokio async runtime with Ratatui for rendering.
+
+```
++------------+   mpsc channels   +----------------+
+|  TUI       | <---------------> |  Signal        |
+|  (main     |   SignalEvent     |  Backend       |
+|  thread)   |   UserCommand     |  (tokio task)  |
++------------+                   +--------+-------+
+                                          |
+                                   stdin/stdout
+                                          |
+                                 +--------v-------+
+                                 |  signal-cli    |
+                                 |  (child proc)  |
+                                 +----------------+
+```
+
+## Async runtime
+
+The application uses a **multi-threaded Tokio runtime** (via `#[tokio::main]`).
+The main thread runs the TUI event loop. signal-cli communication happens in
+spawned Tokio tasks that communicate back to the main thread via
+`tokio::sync::mpsc` channels.
+
+## Event loop
+
+The main loop in `main.rs` runs on a 50ms tick:
+
+1. **Poll keyboard** -- check for key events via Crossterm (non-blocking, 50ms timeout)
+2. **Drain signal events** -- process all pending `SignalEvent` messages from the mpsc channel
+3. **Render** -- call `ui::draw()` with the current `App` state
+
+This keeps the UI responsive while processing backend events as they arrive.
+
+## Startup sequence
+
+1. Load config from TOML (or defaults)
+2. Check if setup is needed (`account` field empty)
+3. If needed: run the setup wizard (signal-cli detection, phone input, QR linking)
+4. Open SQLite database (or in-memory for `--incognito`)
+5. Spawn signal-cli child process
+6. Load conversations and contacts from database + signal-cli
+7. Enter the main event loop
+
+## Key dependencies
+
+| Crate | Purpose |
+|---|---|
+| `ratatui` 0.29 | Terminal UI framework |
+| `crossterm` 0.28 | Cross-platform terminal I/O |
+| `tokio` 1.x | Async runtime |
+| `serde` / `serde_json` | JSON serialization for signal-cli RPC |
+| `rusqlite` 0.32 | SQLite database (bundled) |
+| `chrono` 0.4 | Timestamp handling |
+| `qrcode` 0.14 | QR code generation for device linking |
+| `image` 0.25 | Image decoding for inline previews |
+| `anyhow` 1.x | Error handling |
+| `toml` 0.8 | Config file parsing |
+| `dirs` 6.x | Platform-specific directory paths |
+| `uuid` 1.x | RPC request ID generation |

--- a/docs/src/dev-guide/ci-releases.md
+++ b/docs/src/dev-guide/ci-releases.md
@@ -1,0 +1,82 @@
+# CI & Releases
+
+## Continuous integration
+
+CI runs automatically on every push and pull request via
+`.github/workflows/ci.yml`.
+
+### CI pipeline
+
+| Step | Command |
+|---|---|
+| Checkout | `actions/checkout@v4` |
+| Rust toolchain | `dtolnay/rust-toolchain@stable` |
+| Cache | `Swatinem/rust-cache@v2` |
+| Lint | `cargo clippy --tests -- -D warnings` |
+| Test | `cargo test` |
+
+CI must pass before merging any PR.
+
+## Release pipeline
+
+Releases are triggered by pushing a version tag. The workflow is defined in
+`.github/workflows/release.yml`.
+
+### Triggering a release
+
+```sh
+# 1. Update version in Cargo.toml
+# 2. Commit the version bump
+# 3. Tag and push
+git tag v0.3.0
+git push origin v0.3.0
+```
+
+### Release pipeline steps
+
+1. **Lint & Test** -- same as CI (clippy + tests)
+2. **Build** -- compiles release binaries for 4 targets:
+
+| Target | Runner | Archive |
+|---|---|---|
+| `x86_64-unknown-linux-gnu` | `ubuntu-latest` | `.tar.gz` |
+| `x86_64-apple-darwin` | `macos-latest` | `.tar.gz` |
+| `aarch64-apple-darwin` | `macos-latest` | `.tar.gz` |
+| `x86_64-pc-windows-msvc` | `windows-latest` | `.zip` |
+
+3. **Package** -- creates archives (`tar.gz` on Unix, `zip` on Windows)
+4. **Release** -- creates a GitHub Release with auto-generated changelog and
+   attached archives (via `softprops/action-gh-release@v2`)
+
+### Version tags
+
+Use semantic versioning: `v0.1.0`, `v0.2.0`, `v1.0.0`.
+
+Remember to update the `version` field in `Cargo.toml` before creating the tag.
+
+## Install scripts
+
+Two install scripts are provided in the repository root:
+
+### `install.sh` (Linux / macOS)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.sh | bash
+```
+
+Downloads the latest release binary for the detected platform and checks for
+signal-cli.
+
+### `install.ps1` (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.ps1 | iex
+```
+
+Downloads the latest Windows release binary and checks for signal-cli.
+
+## Documentation deployment
+
+Documentation is built and deployed via `.github/workflows/docs.yml`. See the
+docs workflow for details on how changes to the `docs/` directory trigger a
+rebuild and deployment to GitHub Pages.

--- a/docs/src/dev-guide/contributing.md
+++ b/docs/src/dev-guide/contributing.md
@@ -1,0 +1,87 @@
+# Contributing
+
+## Getting started
+
+1. Fork the repository and clone your fork
+2. Install prerequisites: **Rust 1.70+** and
+   [signal-cli](https://github.com/AsamK/signal-cli)
+3. Build and run tests:
+
+```sh
+cargo build
+cargo test
+```
+
+Use `--demo` mode to test the UI without a Signal account:
+
+```sh
+cargo run -- --demo
+```
+
+## Making changes
+
+1. Create a feature branch from `master`:
+
+```sh
+git checkout -b feature/my-change
+```
+
+2. Make your changes. Run checks before committing:
+
+```sh
+cargo clippy --tests -- -D warnings
+cargo test
+```
+
+3. Push your branch and open a pull request against `master`.
+
+## Branch naming
+
+Use prefixed names:
+
+| Prefix | Use case |
+|---|---|
+| `feature/` | New functionality |
+| `fix/` | Bug fixes |
+| `refactor/` | Code restructuring |
+| `docs/` | Documentation changes |
+
+Examples: `feature/dark-mode`, `fix/unread-count`, `docs/update-readme`
+
+## Code style
+
+- Follow existing patterns in the codebase
+- Run `cargo clippy` with warnings-as-errors -- CI enforces this
+- Keep commits focused: one logical change per commit
+- Write descriptive commit messages
+- Reference issue numbers in commits and PRs (e.g., `closes #29`)
+
+## Pull requests
+
+- Create a PR targeting `master`
+- Include a clear description of what changed and why
+- Reference the issue being addressed if applicable
+- Make sure CI passes (clippy + tests)
+- Trivial docs-only changes may be committed directly to `master`; all code
+  changes must go through a PR
+
+## Reporting bugs
+
+Use the
+[bug report template](https://github.com/johnsideserf/signal-tui/issues/new?template=bug_report.yml).
+Include:
+
+- Your OS and terminal emulator
+- signal-tui version (`signal-tui --version` or the release tag)
+- Steps to reproduce the issue
+
+## Suggesting features
+
+Use the
+[feature request template](https://github.com/johnsideserf/signal-tui/issues/new?template=feature_request.yml).
+Describe the problem you're trying to solve before proposing a solution.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under
+[GPL-3.0](https://github.com/johnsideserf/signal-tui/blob/master/LICENSE).

--- a/docs/src/dev-guide/data-flow.md
+++ b/docs/src/dev-guide/data-flow.md
@@ -1,0 +1,89 @@
+# Data Flow
+
+## Outbound messages (user sends)
+
+```
+1. User types message + presses Enter
+2. input::parse_input() -> InputAction::SendText
+3. App sends JsonRpcRequest via mpsc to SignalClient
+4. SignalClient writes JSON-RPC to signal-cli stdin
+5. signal-cli transmits via Signal protocol
+```
+
+The request is a JSON-RPC call to the `send` method with the recipient and
+message body as parameters. Each request gets a unique UUID as its RPC ID.
+
+## Inbound messages (received)
+
+```
+1. signal-cli receives message via Signal protocol
+2. signal-cli writes JSON-RPC notification to stdout
+3. SignalClient stdout reader parses the JSON line
+4. Notification has method = "receive" with message data
+5. Parsed into SignalEvent::MessageReceived
+6. Sent through mpsc channel to main thread
+7. App::handle_signal_event() processes it:
+   a. get_or_create_conversation() ensures the conversation exists
+   b. Message is appended to the conversation's message list
+   c. Message is inserted into SQLite
+   d. Unread count is updated (if not the active conversation)
+   e. Terminal bell fires (if notifications enabled and not muted)
+8. Next render cycle shows the new message
+```
+
+## RPC request/response correlation
+
+signal-cli uses JSON-RPC 2.0. There are two types of messages:
+
+### Notifications (incoming)
+
+Notifications arrive as JSON-RPC **requests** from signal-cli (they have a
+`method` field). These include:
+
+- `receive` -- incoming message
+- `receiveTyping` -- typing indicator
+- `receiveReceipt` -- delivery/read receipt
+
+These are unsolicited and do not have an `id` field matching any outbound request.
+
+### RPC responses
+
+When signal-tui sends a request (e.g., `listContacts`, `listGroups`, `send`),
+signal-cli replies with a response that has a matching `id` field and a `result`
+(or `error`) field.
+
+The `pending_requests` map in `SignalClient` stores `id -> method` pairs. When
+a response arrives, the client looks up the method by ID to know how to parse
+the result:
+
+```
+outbound:  { "jsonrpc": "2.0", "id": "abc-123", "method": "listContacts", ... }
+inbound:   { "jsonrpc": "2.0", "id": "abc-123", "result": [...] }
+
+pending_requests["abc-123"] = "listContacts"
+-> parse result as Vec<Contact>
+-> emit SignalEvent::ContactList
+```
+
+## Sync messages
+
+When you send a message from your phone, signal-cli receives a sync notification.
+These appear as `SignalMessage` with `is_outgoing = true` and a `destination`
+field indicating the recipient. The app routes these to the correct conversation
+and displays them as outgoing messages.
+
+## Channel architecture
+
+```
+                     mpsc::channel
+SignalClient ───────────────────────> App (main thread)
+  (tokio tasks)      SignalEvent
+
+                     mpsc::channel
+App (main thread) ──────────────────> SignalClient
+                     JsonRpcRequest     (stdin writer task)
+```
+
+Both channels are unbounded `tokio::sync::mpsc` channels. The signal event
+channel carries `SignalEvent` variants. The command channel carries
+`JsonRpcRequest` structs to be serialized and written to signal-cli's stdin.

--- a/docs/src/dev-guide/database.md
+++ b/docs/src/dev-guide/database.md
@@ -1,0 +1,96 @@
+# Database Schema
+
+signal-tui uses SQLite with WAL (Write-Ahead Logging) mode for safe concurrent
+reads/writes. The database file is stored alongside the config file.
+
+## Tables
+
+### `schema_version`
+
+Tracks the current migration version.
+
+```sql
+CREATE TABLE schema_version (
+    version INTEGER NOT NULL
+);
+```
+
+### `conversations`
+
+One row per conversation (1:1 or group).
+
+```sql
+CREATE TABLE conversations (
+    id         TEXT PRIMARY KEY,      -- phone number or group ID
+    name       TEXT NOT NULL,         -- display name
+    is_group   INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    muted      INTEGER NOT NULL DEFAULT 0   -- added in migration v2
+);
+```
+
+The `id` is a phone number (E.164 format) for 1:1 conversations or a
+base64-encoded group ID for groups.
+
+### `messages`
+
+All messages, ordered by insertion rowid.
+
+```sql
+CREATE TABLE messages (
+    rowid           INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id TEXT NOT NULL REFERENCES conversations(id),
+    sender          TEXT NOT NULL,       -- sender phone or empty for system
+    timestamp       TEXT NOT NULL,       -- RFC 3339 timestamp
+    body            TEXT NOT NULL,       -- message text
+    is_system       INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_messages_conv_ts ON messages(conversation_id, timestamp);
+```
+
+System messages (`is_system = 1`) are used for join/leave notifications and
+are excluded from unread counts.
+
+### `read_markers`
+
+Tracks the last-read message per conversation for unread counting.
+
+```sql
+CREATE TABLE read_markers (
+    conversation_id TEXT PRIMARY KEY REFERENCES conversations(id),
+    last_read_rowid INTEGER NOT NULL DEFAULT 0
+);
+```
+
+Unread count = messages with `rowid > last_read_rowid` and `is_system = 0`.
+
+## Migrations
+
+Migrations are version-based and run sequentially in `Database::migrate()`:
+
+| Version | Changes |
+|---|---|
+| 1 | Initial schema: `conversations`, `messages`, `read_markers` tables |
+| 2 | Add `muted` column to `conversations` |
+
+Each migration is wrapped in a transaction. The `schema_version` table tracks
+the current version.
+
+## WAL mode
+
+WAL mode is enabled on every connection:
+
+```sql
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+```
+
+WAL allows concurrent readers while a writer is active, preventing database
+locks during normal operation.
+
+## In-memory mode
+
+When running with `--incognito`, `Database::open_in_memory()` is used instead
+of `Database::open()`. The same schema and migrations apply, but everything
+lives in memory and is lost on exit.

--- a/docs/src/dev-guide/modules.md
+++ b/docs/src/dev-guide/modules.md
@@ -1,0 +1,94 @@
+# Module Reference
+
+signal-tui is organized into a flat module structure under `src/`.
+
+## Source files
+
+### `main.rs`
+
+Entry point. Parses CLI arguments, runs the setup wizard if needed, opens the
+database, spawns signal-cli, and runs the main event loop. Orchestrates the
+startup sequence: setup wizard -> device linking -> app startup.
+
+The event loop polls keyboard input (50ms timeout), drains signal events from
+the mpsc channel, and renders each frame with `ui::draw()`.
+
+### `app.rs`
+
+All application state lives in the `App` struct. Owns conversations (stored in
+a `HashMap` with an ordered `Vec` for sidebar ordering), the input buffer, and
+the current mode (Normal / Insert).
+
+Key entry point: `handle_signal_event()` processes all backend events -- incoming
+messages, typing indicators, contact lists, group lists, and errors. This is the
+single place where signal-cli events modify application state.
+
+`get_or_create_conversation()` is the single point for ensuring a conversation
+exists. It upserts to both the in-memory `HashMap` and SQLite. New conversations
+append to `conversation_order`; existing ones are no-ops.
+
+### `signal/client.rs`
+
+Spawns the signal-cli child process and manages communication. Two Tokio tasks:
+
+- **stdout reader** -- reads lines from signal-cli stdout, parses JSON-RPC into
+  `SignalEvent` variants, and sends them through the mpsc channel
+- **stdin writer** -- receives `JsonRpcRequest` structs and writes them as JSON
+  lines to signal-cli stdin
+
+The `pending_requests` map tracks RPC call IDs to correlate responses with their
+original method (e.g., mapping a response ID back to `listContacts`).
+
+### `signal/types.rs`
+
+Shared types for signal-cli communication:
+
+- `SignalEvent` -- enum of all events the backend can produce
+- `SignalMessage` -- a message with source, timestamp, body, attachments, group info
+- `Attachment` -- file metadata (content type, filename, local path)
+- `JsonRpcRequest` / `JsonRpcResponse` -- JSON-RPC protocol structs
+- `Contact` / `Group` -- address book and group info
+
+### `ui.rs`
+
+Stateless rendering. The `draw()` function takes an immutable `&App` reference and
+renders the full UI: sidebar, chat area, input bar, and status bar.
+
+Sender colors are hash-based (8 colors). Groups are prefixed with `#` in the sidebar.
+OSC 8 hyperlinks are injected in a post-render pass (written directly to the terminal
+after Ratatui's draw to avoid width calculation issues).
+
+### `db.rs`
+
+SQLite database layer with WAL mode. Three tables: `conversations`, `messages`,
+`read_markers`. Schema migration is version-based (see [Database Schema](database.md)).
+
+Provides `open()` for disk-backed storage and `open_in_memory()` for incognito mode.
+
+### `config.rs`
+
+TOML configuration. The `Config` struct is serialized/deserialized with serde.
+Fields: `account`, `signal_cli_path`, `download_dir`, `notify_direct`,
+`notify_group`, `inline_images`. All fields have defaults.
+
+`Config::load()` reads from the platform-specific path (or a custom path).
+`Config::save()` writes the current config back to disk.
+
+### `input.rs`
+
+Input parsing. Converts text input into an `InputAction` enum. Handles all
+slash commands (`/join`, `/part`, `/quit`, `/sidebar`, `/bell`, `/mute`,
+`/settings`, `/help`) and their aliases.
+
+Also defines `CommandInfo` and the `COMMANDS` constant used for autocomplete.
+
+### `setup.rs`
+
+Multi-step first-run wizard. Handles signal-cli detection (searching PATH),
+phone number input with validation, and triggers the device linking flow.
+
+### `link.rs`
+
+Device linking flow. Runs signal-cli's `link` command, captures the QR code URI,
+renders it in the terminal, and waits for the user to scan it with their phone.
+Checks for successful account registration afterward.

--- a/docs/src/dev-guide/protocol.md
+++ b/docs/src/dev-guide/protocol.md
@@ -1,0 +1,118 @@
+# signal-cli Protocol
+
+signal-tui communicates with signal-cli using
+[JSON-RPC 2.0](https://www.jsonrpc.org/specification) over stdin/stdout. signal-cli
+is spawned as a child process in `jsonRpc` mode.
+
+## Starting signal-cli
+
+signal-cli is launched with:
+
+```sh
+signal-cli -a +15551234567 jsonRpc
+```
+
+This starts signal-cli in JSON-RPC mode, reading requests from stdin and writing
+responses/notifications to stdout. Each message is a single JSON line.
+
+## Request format
+
+Requests sent from signal-tui to signal-cli:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "method": "send",
+    "params": {
+        "recipient": ["+15551234567"],
+        "message": "Hello!"
+    }
+}
+```
+
+Each request has a unique UUID `id` for response correlation.
+
+## Response format
+
+Responses from signal-cli for RPC calls:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "result": { ... }
+}
+```
+
+Or on error:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "id": "550e8400-e29b-41d4-a716-446655440000",
+    "error": {
+        "code": -1,
+        "message": "error description"
+    }
+}
+```
+
+## Notification format
+
+Notifications are unsolicited JSON-RPC requests from signal-cli (no matching
+outbound request). They have a `method` field but no `id`:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "method": "receive",
+    "params": {
+        "envelope": {
+            "source": "+15559876543",
+            "sourceDevice": 1,
+            "timestamp": 1700000000000,
+            "dataMessage": {
+                "message": "Hey there!",
+                "timestamp": 1700000000000
+            }
+        }
+    }
+}
+```
+
+## Methods used
+
+### Outbound (signal-tui -> signal-cli)
+
+| Method | Purpose |
+|---|---|
+| `send` | Send a message to a contact or group |
+| `listContacts` | Request the contact address book |
+| `listGroups` | Request the list of groups |
+| `sendSyncRequest` | Request a sync from the primary device |
+
+### Inbound notifications (signal-cli -> signal-tui)
+
+| Method | Purpose | Maps to |
+|---|---|---|
+| `receive` | Incoming message | `SignalEvent::MessageReceived` |
+| `receiveTyping` | Typing indicator | `SignalEvent::TypingIndicator` |
+| `receiveReceipt` | Delivery/read receipt | `SignalEvent::ReceiptReceived` |
+
+## Parsing logic
+
+The stdout reader in `SignalClient` determines the message type by checking
+which fields are present:
+
+1. If `method` is present -> it's a notification, parse based on method name
+2. If `id` and `result`/`error` are present -> it's a response, look up the
+   method via `pending_requests[id]` and parse accordingly
+3. Unknown methods are logged and discarded
+
+## Sync messages
+
+Messages sent from the primary device arrive as sync messages. They are
+identified by having `is_outgoing = true` in the parsed `SignalMessage`.
+The `destination` field indicates the recipient, and the message is routed
+to the appropriate conversation.

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -1,0 +1,44 @@
+# Roadmap
+
+## Completed
+
+- [x] Send and receive plain text messages (1:1 and group)
+- [x] Receive file attachments (displayed as `[attachment: filename]`)
+- [x] Typing indicators
+- [x] SQLite-backed message persistence with WAL mode
+- [x] Unread message counts with persistent read markers
+- [x] Vim-style modal editing (Normal / Insert modes)
+- [x] Responsive layout with auto-hiding sidebar
+- [x] First-run setup wizard with QR device linking
+- [x] TUI error screens instead of stderr crashes
+- [x] Commands: `/join`, `/part`, `/quit`, `/sidebar`, `/help`
+- [x] Load contacts and groups on startup (name resolution, groups in sidebar)
+- [x] Echo outgoing messages from other devices via sync messages
+- [x] Contact name resolution from address book
+- [x] Sync request at startup to refresh data from primary device
+- [x] Inline image preview for attachments (halfblock rendering)
+- [x] New message notifications (terminal bell, per-type toggles, per-chat mute)
+- [x] Command autocomplete with Tab completion
+- [x] Settings overlay
+- [x] Input history (Up/Down to recall previous messages)
+- [x] Incognito mode (`--incognito`)
+- [x] Demo mode (`--demo`)
+
+## Up next
+
+- [ ] **Delivery/read receipt display** -- receipts are already parsed but
+  silently discarded. Show checkmark indicators next to messages.
+- [ ] **Send attachments** -- only receiving works today. Add a `/send-file <path>`
+  command.
+
+## Future
+
+- [ ] Message search
+- [ ] Multi-line message input (Shift+Enter for newlines)
+- [ ] Message history pagination (scroll-up to load older messages)
+- [ ] Correct group typing indicators (per-sender-to-group mapping)
+- [ ] Message reactions (emoji badges with counts)
+- [ ] Message deletion and editing
+- [ ] Group management (create, add/remove members, member list)
+- [ ] Scroll position memory per conversation
+- [ ] Configurable keybindings

--- a/docs/src/dev-guide/testing.md
+++ b/docs/src/dev-guide/testing.md
@@ -1,0 +1,82 @@
+# Testing
+
+## Running tests
+
+Run the full test suite:
+
+```sh
+cargo test
+```
+
+Run tests for a specific module:
+
+```sh
+cargo test app::tests          # App module tests
+cargo test signal::client::tests  # Signal client tests
+cargo test db::tests           # Database tests
+cargo test input::tests        # Input parsing tests
+```
+
+Run a single test by name:
+
+```sh
+cargo test test_name
+```
+
+## Test modules
+
+Tests are defined as `#[cfg(test)] mod tests` blocks within each source file.
+
+### `db.rs` tests
+
+Database tests use `Database::open_in_memory()` for isolated, fast test instances.
+Coverage includes:
+
+- Schema migration and table creation
+- Conversation upsert and loading
+- Name updates on conflict
+- Message insertion and retrieval (ordering)
+- Unread count with read markers
+- System message exclusion from unread counts
+- Conversation ordering by most recent message
+- Mute flag round-trip
+- Last message rowid tracking
+
+### `input.rs` tests
+
+Input parser tests cover:
+
+- Plain text passthrough
+- Empty and whitespace-only input
+- All commands and their aliases (`/join`, `/j`, `/part`, `/p`, etc.)
+- Commands with and without arguments
+- Unknown command handling
+
+### `app.rs` tests
+
+Application state tests cover signal event handling, conversation management,
+and mode transitions.
+
+### `signal/client.rs` tests
+
+Signal client tests cover JSON-RPC parsing and event routing.
+
+## Demo mode for manual testing
+
+```sh
+cargo run -- --demo
+```
+
+Demo mode populates the UI with dummy conversations and messages without
+requiring signal-cli. This is the easiest way to manually test UI changes,
+keybindings, and rendering.
+
+## Linting
+
+The project enforces zero clippy warnings:
+
+```sh
+cargo clippy --tests -- -D warnings
+```
+
+CI runs this on every push and pull request. Fix all warnings before pushing.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,44 @@
+# signal-tui
+
+A terminal-based Signal messenger client with an IRC aesthetic.
+
+signal-tui wraps [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC, giving you a
+full-featured messaging interface that runs entirely in your terminal. Built with
+[Ratatui](https://ratatui.rs/), [Crossterm](https://github.com/crossterm-rs/crossterm), and
+[Tokio](https://tokio.rs/).
+
+## Why signal-tui?
+
+- **Lightweight** -- no Electron, no web browser, just your terminal
+- **Vim keybindings** -- modal editing with Normal and Insert modes
+- **Persistent** -- SQLite-backed message history that survives restarts
+- **Private** -- incognito mode for ephemeral sessions with zero disk traces
+- **Extensible** -- TOML configuration, slash commands, and a clean module architecture
+
+## Quick start
+
+```sh
+# Install (Linux/macOS)
+curl -fsSL https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.sh | bash
+
+# Install (Windows PowerShell)
+irm https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.ps1 | iex
+
+# Launch
+signal-tui
+```
+
+The setup wizard will guide you through linking your Signal account on first launch.
+
+## Try it without Signal
+
+```sh
+signal-tui --demo
+```
+
+Demo mode populates the UI with dummy conversations and messages so you can explore
+the interface without a Signal account or signal-cli installed.
+
+## License
+
+[GPL-3.0](https://github.com/johnsideserf/signal-tui/blob/master/LICENSE)

--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -1,0 +1,63 @@
+# Commands
+
+All commands start with `/`. Type `/` in Insert mode to open the autocomplete popup.
+
+## Command reference
+
+| Command | Alias | Arguments | Description |
+|---|---|---|---|
+| `/join` | `/j` | `<name>` | Switch to a conversation by contact name, number, or group |
+| `/part` | `/p` | | Leave current conversation |
+| `/sidebar` | `/sb` | | Toggle sidebar visibility |
+| `/bell` | `/notify` | `[type]` | Toggle notifications (`direct`, `group`, or both) |
+| `/mute` | | | Mute/unmute current conversation |
+| `/settings` | | | Open settings overlay |
+| `/help` | `/h` | | Show help overlay |
+| `/quit` | `/q` | | Exit signal-tui |
+
+## Autocomplete
+
+When you type `/`, a popup appears showing matching commands. As you continue
+typing, the list filters down. Use:
+
+- **Up/Down arrows** to navigate the list
+- **Tab** to complete the selected command
+- **Esc** to dismiss the popup
+
+## Examples
+
+**Join a conversation by name:**
+```
+/join Alice
+```
+
+**Join by phone number:**
+```
+/j +15551234567
+```
+
+**Toggle direct message notifications off:**
+```
+/bell direct
+```
+
+**Toggle all notifications:**
+```
+/bell
+```
+
+**Mute the current conversation:**
+```
+/mute
+```
+
+## Messaging a new contact
+
+To start a conversation with someone not in your sidebar, use `/join` with their
+phone number in E.164 format:
+
+```
+/join +15551234567
+```
+
+The conversation will appear in your sidebar once the first message is exchanged.

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -1,0 +1,71 @@
+# Configuration
+
+## Config file location
+
+signal-tui loads its config from a TOML file at the platform-specific path:
+
+| Platform | Path |
+|---|---|
+| Linux / macOS | `~/.config/signal-tui/config.toml` |
+| Windows | `%APPDATA%\signal-tui\config.toml` |
+
+You can override the path with the `-c` flag:
+
+```sh
+signal-tui -c /path/to/config.toml
+```
+
+## Config fields
+
+All fields are optional. Here is a complete example with defaults:
+
+```toml
+account = "+15551234567"
+signal_cli_path = "signal-cli"
+download_dir = "/home/user/signal-downloads"
+notify_direct = true
+notify_group = true
+inline_images = true
+```
+
+### Field reference
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `account` | string | `""` | Phone number in E.164 format |
+| `signal_cli_path` | string | `"signal-cli"` | Path to the signal-cli binary |
+| `download_dir` | string | `~/signal-downloads/` | Directory for downloaded attachments |
+| `notify_direct` | bool | `true` | Terminal bell on new direct messages |
+| `notify_group` | bool | `true` | Terminal bell on new group messages |
+| `inline_images` | bool | `true` | Render image attachments as halfblock art |
+
+## CLI flags
+
+CLI flags override config file values for the current session:
+
+| Flag | Overrides |
+|---|---|
+| `-a +15551234567` | `account` |
+| `-c /path/to/config.toml` | Config file path |
+| `--incognito` | Uses in-memory database (no persistence) |
+
+## Settings overlay
+
+Press `/settings` inside the app to open the settings overlay. This provides
+toggles for runtime settings:
+
+- Notification toggles (direct / group)
+- Sidebar visibility
+- Inline image previews
+
+Changes made in the settings overlay apply immediately to the running session.
+
+## Incognito mode
+
+```sh
+signal-tui --incognito
+```
+
+Incognito mode replaces the on-disk SQLite database with an in-memory database.
+No messages, conversations, or read markers are saved. When you exit, all data is
+gone. The status bar shows a bold magenta **incognito** indicator.

--- a/docs/src/user-guide/faq.md
+++ b/docs/src/user-guide/faq.md
@@ -1,0 +1,62 @@
+# FAQ
+
+## Does signal-tui replace the Signal phone app?
+
+No. signal-tui runs as a **linked device**, just like Signal Desktop. Your phone
+remains the primary device and must stay registered. signal-tui connects through
+signal-cli, which registers as a secondary device on your account.
+
+## Can I use signal-tui without a phone?
+
+No. Signal requires a phone number for registration and a primary device. signal-tui
+links to your existing account as a secondary device.
+
+## Is my data encrypted?
+
+Messages are end-to-end encrypted in transit by the Signal protocol (handled by
+signal-cli). Locally, messages are stored in a plain SQLite database. If you want
+zero local persistence, use `--incognito` mode.
+
+## Can I send files and images?
+
+Currently, signal-tui can **receive** attachments (images are rendered inline,
+other files are saved to disk). **Sending** attachments is on the
+[roadmap](../dev-guide/roadmap.md).
+
+## Does it work on Windows?
+
+Yes. Pre-built Windows binaries are provided in each release. Use a modern
+terminal like Windows Terminal for the best experience (clickable links, proper
+Unicode, truecolor support).
+
+## Does it work over SSH?
+
+Yes. signal-tui is a terminal application and works perfectly over SSH sessions.
+Make sure signal-cli and Java are available on the remote machine.
+
+## Can I use multiple Signal accounts?
+
+Yes. Use the `-a` flag or config file to specify which account to use:
+
+```sh
+signal-tui -a +15551234567
+signal-tui -a +15559876543
+```
+
+Each account needs its own device linking via signal-cli.
+
+## How do I update signal-tui?
+
+Re-run the install script, or download the latest binary from the
+[Releases page](https://github.com/johnsideserf/signal-tui/releases).
+
+If you installed from source:
+
+```sh
+cargo install --git https://github.com/johnsideserf/signal-tui.git --force
+```
+
+## What license is signal-tui under?
+
+[GPL-3.0](https://github.com/johnsideserf/signal-tui/blob/master/LICENSE).
+This is a copyleft license -- forks must remain open source under the same terms.

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -1,0 +1,81 @@
+# Features
+
+## Messaging
+
+Send and receive 1:1 and group messages. Messages sent from your phone (or other
+linked devices) sync into the TUI automatically.
+
+## Attachments
+
+- **Images** -- rendered inline as halfblock art when `inline_images = true`
+- **Other files** -- shown as `[attachment: filename]` with the download path
+
+Received attachments are saved to the `download_dir` configured in your config file
+(default: `~/signal-downloads/`).
+
+## Clickable links
+
+URLs and file paths in messages are rendered as
+[OSC 8 hyperlinks](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda).
+In supported terminals (Windows Terminal, iTerm2, Kitty, etc.), you can click them
+to open in your browser.
+
+## Typing indicators
+
+When someone is typing, their name appears below the chat area. Contact name
+resolution is used where available.
+
+## Persistence
+
+All conversations, messages, and read markers are stored in a SQLite database with
+WAL (Write-Ahead Logging) mode for safe concurrent access. Data survives app restarts.
+
+The database is stored alongside the config file:
+- **Linux / macOS:** `~/.config/signal-tui/signal-tui.db`
+- **Windows:** `%APPDATA%\signal-tui\signal-tui.db`
+
+## Unread tracking
+
+The sidebar shows unread counts next to each conversation. When you open a
+conversation, a "new messages" separator line marks where you left off. Read
+markers persist across restarts.
+
+## Notifications
+
+Terminal bell notifications fire when new messages arrive in background
+conversations. Configure them per type:
+
+- `notify_direct` -- 1:1 messages (default: on)
+- `notify_group` -- group messages (default: on)
+- `/mute` -- per-conversation mute (persists in the database)
+- `/bell` -- toggle notification types at runtime
+
+## Contact resolution
+
+On startup, signal-tui requests your contact list and group list from signal-cli.
+Names from your Signal address book are used throughout the sidebar, chat area,
+and typing indicators.
+
+## Responsive layout
+
+The sidebar auto-hides on narrow terminals (less than 60 columns). Use
+`Ctrl+Left` / `Ctrl+Right` to resize it, or `/sidebar` to toggle it.
+
+## Incognito mode
+
+```sh
+signal-tui --incognito
+```
+
+Uses an in-memory database instead of on-disk SQLite. No messages, conversations,
+or read markers are written to disk. The status bar shows a bold magenta
+**incognito** indicator. When you exit, everything is gone.
+
+## Demo mode
+
+```sh
+signal-tui --demo
+```
+
+Launches with dummy conversations and messages. No signal-cli process is spawned.
+Useful for testing the UI, exploring keybindings, and taking screenshots.

--- a/docs/src/user-guide/getting-started.md
+++ b/docs/src/user-guide/getting-started.md
@@ -1,0 +1,74 @@
+# Getting Started
+
+## First launch
+
+Run signal-tui with no arguments:
+
+```sh
+signal-tui
+```
+
+If no config file exists, the **setup wizard** starts automatically.
+
+## Setup wizard
+
+The wizard walks through three steps:
+
+1. **Locate signal-cli** -- signal-tui searches your `PATH` for `signal-cli`. If it
+   can't find it, you'll be prompted to enter the full path.
+
+2. **Enter your phone number** -- provide your Signal phone number in E.164 format
+   (e.g. `+15551234567`). This is the account signal-tui will connect to.
+
+3. **Link your device** -- a QR code is displayed in the terminal. Scan it with the
+   Signal app on your phone:
+   - Open Signal on your phone
+   - Go to **Settings > Linked Devices > Link New Device**
+   - Scan the QR code shown in the terminal
+
+Once linked, signal-tui saves your config and starts the main interface.
+
+## Re-running setup
+
+To re-run the setup wizard at any time:
+
+```sh
+signal-tui --setup
+```
+
+This is useful if you need to link a different account or reconfigure signal-cli.
+
+## Demo mode
+
+Try the full UI without a Signal account or signal-cli:
+
+```sh
+signal-tui --demo
+```
+
+Demo mode populates the interface with dummy conversations and messages. It's useful
+for exploring keybindings, commands, and the layout before committing to setup.
+
+## CLI options
+
+| Flag | Description |
+|---|---|
+| `-a`, `--account <NUMBER>` | Phone number in E.164 format (overrides config) |
+| `-c`, `--config <PATH>` | Path to a custom config file |
+| `--setup` | Re-run the first-time setup wizard |
+| `--demo` | Launch with dummy data (no signal-cli needed) |
+| `--incognito` | In-memory storage only; nothing persists after exit |
+
+## Basic navigation
+
+Once launched, the interface has three areas:
+
+- **Sidebar** (left) -- lists your conversations; groups are prefixed with `#`
+- **Chat area** (center) -- shows messages for the selected conversation
+- **Input bar** (bottom) -- type messages and commands here
+
+Use `Tab` / `Shift+Tab` to switch between conversations, or type `/join <name>` to
+jump to a specific contact or group.
+
+Press `Esc` to enter Normal mode for vim-style scrolling and navigation. The default
+mode is Insert, where you can type messages immediately.

--- a/docs/src/user-guide/installation.md
+++ b/docs/src/user-guide/installation.md
@@ -1,0 +1,68 @@
+# Installation
+
+## Pre-built binaries
+
+Download the latest release for your platform from the
+[Releases page](https://github.com/johnsideserf/signal-tui/releases).
+
+### Linux / macOS (one-liner)
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.sh | bash
+```
+
+### Windows (PowerShell)
+
+```powershell
+irm https://raw.githubusercontent.com/johnsideserf/signal-tui/master/install.ps1 | iex
+```
+
+Both install scripts download the latest release binary and check for signal-cli.
+
+## Build from source
+
+Requires **Rust 1.70+**.
+
+Install directly from the repository:
+
+```sh
+cargo install --git https://github.com/johnsideserf/signal-tui.git
+```
+
+Or clone and build locally:
+
+```sh
+git clone https://github.com/johnsideserf/signal-tui.git
+cd signal-tui
+cargo build --release
+# Binary is at target/release/signal-tui
+```
+
+## signal-cli setup
+
+signal-tui requires [signal-cli](https://github.com/AsamK/signal-cli) as its messaging backend.
+
+1. **Install signal-cli** -- follow the
+   [signal-cli installation guide](https://github.com/AsamK/signal-cli/wiki/Installation).
+   The install scripts above will check for it automatically.
+
+2. **Make it accessible** -- signal-cli must be on your `PATH`, or you can set the
+   full path in the [config file](configuration.md):
+
+   ```toml
+   signal_cli_path = "/usr/local/bin/signal-cli"
+   ```
+
+   On Windows, point to `signal-cli.bat` if it isn't in your `PATH`.
+
+3. **Java runtime** -- signal-cli requires Java 21+. Make sure `java` is available
+   in your shell.
+
+## Supported platforms
+
+| Platform | Binary | Notes |
+|---|---|---|
+| Linux x86_64 | `signal-tui-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` | |
+| macOS x86_64 | `signal-tui-vX.Y.Z-x86_64-apple-darwin.tar.gz` | Intel Macs |
+| macOS arm64 | `signal-tui-vX.Y.Z-aarch64-apple-darwin.tar.gz` | Apple Silicon |
+| Windows x86_64 | `signal-tui-vX.Y.Z-x86_64-pc-windows-msvc.zip` | |

--- a/docs/src/user-guide/keybindings.md
+++ b/docs/src/user-guide/keybindings.md
@@ -1,0 +1,71 @@
+# Keybindings
+
+signal-tui uses vim-style modal editing with two modes: **Insert** (default) and
+**Normal**.
+
+## Global (both modes)
+
+| Key | Action |
+|---|---|
+| `Ctrl+C` | Quit |
+| `Tab` / `Shift+Tab` | Next / previous conversation |
+| `PgUp` / `PgDn` | Scroll messages (5 lines) |
+| `Ctrl+Left` / `Ctrl+Right` | Resize sidebar |
+
+## Normal mode
+
+Press `Esc` to enter Normal mode. The cursor stops blinking and the mode indicator
+changes in the status bar.
+
+### Scrolling
+
+| Key | Action |
+|---|---|
+| `j` / `k` | Scroll down / up 1 line |
+| `Ctrl+D` / `Ctrl+U` | Scroll down / up half page |
+| `g` / `G` | Scroll to top / bottom |
+
+### Cursor movement
+
+| Key | Action |
+|---|---|
+| `h` / `l` | Move cursor left / right |
+| `w` / `b` | Word forward / back |
+| `0` / `$` | Start / end of line |
+
+### Editing
+
+| Key | Action |
+|---|---|
+| `x` | Delete character at cursor |
+| `D` | Delete from cursor to end of line |
+
+### Entering Insert mode
+
+| Key | Action |
+|---|---|
+| `i` | Insert at cursor |
+| `a` | Insert after cursor |
+| `I` | Insert at start of line |
+| `A` | Insert at end of line |
+| `o` | Insert (clear buffer first) |
+| `/` | Insert with `/` pre-typed (for commands) |
+
+## Insert mode (default)
+
+Insert mode is the default on startup. You can type messages and commands directly.
+
+| Key | Action |
+|---|---|
+| `Esc` | Switch to Normal mode |
+| `Enter` | Send message or execute command |
+| `Backspace` / `Delete` | Delete characters |
+| `Up` / `Down` | Recall input history |
+| `Left` / `Right` | Move cursor |
+| `Home` / `End` | Jump to start / end of line |
+
+## Input history
+
+In Insert mode, press `Up` and `Down` to cycle through previously sent messages
+and commands. History is per-session (not persisted to disk). Your current draft
+is preserved while browsing history.

--- a/docs/src/user-guide/troubleshooting.md
+++ b/docs/src/user-guide/troubleshooting.md
@@ -1,0 +1,76 @@
+# Troubleshooting
+
+## signal-cli not found
+
+**Symptom:** setup wizard says it cannot find signal-cli.
+
+**Fix:** ensure signal-cli is installed and on your `PATH`. You can also set the
+full path in your config:
+
+```toml
+signal_cli_path = "/usr/local/bin/signal-cli"
+```
+
+On Windows, use the full path to `signal-cli.bat`.
+
+## QR code doesn't display properly
+
+**Symptom:** the QR code appears garbled or too large during device linking.
+
+**Fix:** make sure your terminal is at least 60 columns wide and supports Unicode
+block characters. Try a modern terminal emulator like Windows Terminal, iTerm2,
+Kitty, or Alacritty.
+
+## "Java not found" errors
+
+**Symptom:** signal-cli fails to start with Java-related errors.
+
+**Fix:** signal-cli requires Java 21+. Install a JDK and make sure `java` is on
+your `PATH`:
+
+```sh
+java -version
+```
+
+## Messages not appearing
+
+**Symptom:** the app starts but no messages show up.
+
+**Fix:**
+1. Check that your device is properly linked in Signal's settings on your phone
+   (**Settings > Linked Devices**)
+2. Try re-running the setup wizard: `signal-tui --setup`
+3. Check signal-cli can communicate by running it directly:
+   ```sh
+   signal-cli -a +15551234567 receive
+   ```
+
+## Images not rendering
+
+**Symptom:** images show as `[attachment: image.jpg]` instead of inline previews.
+
+**Fix:** make sure `inline_images = true` in your config (this is the default).
+Also check that your terminal supports 256 colors or truecolor. Halfblock
+rendering requires a terminal with proper Unicode support.
+
+## Sidebar disappeared
+
+**Symptom:** the sidebar is not visible.
+
+**Fix:** if your terminal is narrower than 60 columns, the sidebar auto-hides.
+Widen your terminal, or press `/sidebar` to force it on. You can also use
+`Ctrl+Right` to widen the sidebar.
+
+## Database errors
+
+**Symptom:** errors about SQLite or the database file.
+
+**Fix:** the database is stored alongside the config file. If it becomes corrupted,
+you can delete it and signal-tui will create a fresh one on next launch. You'll
+lose message history but all conversations will re-populate from signal-cli.
+
+As a workaround, you can also run in incognito mode:
+
+```sh
+signal-tui --incognito
+```

--- a/docs/theme/css/irc-theme.css
+++ b/docs/theme/css/irc-theme.css
@@ -1,0 +1,327 @@
+/* signal-tui docs — IRC theme
+ * Dark terminal aesthetic with modern polish.
+ * Overrides the mdBook "coal" theme.
+ */
+
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,600;0,700;1,400&display=swap');
+
+/* ── colour palette ────────────────────────────────────── */
+:root {
+    --bg-deep:       #0c0c1d;
+    --bg-main:       #1a1a2e;
+    --bg-sidebar:    #12122a;
+    --bg-code:       #0f0f23;
+    --text-primary:  #c0c0c0;
+    --text-heading:  #00ff88;
+    --accent-cyan:   #00e5ff;
+    --accent-green:  #39ff14;
+    --accent-amber:  #ffb000;
+    --border-dim:    #2a2a4a;
+    --border-bright: #3a3a5a;
+}
+
+/* ── global typography ─────────────────────────────────── */
+.coal {
+    --bg:             var(--bg-main);
+    --fg:             var(--text-primary);
+    --sidebar-bg:     var(--bg-sidebar);
+    --sidebar-fg:     #8888aa;
+    --sidebar-active: var(--accent-cyan);
+    --links:          var(--accent-cyan);
+    --inline-code-color: var(--accent-green);
+    --theme-popup-bg:    var(--bg-deep);
+    --theme-popup-border: var(--border-dim);
+    --search-mark-bg: rgba(0, 229, 255, 0.2);
+}
+
+body,
+.content,
+.sidebar,
+code,
+pre,
+input,
+textarea {
+    font-family: 'JetBrains Mono', 'Cascadia Code', 'Fira Code', 'Source Code Pro', 'Consolas', monospace !important;
+}
+
+html {
+    background-color: var(--bg-deep) !important;
+}
+
+body {
+    color: var(--text-primary);
+    font-size: 14px;
+    line-height: 1.7;
+}
+
+/* ── headings ──────────────────────────────────────────── */
+.content h1 {
+    color: var(--text-heading);
+    border-bottom: 2px solid var(--border-dim);
+    padding-bottom: 0.4em;
+    font-size: 1.6em;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.content h2 {
+    color: var(--accent-amber);
+    border-bottom: 1px dotted var(--border-dim);
+    padding-bottom: 0.3em;
+    font-size: 1.25em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.content h3 {
+    color: var(--accent-cyan);
+    font-size: 1.05em;
+}
+
+.content h4,
+.content h5,
+.content h6 {
+    color: var(--text-primary);
+}
+
+/* ── links ─────────────────────────────────────────────── */
+.content a {
+    color: var(--accent-cyan);
+    text-decoration: none;
+    border-bottom: 1px dotted var(--accent-cyan);
+    transition: border-bottom-style 0.15s ease;
+}
+
+.content a:hover {
+    border-bottom-style: solid;
+    text-shadow: 0 0 6px rgba(0, 229, 255, 0.3);
+}
+
+/* ── inline code ───────────────────────────────────────── */
+.content code {
+    color: var(--accent-green);
+    background-color: rgba(15, 15, 35, 0.6);
+    border: 1px solid var(--border-dim);
+    border-radius: 3px;
+    padding: 0.1em 0.35em;
+    font-size: 0.9em;
+}
+
+/* ── code blocks ───────────────────────────────────────── */
+.content pre {
+    background-color: var(--bg-code) !important;
+    border: 1px solid var(--border-dim);
+    border-radius: 4px;
+    padding: 1em 1.2em;
+    position: relative;
+    overflow-x: auto;
+}
+
+.content pre > code {
+    color: var(--text-primary);
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+/* terminal title bar for code blocks */
+.content pre::before {
+    content: '>';
+    display: block;
+    color: var(--accent-green);
+    font-size: 0.8em;
+    margin-bottom: 0.5em;
+    opacity: 0.5;
+}
+
+/* ── blockquotes ───────────────────────────────────────── */
+.content blockquote {
+    border-left: 3px solid var(--accent-amber);
+    background-color: rgba(255, 176, 0, 0.05);
+    color: #aaa;
+    padding: 0.5em 1em;
+    margin: 1em 0;
+}
+
+/* ── tables ────────────────────────────────────────────── */
+.content table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+}
+
+.content table th {
+    color: var(--accent-amber);
+    background-color: rgba(255, 176, 0, 0.08);
+    border: 1px solid var(--border-dim);
+    padding: 0.5em 0.8em;
+    text-align: left;
+    text-transform: uppercase;
+    font-size: 0.85em;
+    letter-spacing: 0.06em;
+}
+
+.content table td {
+    border: 1px solid var(--border-dim);
+    padding: 0.45em 0.8em;
+}
+
+.content table tr:nth-child(even) {
+    background-color: rgba(18, 18, 42, 0.4);
+}
+
+/* ── sidebar (IRC channel list) ────────────────────────── */
+.sidebar {
+    background-color: var(--bg-sidebar) !important;
+    border-right: 1px solid var(--border-dim);
+}
+
+.sidebar .sidebar-scrollbox {
+    background-color: var(--bg-sidebar) !important;
+}
+
+/* section headers look like IRC network names */
+.sidebar .chapter li.part-title {
+    color: var(--accent-amber);
+    text-transform: uppercase;
+    font-size: 0.75em;
+    letter-spacing: 0.12em;
+    padding: 0.8em 0 0.3em 1em;
+    border-bottom: 1px solid var(--border-dim);
+    margin-bottom: 0.2em;
+}
+
+/* chapter links look like IRC channel names */
+.sidebar .chapter a {
+    color: #8888aa;
+    border-left: 3px solid transparent;
+    padding: 0.25em 0 0.25em 0.8em;
+    display: block;
+    transition: all 0.12s ease;
+}
+
+.sidebar .chapter a:hover {
+    color: var(--accent-cyan);
+    border-left-color: var(--accent-cyan);
+    background-color: rgba(0, 229, 255, 0.05);
+}
+
+.sidebar .chapter li.chapter-item.expanded > a,
+.sidebar .chapter a.active {
+    color: var(--accent-cyan);
+    border-left-color: var(--accent-cyan);
+    background-color: rgba(0, 229, 255, 0.08);
+    font-weight: 600;
+}
+
+/* ── top menu bar ──────────────────────────────────────── */
+.menu-bar,
+.menu-bar.bordered {
+    background-color: var(--bg-deep) !important;
+    border-bottom: 1px solid var(--border-dim) !important;
+}
+
+.menu-bar .icon-button {
+    color: #6666aa;
+}
+
+.menu-bar .icon-button:hover {
+    color: var(--accent-cyan);
+}
+
+/* ── CRT scanline overlay (desktop only) ───────────────── */
+@media (min-width: 768px) {
+    .content main::after {
+        content: '';
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 9999;
+        background: repeating-linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.03) 0px,
+            rgba(0, 0, 0, 0.03) 1px,
+            transparent 1px,
+            transparent 3px
+        );
+    }
+}
+
+/* ── selection ─────────────────────────────────────────── */
+::selection {
+    background-color: rgba(0, 229, 255, 0.25);
+    color: #fff;
+}
+
+/* ── scrollbar ─────────────────────────────────────────── */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--bg-deep);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border-bright);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: #4a4a6a;
+}
+
+/* ── search box ────────────────────────────────────────── */
+#searchbar {
+    background-color: var(--bg-code) !important;
+    border: 1px solid var(--border-dim) !important;
+    color: var(--text-primary) !important;
+}
+
+#searchbar:focus {
+    border-color: var(--accent-cyan) !important;
+    box-shadow: 0 0 4px rgba(0, 229, 255, 0.2);
+}
+
+#searchresults a {
+    color: var(--accent-cyan);
+}
+
+#searchresults .teaser {
+    color: #888;
+}
+
+/* ── navigation buttons ────────────────────────────────── */
+.nav-chapters {
+    color: #6666aa;
+    transition: color 0.15s ease;
+}
+
+.nav-chapters:hover {
+    color: var(--accent-cyan);
+}
+
+/* ── page footer ───────────────────────────────────────── */
+.content .warning {
+    border-left-color: var(--accent-amber);
+    background-color: rgba(255, 176, 0, 0.06);
+}
+
+/* ── responsive adjustments ────────────────────────────── */
+@media (max-width: 768px) {
+    body {
+        font-size: 13px;
+    }
+
+    .content h1 {
+        font-size: 1.3em;
+    }
+
+    .content h2 {
+        font-size: 1.1em;
+    }
+}


### PR DESCRIPTION
## Summary

- Add full documentation site using mdBook with 17 content chapters
- **User Guide**: installation, getting started, configuration, commands, keybindings, features, troubleshooting, FAQ
- **Developer Guide**: architecture, module reference, data flow, database schema, signal-cli protocol, testing, contributing, CI & releases, roadmap
- Custom IRC-themed CSS: dark terminal palette, monospace typography, CRT scanline overlay, IRC-style sidebar navigation
- GitHub Actions workflow (`docs.yml`) to build and deploy to GitHub Pages on push to master
- Add `docs/book/` to `.gitignore` and docs badge to README

## Setup required

After merging, enable GitHub Pages in repo settings:
- **Settings > Pages > Source**: select "GitHub Actions"

## Test plan

- [x] `mdbook build docs` succeeds with no errors
- [x] All 17 chapter pages generated in `docs/book/`
- [x] IRC theme CSS is linked in HTML output
- [x] `cargo clippy --tests -- -D warnings` passes (no regressions)
- [ ] Verify GitHub Pages deploys after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)