### PR TITLE
Show full timestamp in status bar when scrolling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -154,6 +154,8 @@ pub struct App {
     pub pending_sends: HashMap<String, (String, i64)>,
     /// Receipts that arrived before their matching SendTimestamp — replayed after each SendTimestamp
     pub pending_receipts: Vec<(String, String, Vec<i64>)>,
+    /// Timestamp of the message at the scroll cursor (set during draw, cleared at scroll_offset=0)
+    pub focused_message_time: Option<DateTime<Utc>>,
 }
 
 pub const SETTINGS_ITEMS: &[&str] = &[
@@ -344,6 +346,7 @@ impl App {
             nerd_fonts: false,
             pending_sends: HashMap::new(),
             pending_receipts: Vec::new(),
+            focused_message_time: None,
         }
     }
 


### PR DESCRIPTION
## Summary
- When scrolling through messages in Normal mode (j/k), the status bar now displays the full date and time of the focused message
- Format: `Sun Mar 01, 2026 12:34:56 PM` — shown after the scroll offset indicator
- Clears automatically when returning to the bottom (scroll_offset=0) or switching to Insert mode

Closes #27

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (81 tests)
- [ ] Scroll up in a conversation — full timestamp appears in status bar
- [ ] Scroll back to bottom — timestamp disappears
- [ ] Switch to Insert mode while scrolled — timestamp disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)