### PR TITLE
Add y/Y to copy message to clipboard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ rusqlite = { version = "0.32", features = ["bundled"] }
 qrcode = "0.14"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "gif", "webp"] }
 base64 = "0.22"
+arboard = "3"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1201,6 +1201,55 @@ impl App {
     pub fn total_unread(&self) -> usize {
         self.conversations.values().map(|c| c.unread).sum()
     }
+
+    /// Get the message at the current scroll position.
+    /// Returns the message at the bottom of the visible viewport.
+    /// scroll_offset=0 means the newest message; higher values go older.
+    fn selected_message(&self) -> Option<&DisplayMessage> {
+        let conv_id = self.active_conversation.as_ref()?;
+        let conv = self.conversations.get(conv_id)?;
+        let total = conv.messages.len();
+        if total == 0 {
+            return None;
+        }
+        let index = total.saturating_sub(1).saturating_sub(self.scroll_offset);
+        conv.messages.get(index)
+    }
+
+    /// Copy the selected message text to the system clipboard.
+    /// If `full_line` is true, copies "[HH:MM] <sender> body"; otherwise just the body.
+    pub fn copy_selected_message(&mut self, full_line: bool) {
+        let text = match self.selected_message() {
+            Some(msg) if msg.is_system => Some(msg.body.clone()),
+            Some(msg) => {
+                if full_line {
+                    Some(format!("[{}] <{}> {}", msg.format_time(), msg.sender, msg.body))
+                } else {
+                    Some(msg.body.clone())
+                }
+            }
+            None => None,
+        };
+
+        let Some(text) = text else {
+            self.status_message = "No message to copy".to_string();
+            return;
+        };
+
+        match arboard::Clipboard::new() {
+            Ok(mut clipboard) => match clipboard.set_text(&text) {
+                Ok(()) => {
+                    self.status_message = "Copied to clipboard".to_string();
+                }
+                Err(e) => {
+                    self.status_message = format!("Clipboard error: {e}");
+                }
+            },
+            Err(e) => {
+                self.status_message = format!("Clipboard error: {e}");
+            }
+        }
+    }
 }
 
 /// Shorten a phone number for display: +15551234567 -> +1***4567

--- a/src/main.rs
+++ b/src/main.rs
@@ -636,6 +636,14 @@ async fn run_app(
                                 app.input_buffer.truncate(app.input_cursor);
                             }
 
+                            // Copy message to clipboard
+                            (_, KeyCode::Char('y')) => {
+                                app.copy_selected_message(false);
+                            }
+                            (_, KeyCode::Char('Y')) => {
+                                app.copy_selected_message(true);
+                            }
+
                             // Quick actions
                             (_, KeyCode::Char('/')) => {
                                 app.input_buffer = "/".to_string();
@@ -912,6 +920,12 @@ async fn run_demo_app(
                                 }
                                 (_, KeyCode::Char('D')) => {
                                     app.input_buffer.truncate(app.input_cursor);
+                                }
+                                (_, KeyCode::Char('y')) => {
+                                    app.copy_selected_message(false);
+                                }
+                                (_, KeyCode::Char('Y')) => {
+                                    app.copy_selected_message(true);
                                 }
                                 (_, KeyCode::Char('/')) => {
                                     app.input_buffer = "/".to_string();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1067,6 +1067,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         ("w / b", "Word forward / back"),
         ("0 / $", "Start / end of line"),
         ("x / D", "Delete char / to end"),
+        ("y / Y", "Copy message / full line"),
         ("/", "Start command input"),
     ];
 


### PR DESCRIPTION
## Summary
- In Normal mode, `y` copies the selected message body to the system clipboard
- `Y` copies the full formatted line: `[HH:MM] <sender> body`
- Uses `arboard` crate for cross-platform clipboard (Windows, macOS, Linux/X11/Wayland)
- Status bar shows "Copied to clipboard" confirmation or error message

Closes #28

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (81 tests)
- [ ] Press `y` on a message → body text copied to clipboard
- [ ] Press `Y` on a message → full `[HH:MM] <sender> body` copied
- [ ] Try on an empty conversation → "No message to copy" status message

🤖 Generated with [Claude Code](https://claude.com/claude-code)