### PR TITLE
Refactor: split parse_receive_event, modernize tests, minor cleanups

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -93,58 +93,44 @@ mod tests {
 
     #[test]
     fn plain_text() {
-        match parse_input("hello world") {
-            InputAction::SendText(s) => assert_eq!(s, "hello world"),
-            other => panic!("expected SendText, got {other:?}"),
-        }
+        let InputAction::SendText(s) = parse_input("hello world") else { panic!("expected SendText") };
+        assert_eq!(s, "hello world");
     }
 
     #[test]
     fn empty_input() {
-        match parse_input("") {
-            InputAction::SendText(s) => assert!(s.is_empty()),
-            other => panic!("expected empty SendText, got {other:?}"),
-        }
+        let InputAction::SendText(s) = parse_input("") else { panic!("expected SendText") };
+        assert!(s.is_empty());
     }
 
     #[test]
     fn whitespace_only() {
-        match parse_input("   ") {
-            InputAction::SendText(s) => assert!(s.is_empty()),
-            other => panic!("expected empty SendText, got {other:?}"),
-        }
+        let InputAction::SendText(s) = parse_input("   ") else { panic!("expected SendText") };
+        assert!(s.is_empty());
     }
 
     #[test]
     fn trimmed_text() {
-        match parse_input("  hello  ") {
-            InputAction::SendText(s) => assert_eq!(s, "hello"),
-            other => panic!("expected SendText, got {other:?}"),
-        }
+        let InputAction::SendText(s) = parse_input("  hello  ") else { panic!("expected SendText") };
+        assert_eq!(s, "hello");
     }
 
     #[test]
     fn join_with_arg() {
-        match parse_input("/join Alice") {
-            InputAction::Join(s) => assert_eq!(s, "Alice"),
-            other => panic!("expected Join, got {other:?}"),
-        }
+        let InputAction::Join(s) = parse_input("/join Alice") else { panic!("expected Join") };
+        assert_eq!(s, "Alice");
     }
 
     #[test]
     fn join_alias() {
-        match parse_input("/j +1234567890") {
-            InputAction::Join(s) => assert_eq!(s, "+1234567890"),
-            other => panic!("expected Join, got {other:?}"),
-        }
+        let InputAction::Join(s) = parse_input("/j +1234567890") else { panic!("expected Join") };
+        assert_eq!(s, "+1234567890");
     }
 
     #[test]
     fn join_without_arg() {
-        match parse_input("/join") {
-            InputAction::Unknown(s) => assert!(s.contains("requires")),
-            other => panic!("expected Unknown, got {other:?}"),
-        }
+        let InputAction::Unknown(s) = parse_input("/join") else { panic!("expected Unknown") };
+        assert!(s.contains("requires"));
     }
 
     #[test]
@@ -179,26 +165,19 @@ mod tests {
 
     #[test]
     fn bell_no_arg() {
-        match parse_input("/bell") {
-            InputAction::ToggleBell(None) => {}
-            other => panic!("expected ToggleBell(None), got {other:?}"),
-        }
+        let InputAction::ToggleBell(None) = parse_input("/bell") else { panic!("expected ToggleBell(None)") };
     }
 
     #[test]
     fn bell_with_arg() {
-        match parse_input("/bell direct") {
-            InputAction::ToggleBell(Some(s)) => assert_eq!(s, "direct"),
-            other => panic!("expected ToggleBell(Some), got {other:?}"),
-        }
+        let InputAction::ToggleBell(Some(s)) = parse_input("/bell direct") else { panic!("expected ToggleBell(Some)") };
+        assert_eq!(s, "direct");
     }
 
     #[test]
     fn notify_alias() {
-        match parse_input("/notify group") {
-            InputAction::ToggleBell(Some(s)) => assert_eq!(s, "group"),
-            other => panic!("expected ToggleBell(Some), got {other:?}"),
-        }
+        let InputAction::ToggleBell(Some(s)) = parse_input("/notify group") else { panic!("expected ToggleBell(Some)") };
+        assert_eq!(s, "group");
     }
 
     #[test]
@@ -233,9 +212,7 @@ mod tests {
 
     #[test]
     fn unknown_command() {
-        match parse_input("/foo") {
-            InputAction::Unknown(s) => assert!(s.contains("/foo")),
-            other => panic!("expected Unknown, got {other:?}"),
-        }
+        let InputAction::Unknown(s) = parse_input("/foo") else { panic!("expected Unknown") };
+        assert!(s.contains("/foo"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,9 @@ use config::Config;
 use setup::SetupResult;
 use signal::client::SignalClient;
 
+/// Keyboard polling interval for the main event loop.
+const POLL_TIMEOUT: Duration = Duration::from_millis(50);
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Disable the default Windows Ctrl+C handler — crossterm captures it as a
@@ -471,7 +474,7 @@ async fn run_app(
         }
 
         // Poll for events with a short timeout so we stay responsive to signal events
-        let has_terminal_event = event::poll(Duration::from_millis(50))?;
+        let has_terminal_event = event::poll(POLL_TIMEOUT)?;
 
         if has_terminal_event {
             if let Event::Key(key) = event::read()? {
@@ -566,7 +569,7 @@ async fn run_demo_app(
             emit_native_images(terminal.backend_mut(), &mut app)?;
         }
 
-        let has_terminal_event = event::poll(Duration::from_millis(50))?;
+        let has_terminal_event = event::poll(POLL_TIMEOUT)?;
 
         if has_terminal_event {
             if let Event::Key(key) = event::read()? {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -163,6 +163,9 @@ pub async fn run_setup(
                                 step = Step::SignalCli;
                                 signal_cli_found = false;
                                 custom_path_mode = false;
+                                phone_input.clear();
+                                phone_cursor = 0;
+                                phone_error = None;
                             }
                             (_, KeyCode::Enter) => {
                                 match validate_phone(&phone_input) {


### PR DESCRIPTION
## Summary
- Split `parse_receive_event` (~157 lines) into 4 focused sub-functions: dispatcher, `parse_typing_indicator`, `parse_receipt_message`, `parse_data_message`
- Convert input.rs tests from `match + panic!` to idiomatic `let-else` pattern
- Extract `POLL_TIMEOUT` constant in main.rs (replaces magic `Duration::from_millis(50)`)
- Clear phone input fields on Esc in setup wizard account step
- Default receipt_type to `"UNKNOWN"` instead of empty string for robustness

Batch 4 (low priority) of code review items: #15 (skipped — cosmetic), #16, #17, #18, #19, #20.

## Test plan
- [x] `cargo clippy --tests -- -D warnings` — zero warnings
- [x] `cargo test` — 83 tests pass
- [x] Net -9 lines (87 added, 96 removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)