### PR TITLE
Capture signal-cli stderr for startup error handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -953,7 +953,8 @@ impl App {
             }
             SignalEvent::ContactList(contacts) => self.handle_contact_list(contacts),
             SignalEvent::GroupList(groups) => self.handle_group_list(groups),
-            SignalEvent::Error(err) => {
+            SignalEvent::Error(ref err) => {
+                crate::debug_log::logf(format_args!("signal event error: {err}"));
                 self.status_message = format!("error: {err}");
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -983,7 +983,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
     // Connection status dot
     if let Some(ref err) = app.connection_error {
         segments.push(Span::styled(" ● ", Style::default().fg(Color::Red)));
-        let display: String = err.chars().take(30).collect();
+        let display: String = err.chars().take(60).collect();
         segments.push(Span::styled(
             format!("error: {display}"),
             Style::default().fg(Color::Red),


### PR DESCRIPTION
## Summary
- Capture signal-cli stderr into a shared buffer with a dedicated tokio reader task, logging each line via `debug_log`
- Replace the generic "signal-cli disconnected" status bar message with the actual stderr output (e.g. "signal-cli: User +447... is not registered") or exit code info
- Widen status bar error truncation from 30 → 60 chars so diagnostic messages are readable
- Add `debug_log` to two previously silent error paths: `SignalEvent::Error` handler and `check_account_registered` failure

## Test plan
- [x] `cargo clippy --tests -- -D warnings` — zero warnings
- [x] `cargo test` — all 96 tests pass
- [ ] Manual: `cargo run -- --account +0000000000 --debug` — status bar shows "signal-cli: User +0000000000 is not registered" (not generic "disconnected")
- [ ] Manual: kill signal-cli process externally — status bar shows exit code info
- [ ] Manual: verify stderr lines appear in `signal-tui-debug.log` when `--debug` is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)