### PR TITLE
Update docs for v0.6.0 release

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,77 @@
 # Changelog
 
+## v0.6.0
+
+### Reply, edit, and delete messages
+
+- **Quote reply** -- press `q` in Normal mode on any message to reply with a
+  quote. A reply indicator appears above the input box, and the sent message
+  includes a quoted block showing the original author and text (closes #15)
+- **Edit messages** -- press `e` on your own outgoing message to edit it.
+  The original text is loaded into the input buffer for modification. Edited
+  messages display an "(edited)" label. Edits sync across devices (closes #24)
+- **Delete messages** -- press `d` on any message to open a delete confirmation.
+  Outgoing messages offer "delete for everyone" (remote delete) or "delete
+  locally". Incoming messages can be deleted locally. Deleted messages show as
+  "[deleted]" (closes #23)
+
+### Message search
+
+- **`/search` command** -- search across all conversations with `/search <query>`
+  (alias: `/s`). Results appear in a scrollable overlay showing sender, message
+  snippet, and conversation name. Press Enter to jump directly to the message in
+  context. Use `n`/`N` in Normal mode to cycle through matches (closes #14)
+- **Highlight matches** -- search terms are highlighted in the result snippets
+
+### File attachments
+
+- **`/attach` command** -- send files with `/attach` to open a file browser
+  overlay. Navigate with `j`/`k`, Enter to select, Backspace to go up a
+  directory. The selected file attaches to your next message, shown as a
+  pending indicator in the input area (closes #54)
+
+### /join autocomplete
+
+- **Contact and group autocomplete** -- `/join` now offers Tab-completable
+  suggestions from your contacts and groups. Type `/join ` and see matching
+  names, or keep typing to filter. Groups and contacts are distinguished by
+  color (closes #21)
+
+### Send typing indicators
+
+- **Outbound typing** -- signal-tui now sends typing indicators to your
+  conversation partner while you type. Typing state starts on the first
+  keypress, auto-stops after 5 seconds of inactivity, and stops immediately
+  when you send or switch conversations (closes #58)
+
+### Send read receipts
+
+- **Read receipt sending** -- when you view a conversation, read receipts are
+  automatically sent to message senders, letting them know you've read their
+  messages. Controlled by the "Send read receipts" toggle in `/settings`
+  (closes #59)
+
+### Welcome screen
+
+- **Getting started hints** -- the welcome screen now shows useful commands
+  and navigation tips including Tab/Shift+Tab for cycling conversations
+
+### Bug fixes
+
+- **Out-of-order messages** -- messages with delayed delivery timestamps are
+  now inserted in correct chronological order (#56)
+- **Link highlight** -- fixed background color bleeding on highlighted links
+  and J/K message navigation edge cases (#55)
+
+### Database
+
+- **Migration v5** -- adds index on `messages(conversation_id, timestamp_ms)`
+  for faster search queries
+- **Migration v6** -- adds `is_edited`, `is_deleted`, `quote_author`,
+  `quote_body`, `quote_ts_ms`, and `sender_id` columns to the messages table
+
+---
+
 ## v0.5.0
 
 ### Message reactions

--- a/docs/src/dev-guide/database.md
+++ b/docs/src/dev-guide/database.md
@@ -40,17 +40,45 @@ All messages, ordered by insertion rowid.
 CREATE TABLE messages (
     rowid           INTEGER PRIMARY KEY AUTOINCREMENT,
     conversation_id TEXT NOT NULL REFERENCES conversations(id),
-    sender          TEXT NOT NULL,       -- sender phone or empty for system
+    sender          TEXT NOT NULL,       -- sender display name or empty for system
     timestamp       TEXT NOT NULL,       -- RFC 3339 timestamp
     body            TEXT NOT NULL,       -- message text
-    is_system       INTEGER NOT NULL DEFAULT 0
+    is_system       INTEGER NOT NULL DEFAULT 0,
+    status          INTEGER NOT NULL DEFAULT 0,    -- MessageStatus enum (v3)
+    timestamp_ms    INTEGER NOT NULL DEFAULT 0,    -- server epoch ms (v3)
+    is_edited       INTEGER NOT NULL DEFAULT 0,    -- edited flag (v6)
+    is_deleted      INTEGER NOT NULL DEFAULT 0,    -- deleted flag (v6)
+    quote_author    TEXT,                           -- quoted reply author (v6)
+    quote_body      TEXT,                           -- quoted reply body (v6)
+    quote_ts_ms     INTEGER,                        -- quoted reply timestamp (v6)
+    sender_id       TEXT NOT NULL DEFAULT ''        -- sender phone number (v6)
 );
 
 CREATE INDEX idx_messages_conv_ts ON messages(conversation_id, timestamp);
+CREATE INDEX idx_messages_conv_ts_ms ON messages(conversation_id, timestamp_ms);
 ```
 
 System messages (`is_system = 1`) are used for join/leave notifications and
 are excluded from unread counts.
+
+### `reactions`
+
+Emoji reactions on messages. One reaction per sender per message, with
+the latest emoji replacing any previous one.
+
+```sql
+CREATE TABLE reactions (
+    rowid           INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id TEXT NOT NULL,
+    target_ts_ms    INTEGER NOT NULL,     -- timestamp of the reacted-to message
+    target_author   TEXT NOT NULL,         -- author of the reacted-to message
+    emoji           TEXT NOT NULL,
+    sender          TEXT NOT NULL,         -- who sent this reaction
+    UNIQUE(conversation_id, target_ts_ms, target_author, sender)
+);
+
+CREATE INDEX idx_reactions_target ON reactions(conversation_id, target_ts_ms);
+```
 
 ### `read_markers`
 
@@ -73,6 +101,10 @@ Migrations are version-based and run sequentially in `Database::migrate()`:
 |---|---|
 | 1 | Initial schema: `conversations`, `messages`, `read_markers` tables |
 | 2 | Add `muted` column to `conversations` |
+| 3 | Add `status` and `timestamp_ms` columns to `messages` (delivery status tracking) |
+| 4 | Create `reactions` table with unique constraint per sender per message |
+| 5 | Add index on `messages(conversation_id, timestamp_ms)` for search performance |
+| 6 | Add `is_edited`, `is_deleted`, `quote_author`, `quote_body`, `quote_ts_ms`, `sender_id` columns to `messages` |
 
 Each migration is wrapped in a transaction. The `schema_version` table tracks
 the current version.

--- a/docs/src/dev-guide/modules.md
+++ b/docs/src/dev-guide/modules.md
@@ -60,8 +60,9 @@ after Ratatui's draw to avoid width calculation issues).
 
 ### `db.rs`
 
-SQLite database layer with WAL mode. Three tables: `conversations`, `messages`,
-`read_markers`. Schema migration is version-based (see [Database Schema](database.md)).
+SQLite database layer with WAL mode. Four tables: `conversations`, `messages`,
+`read_markers`, `reactions`. Schema migration is version-based (currently at v6,
+see [Database Schema](database.md)).
 
 Provides `open()` for disk-backed storage and `open_in_memory()` for incognito mode.
 
@@ -69,7 +70,7 @@ Provides `open()` for disk-backed storage and `open_in_memory()` for incognito m
 
 TOML configuration. The `Config` struct is serialized/deserialized with serde.
 Fields: `account`, `signal_cli_path`, `download_dir`, `notify_direct`,
-`notify_group`, `inline_images`. All fields have defaults.
+`notify_group`, `inline_images`, `send_read_receipts`. All fields have defaults.
 
 `Config::load()` reads from the platform-specific path (or a custom path).
 `Config::save()` writes the current config back to disk.
@@ -78,7 +79,7 @@ Fields: `account`, `signal_cli_path`, `download_dir`, `notify_direct`,
 
 Input parsing. Converts text input into an `InputAction` enum. Handles all
 slash commands (`/join`, `/part`, `/quit`, `/sidebar`, `/bell`, `/mute`,
-`/settings`, `/help`) and their aliases.
+`/contacts`, `/settings`, `/search`, `/attach`, `/help`) and their aliases.
 
 Also defines `CommandInfo` and the `COMMANDS` constant used for autocomplete.
 

--- a/docs/src/dev-guide/protocol.md
+++ b/docs/src/dev-guide/protocol.md
@@ -87,10 +87,14 @@ outbound request). They have a `method` field but no `id`:
 
 | Method | Purpose |
 |---|---|
-| `send` | Send a message to a contact or group |
+| `send` | Send a message (also used for edits via `editTimestamp` param) |
 | `listContacts` | Request the contact address book |
 | `listGroups` | Request the list of groups |
 | `sendSyncRequest` | Request a sync from the primary device |
+| `sendReaction` | Send an emoji reaction to a message |
+| `remoteDelete` | Delete a message for all recipients |
+| `sendTypingIndicator` | Send typing started/stopped indicator |
+| `sendReceipt` | Send a read receipt for one or more messages |
 
 ### Inbound notifications (signal-cli -> signal-tui)
 
@@ -99,6 +103,16 @@ outbound request). They have a `method` field but no `id`:
 | `receive` | Incoming message | `SignalEvent::MessageReceived` |
 | `receiveTyping` | Typing indicator | `SignalEvent::TypingIndicator` |
 | `receiveReceipt` | Delivery/read receipt | `SignalEvent::ReceiptReceived` |
+
+Incoming `receive` envelopes may also contain:
+
+| Envelope field | Purpose | Maps to |
+|---|---|---|
+| `dataMessage.reaction` | Incoming reaction | `SignalEvent::ReactionReceived` |
+| `dataMessage.remoteDelete` | Remote delete request | `SignalEvent::RemoteDeleteReceived` |
+| `dataMessage.quote` | Quoted reply metadata | `quote` field on `SignalMessage` |
+| `editMessage` | Edited message | `SignalEvent::EditReceived` |
+| `syncMessage.sentMessage` | Outgoing sync (own messages from other devices) | Same as above, with `is_outgoing = true` |
 
 ## Parsing logic
 

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -4,7 +4,7 @@
 
 - [x] Send and receive plain text messages (1:1 and group)
 - [x] Receive file attachments (displayed as `[attachment: filename]`)
-- [x] Typing indicators
+- [x] Typing indicators (receive and send)
 - [x] SQLite-backed message persistence with WAL mode
 - [x] Unread message counts with persistent read markers
 - [x] Vim-style modal editing (Normal / Insert modes)
@@ -31,21 +31,52 @@
 - [x] @mention autocomplete (type `@` in group or 1:1 chats)
 - [x] Visible message selection (focus highlight, `J`/`K` message-level navigation)
 - [x] Startup error handling (signal-cli stderr captured in TUI error screen)
+- [x] Reply to specific messages (quote reply with `q` key)
+- [x] Edit own messages (`e` key, "(edited)" label, cross-device sync)
+- [x] Delete messages (`d` key, remote delete + local delete)
+- [x] Message search (`/search`, `n`/`N` navigation)
+- [x] Send file attachments (`/attach` command with file browser)
+- [x] `/join` autocomplete (contacts and groups with Tab completion)
+- [x] Send typing indicators (auto-start/stop on keypress)
+- [x] Send read receipts (automatic on conversation view, configurable)
 
 ## Up next
 
-- [ ] **Send attachments** -- only receiving works today. Add a `/send-file <path>`
-  command.
-- [ ] **Message search** -- full-text search across conversations.
+- [ ] **Group management** -- create groups, add/remove members, view member
+  list (#26)
+- [ ] **Disappearing messages** -- honor disappearing message timers, show
+  countdown, set timer per conversation (#61)
+- [ ] **Message requests** -- accept or reject message requests from unknown
+  senders (#62)
 
 ## Future
 
+### High priority
+
+- [ ] Desktop notifications -- OS-native notifications beyond terminal bell (#19)
+
+### Medium priority
+
+- [ ] Color themes -- custom color schemes beyond the default palette (#18)
+- [ ] Mouse support -- clickable sidebar, messages, and buttons (#17)
+- [ ] Block/unblock contacts -- block and unblock users from the TUI (#60)
+- [ ] Link previews -- display URL previews for shared links (#63)
+- [ ] Polls -- create and vote in Signal polls (#64)
+- [ ] Pinned messages -- view and manage pinned messages (#65)
+- [ ] Text styling -- render bold, italic, strikethrough, monospace, and
+  spoiler formatting (#66)
+- [ ] Cross-device read sync -- sync read state across linked devices (#71)
+
+### Low priority
+
+- [ ] Publish to crates.io (#11)
+- [ ] Display stickers (#67)
+- [ ] View-once messages (#68)
+- [ ] Update profile from TUI (#69)
+- [ ] Identity key verification (#70)
+- [ ] Missed call notifications (#72)
 - [ ] Multi-line message input (Shift+Enter for newlines)
 - [ ] Message history pagination (scroll-up to load older messages)
-- [ ] Correct group typing indicators (per-sender-to-group mapping)
-- [ ] Message deletion and editing
-- [ ] Group management (create, add/remove members, member list)
 - [ ] Scroll position memory per conversation
 - [ ] Configurable keybindings
-- [ ] Reply to specific messages (quote reply)
 - [ ] Forward messages

--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -8,6 +8,8 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 |---|---|---|---|
 | `/join` | `/j` | `<name>` | Switch to a conversation by contact name, number, or group |
 | `/part` | `/p` | | Leave current conversation |
+| `/search` | `/s` | `<query>` | Search messages across all conversations |
+| `/attach` | | | Open file browser to attach a file |
 | `/sidebar` | `/sb` | | Toggle sidebar visibility |
 | `/bell` | `/notify` | `[type]` | Toggle notifications (`direct`, `group`, or both) |
 | `/mute` | | | Mute/unmute current conversation |
@@ -24,6 +26,12 @@ typing, the list filters down. Use:
 - **Up/Down arrows** to navigate the list
 - **Tab** to complete the selected command
 - **Esc** to dismiss the popup
+
+### /join autocomplete
+
+After typing `/join `, a second autocomplete popup shows matching contacts and
+groups. Filter by name or phone number. Groups are shown in green. Press Tab to
+complete the selection.
 
 ## Examples
 
@@ -51,6 +59,20 @@ typing, the list filters down. Use:
 ```
 /mute
 ```
+
+**Search for a message:**
+```
+/search hello
+```
+
+**Attach a file:**
+```
+/attach
+```
+
+This opens a file browser. Navigate with `j`/`k`, Enter to select a file or
+enter a directory, Backspace to go up. The selected file attaches to your next
+message.
 
 ## Messaging a new contact
 

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -26,6 +26,7 @@ download_dir = "/home/user/signal-downloads"
 notify_direct = true
 notify_group = true
 inline_images = true
+send_read_receipts = true
 ```
 
 ### Field reference
@@ -38,6 +39,7 @@ inline_images = true
 | `notify_direct` | bool | `true` | Terminal bell on new direct messages |
 | `notify_group` | bool | `true` | Terminal bell on new group messages |
 | `inline_images` | bool | `true` | Render image attachments as halfblock art |
+| `send_read_receipts` | bool | `true` | Send read receipts when viewing conversations |
 
 ## CLI flags
 
@@ -57,8 +59,12 @@ toggles for runtime settings:
 - Notification toggles (direct / group)
 - Sidebar visibility
 - Inline image previews
+- Read receipts / receipt colors / nerd font icons
+- Verbose reactions
+- Send read receipts
 
-Changes made in the settings overlay apply immediately to the running session.
+Changes made in the settings overlay are saved to the config file when you
+close the overlay, and persist across sessions.
 
 ## Incognito mode
 

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -9,6 +9,8 @@ linked devices) sync into the TUI automatically.
 
 - **Images** -- rendered inline as halfblock art when `inline_images = true`
 - **Other files** -- shown as `[attachment: filename]` with the download path
+- **Send files** -- use `/attach` to open a file browser and attach a file to
+  your next message
 
 Received attachments are saved to the `download_dir` configured in your config file
 (default: `~/signal-downloads/`).
@@ -23,7 +25,9 @@ to open in your browser.
 ## Typing indicators
 
 When someone is typing, their name appears below the chat area. Contact name
-resolution is used where available.
+resolution is used where available. signal-tui also sends typing indicators to
+your conversation partners while you type, so they can see when you're composing
+a message.
 
 ## Persistence
 
@@ -97,6 +101,35 @@ When scrolling in Normal mode, the focused message gets a subtle dark background
 highlight. This makes it clear which message `r` (react) and `y`/`Y` (copy) will
 target. Use `J`/`K` (Shift+j/k) to jump between messages, skipping date
 separators and system messages.
+
+## Reply, edit, and delete
+
+In Normal mode, act on the focused message:
+
+- **`q` -- Quote reply** -- reply with a quoted block showing the original
+  message. A reply indicator appears above your input while composing.
+- **`e` -- Edit** -- edit your own outgoing messages. The original text is
+  loaded into the input buffer. Edited messages display "(edited)".
+- **`d` -- Delete** -- delete a message. Outgoing messages offer "delete for
+  everyone" (remote delete) or "delete locally". Incoming messages can be
+  deleted locally. Deleted messages show as "[deleted]".
+
+All three features sync across devices and persist in the database.
+
+## Message search
+
+Use `/search <query>` (alias `/s`) to search across all conversations. Results
+appear in a scrollable overlay with sender, snippet, and conversation name.
+Press Enter to jump to the message in context.
+
+After searching, use `n`/`N` in Normal mode to cycle through matches without
+re-opening the overlay.
+
+## Read receipts
+
+signal-tui sends read receipts to message senders when you view a conversation,
+letting them know you've read their messages. This can be toggled off via
+`/settings` > "Send read receipts".
 
 ## Demo mode
 

--- a/docs/src/user-guide/keybindings.md
+++ b/docs/src/user-guide/keybindings.md
@@ -33,6 +33,11 @@ changes in the status bar.
 | `y` | Copy message body to clipboard |
 | `Y` | Copy full line (`[HH:MM] <sender> body`) to clipboard |
 | `r` | Open reaction picker on focused message |
+| `q` | Reply to focused message (quote reply) |
+| `e` | Edit own outgoing message |
+| `d` | Delete focused message |
+| `n` | Jump to next search result |
+| `N` | Jump to previous search result |
 | `@` | Mention autocomplete (in Insert mode) |
 
 ### Cursor movement


### PR DESCRIPTION
## Summary

- Add **v0.6.0 changelog** covering all new features: reply/edit/delete (#15, #24, #23), message search (#14), /attach (#54), /join autocomplete (#21), send typing indicators (#58), send read receipts (#59), welcome screen hints, bug fixes (#55, #56), DB migrations v5-v6
- Update **roadmap**: move 8 completed items from Up Next/Future, add 18 open issues organized by priority (high/medium/low) with issue references
- Update **commands.md**: add `/search` (`/s`) and `/attach` commands, document `/join` autocomplete for contacts and groups
- Update **keybindings.md**: add `q` (reply), `e` (edit), `d` (delete), `n`/`N` (search next/prev)
- Update **features.md**: new sections for reply/edit/delete, message search, read receipts, send typing indicators, send attachments
- Update **database.md**: full current schema with all columns through migration v6, add reactions table, complete migration history
- Update **protocol.md**: add `sendReaction`, `remoteDelete`, `sendTypingIndicator`, `sendReceipt` to outbound methods; add inbound envelope fields table for reactions, edits, deletes, quotes, sync
- Update **configuration.md**: add `send_read_receipts` field, expand settings overlay description with all current toggles
- Update **modules.md**: reflect new commands and config fields

## Test plan

- [ ] Verify mdBook builds without errors (`mdbook build` in docs/)
- [ ] Check all internal links resolve correctly
- [ ] Review changelog entries match actual PRs merged since v0.5.0
- [ ] Verify roadmap completed items match shipped features
- [ ] Check roadmap open items match current GitHub issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)