### PR TITLE
Fix U+FFFC mention placeholder in quote text

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -212,7 +212,11 @@ impl Database {
                         .ok()?
                         .with_timezone(&chrono::Utc);
                     let quote = match (quote_author, quote_body, quote_ts_ms) {
-                        (Some(author), Some(body), Some(ts)) => Some(crate::app::Quote { author, body, timestamp_ms: ts }),
+                        (Some(author), Some(body), Some(ts)) => Some(crate::app::Quote {
+                            author,
+                            body: body.replace('\u{FFFC}', ""),
+                            timestamp_ms: ts,
+                        }),
                         _ => None,
                     };
                     Some(DisplayMessage {

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -827,11 +827,12 @@ fn parse_data_message(
         })
         .unwrap_or_default();
 
-    // Parse quoted reply
+    // Parse quoted reply (strip U+FFFC mention placeholders from quote text)
     let quote = data.get("quote").and_then(|q| {
         let q_ts = q.get("id").and_then(|v| v.as_i64())?;
         let q_author = q.get("authorNumber").and_then(|v| v.as_str())?.to_string();
-        let q_body = q.get("text").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let q_body = q.get("text").and_then(|v| v.as_str()).unwrap_or("")
+            .replace('\u{FFFC}', "").to_string();
         Some((q_ts, q_author, q_body))
     });
 
@@ -949,11 +950,12 @@ fn parse_sent_sync(
         })
         .unwrap_or_default();
 
-    // Parse quoted reply
+    // Parse quoted reply (strip U+FFFC mention placeholders from quote text)
     let quote = sent.get("quote").and_then(|q| {
         let q_ts = q.get("id").and_then(|v| v.as_i64())?;
         let q_author = q.get("authorNumber").and_then(|v| v.as_str())?.to_string();
-        let q_body = q.get("text").and_then(|v| v.as_str()).unwrap_or("").to_string();
+        let q_body = q.get("text").and_then(|v| v.as_str()).unwrap_or("")
+            .replace('\u{FFFC}', "").to_string();
         Some((q_ts, q_author, q_body))
     });
 


### PR DESCRIPTION
## Summary

- Strip U+FFFC (Object Replacement Character) from quote bodies when parsing incoming quotes, outgoing sync quotes, and loading from the database
- Signal uses U+FFFC as a placeholder for @mentions in raw message text. When a message containing mentions is quoted by another user, the quote text includes these raw placeholders, which render as visible box/obj symbols in the TUI

## Test plan

- [ ] Receive a quote reply to a message that contains an @mention — the quote line should show clean text without any placeholder characters
- [ ] Existing quotes with U+FFFC in the database should render cleanly after restart (DB load path also strips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)