### PR TITLE
Show loading state in welcome screen until contacts arrive

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -133,6 +133,8 @@ pub struct App {
     pub last_read_index: HashMap<String, usize>,
     /// Whether we are connected to signal-cli
     pub connected: bool,
+    /// True until the first ContactList event arrives (initial sync in progress)
+    pub loading: bool,
     /// Current input mode (Normal or Insert)
     pub mode: InputMode,
     /// SQLite database for persistent storage
@@ -993,6 +995,7 @@ impl App {
             typing_indicators: HashMap::new(),
             last_read_index: HashMap::new(),
             connected: false,
+            loading: true,
             mode: InputMode::Insert,
             db,
             connection_error: None,
@@ -1983,6 +1986,7 @@ impl App {
     }
 
     fn handle_contact_list(&mut self, contacts: Vec<Contact>) {
+        self.loading = false;
         for contact in contacts {
             // Store name in lookup for future message resolution
             if let Some(ref name) = contact.name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -219,9 +219,6 @@ async fn run_main_flow(
         }
     }
 
-    // Show loading screen while signal-cli starts up
-    draw_loading_screen(terminal, "Starting signal-cli...")?;
-
     // Spawn signal-cli backend
     let signal_result = SignalClient::spawn(config).await;
     let mut signal_client = match signal_result {
@@ -313,50 +310,6 @@ async fn show_error_screen(
             }
         }
     }
-}
-
-/// Draw a simple loading screen with the app name and a status message.
-fn draw_loading_screen(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    status: &str,
-) -> Result<()> {
-    let status = status.to_string();
-    terminal.draw(|frame| {
-        let area = frame.area();
-
-        let [_, center, _] = Layout::vertical([
-            Constraint::Min(1),
-            Constraint::Length(5),
-            Constraint::Min(1),
-        ])
-        .flex(Flex::Center)
-        .areas(area);
-
-        let [_, inner, _] = Layout::horizontal([
-            Constraint::Min(1),
-            Constraint::Length(30),
-            Constraint::Min(1),
-        ])
-        .flex(Flex::Center)
-        .areas(center);
-
-        let lines = vec![
-            Line::from(Span::styled(
-                "signal-tui",
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
-            )),
-            Line::from(""),
-            Line::from(Span::styled(
-                status.clone(),
-                Style::default().fg(Color::DarkGray),
-            )),
-        ];
-
-        let paragraph = Paragraph::new(lines)
-            .alignment(ratatui::layout::Alignment::Center);
-        frame.render_widget(paragraph, inner);
-    })?;
-    Ok(())
 }
 
 /// Convert a ratatui Color to a crossterm Color for direct terminal output.
@@ -578,7 +531,6 @@ async fn run_app(
     app.set_connected();
 
     // Ask primary device to sync contacts/groups, then fetch them (best-effort)
-    draw_loading_screen(terminal, "Syncing contacts...")?;
     let _ = signal_client.send_sync_request().await;
     let _ = signal_client.list_contacts().await;
     let _ = signal_client.list_groups().await;
@@ -710,6 +662,7 @@ async fn run_demo_app(
     let mut app = App::new("+15551234567".to_string(), db);
     app.is_demo = true;
     app.connected = true;
+    app.loading = false;
     app.status_message = "connected | demo mode".to_string();
 
     populate_demo_data(&mut app);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1007,6 +1007,16 @@ fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
             "  Run with --setup to reconfigure.",
             Style::default().fg(Color::Gray),
         )));
+    } else if app.loading {
+        lines.push(Line::from(Span::styled(
+            "  signal-tui",
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Loading...",
+            Style::default().fg(Color::DarkGray),
+        )));
     } else if app.conversation_order.is_empty() {
         lines.push(Line::from(Span::styled(
             "  Welcome to signal-tui",


### PR DESCRIPTION
## Summary

- Replace the invisible `draw_loading_screen` (rendered once, immediately overwritten) with a `loading` flag on App that the welcome screen checks each frame
- Shows "signal-tui / Loading..." in the chat area while waiting for signal-cli to sync contacts
- `loading` starts true and flips to false when the first `ContactList` event arrives
- Demo mode sets `loading = false` immediately since there's no signal-cli

Supersedes the approach from #81 which drew a separate frame that was overwritten too fast to see.

## Test plan

- [ ] Launch signal-tui — should see "Loading..." in the welcome area until contacts sync completes
- [ ] Launch with --demo — should skip loading and show the welcome screen directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)