### PR TITLE
Fix contacts showing as phone numbers in sidebar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1121,6 +1121,22 @@ impl App {
 
         self.conversation_order = order;
         self.muted_conversations = self.db.load_muted()?;
+
+        // Fix 1:1 conversations still named as phone numbers: scan message senders
+        // for a real display name (from source_name in previous sessions).
+        for conv in self.conversations.values_mut() {
+            if !conv.is_group && conv.name == conv.id && conv.name.starts_with('+') {
+                // Find the most recent non-"you" sender with a real name
+                if let Some(name) = conv.messages.iter().rev()
+                    .find(|m| m.sender != "you" && m.sender != conv.id && !m.sender.starts_with('+'))
+                    .map(|m| m.sender.clone())
+                {
+                    db_warn(self.db.upsert_conversation(&conv.id, &name, false), "upsert_conversation");
+                    conv.name = name;
+                }
+            }
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- signal-cli's `listContacts` can return `name: None` for contacts whose profile name isn't cached, even though message envelopes include the correct `sourceName`. This left 1:1 conversations permanently named as phone numbers in the sidebar.
- On startup, `load_from_db` now scans messages in 1:1 conversations still named as phone numbers and recovers the display name from message sender fields (populated by `sourceName` in previous sessions).

## Test plan
- [x] `cargo clippy --tests -- -D warnings` — zero warnings
- [x] `cargo test` — all 141 tests pass
- [x] Manual: contact with `name: None` in signal-cli now shows correct name in sidebar on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)