### PR TITLE
Update install scripts for Java 25 requirement

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -61,10 +61,22 @@ if ($SignalCli) {
 } else {
     Info "signal-cli not found"
 
-    # Check for Java
+    # Check for Java 25+ (signal-cli 0.14+ requires class file version 69)
     $Java = Get-Command java -ErrorAction SilentlyContinue
+    $JavaOk = $false
     if ($Java) {
-        Info "Java found, installing signal-cli..."
+        $JavaVer = & java -version 2>&1 | Select-Object -First 1
+        if ($JavaVer -match '"(\d+)') {
+            $JavaMajor = [int]$Matches[1]
+            if ($JavaMajor -ge 25) {
+                $JavaOk = $true
+            } else {
+                Info "Java $JavaMajor found, but signal-cli requires Java 25+"
+            }
+        }
+    }
+    if ($JavaOk) {
+        Info "Java 25+ found, installing signal-cli..."
 
         try {
             $ScliRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/$SignalCliRepo/releases/latest"
@@ -98,9 +110,11 @@ if ($SignalCli) {
         Info "Installed signal-cli to $ScliDir"
     } else {
         Write-Host ""
-        Info "signal-cli requires Java 21+. Install Java from:"
+        Info "signal-cli requires Java 25+. Install Java from:"
         Write-Host ""
-        Write-Host "  https://adoptium.net/"
+        Write-Host "  winget install EclipseAdoptium.Temurin.25.JDK"
+        Write-Host ""
+        Write-Host "  Or download from: https://adoptium.net/"
         Write-Host ""
         Info "Then re-run this script to install signal-cli."
         Write-Host ""

--- a/install.sh
+++ b/install.sh
@@ -105,7 +105,7 @@ else
     echo ""
     echo "  Or download manually from:"
     echo "  https://github.com/AsamK/signal-cli/releases"
-    echo "  (Requires Java 21+)"
+    echo "  (Requires Java 25+)"
     echo ""
   fi
 fi


### PR DESCRIPTION
## Summary
- signal-cli 0.14+ requires Java 25 (class file version 69), not Java 21
- Windows `install.ps1`: now checks actual Java major version before installing signal-cli, warns if < 25
- Both scripts: updated messages from "Java 21+" to "Java 25+"
- Added `winget install` command as the recommended install method for Windows

## Test plan
- [ ] Run `install.ps1` with Java 21 installed — should warn and skip signal-cli install
- [ ] Run `install.ps1` with Java 25 installed — should install signal-cli successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)