### PR TITLE
Add cross-device read sync via syncMessage.readMessages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1862,6 +1862,9 @@ impl App {
             SignalEvent::SystemMessage { conv_id, body, timestamp, timestamp_ms } => {
                 self.handle_system_message(&conv_id, &body, timestamp, timestamp_ms);
             }
+            SignalEvent::ReadSyncReceived { read_messages } => {
+                self.handle_read_sync(read_messages);
+            }
             SignalEvent::ContactList(contacts) => self.handle_contact_list(contacts),
             SignalEvent::GroupList(groups) => self.handle_group_list(groups),
             SignalEvent::Error(ref err) => {
@@ -2256,6 +2259,73 @@ impl App {
             self.db.mark_message_deleted(conv_id, target_timestamp),
             "mark_message_deleted",
         );
+    }
+
+    fn handle_read_sync(&mut self, read_messages: Vec<(String, i64)>) {
+        // Group entries by conversation: for 1:1, the sender phone IS the conv_id.
+        // For groups, we need to scan existing conversations to find which group
+        // contains a message with that timestamp from that sender.
+        let mut max_ts_per_conv: HashMap<String, i64> = HashMap::new();
+
+        for (sender, timestamp) in &read_messages {
+            // First try direct match: sender is a 1:1 conversation
+            if self.conversations.contains_key(sender.as_str()) {
+                let entry = max_ts_per_conv.entry(sender.clone()).or_insert(0);
+                *entry = (*entry).max(*timestamp);
+                continue;
+            }
+            // Otherwise, scan group conversations for a message matching this timestamp
+            let mut found = false;
+            for (conv_id, conv) in &self.conversations {
+                if !conv.is_group {
+                    continue;
+                }
+                if conv.messages.iter().any(|m| m.timestamp_ms == *timestamp) {
+                    let entry = max_ts_per_conv.entry(conv_id.clone()).or_insert(0);
+                    *entry = (*entry).max(*timestamp);
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                crate::debug_log::logf(format_args!(
+                    "read_sync: no conversation found for sender={sender} ts={timestamp}"
+                ));
+            }
+        }
+
+        // For each conversation, advance the read marker
+        for (conv_id, max_ts) in &max_ts_per_conv {
+            let new_read_idx = if let Some(conv) = self.conversations.get(conv_id) {
+                // partition_point gives the index of the first message with ts > max_ts
+                conv.messages.partition_point(|m| m.timestamp_ms <= *max_ts)
+            } else {
+                continue;
+            };
+
+            // Only advance, never retreat
+            let current = self.last_read_index.get(conv_id).copied().unwrap_or(0);
+            if new_read_idx > current {
+                self.last_read_index.insert(conv_id.clone(), new_read_idx);
+
+                // Recompute unread from remaining messages after the read marker
+                if let Some(conv) = self.conversations.get_mut(conv_id) {
+                    let unread = conv.messages[new_read_idx..]
+                        .iter()
+                        .filter(|m| !m.is_system && m.status.is_none())
+                        .count();
+                    conv.unread = unread;
+                }
+
+                // Persist to DB
+                if let Ok(Some(rowid)) = self.db.max_rowid_up_to_timestamp(conv_id, *max_ts) {
+                    db_warn(
+                        self.db.save_read_marker(conv_id, rowid),
+                        "save_read_marker (read_sync)",
+                    );
+                }
+            }
+        }
     }
 
     fn handle_contact_list(&mut self, contacts: Vec<Contact>) {
@@ -5049,5 +5119,77 @@ mod tests {
         let read_idx = app.last_read_index["+15551234567"];
         assert_eq!(total, 2);
         assert_eq!(read_idx, total);
+    }
+
+    #[test]
+    fn read_sync_advances_read_marker_and_clears_unread() {
+        let mut app = test_app();
+
+        // Create a conversation with 3 messages (all incoming, unread)
+        let msg = |body: &str, ts_ms: i64| SignalMessage {
+            source: "+15551234567".to_string(),
+            source_name: Some("Alice".to_string()),
+            timestamp: DateTime::from_timestamp_millis(ts_ms).unwrap(),
+            body: Some(body.to_string()),
+            attachments: vec![],
+            group_id: None,
+            group_name: None,
+            is_outgoing: false,
+            destination: None,
+            mentions: vec![],
+            quote: None,
+        };
+        app.handle_signal_event(SignalEvent::MessageReceived(msg("one", 1000)));
+        app.handle_signal_event(SignalEvent::MessageReceived(msg("two", 2000)));
+        app.handle_signal_event(SignalEvent::MessageReceived(msg("three", 3000)));
+
+        assert_eq!(app.conversations["+15551234567"].unread, 3);
+        assert_eq!(app.last_read_index.get("+15551234567").copied().unwrap_or(0), 0);
+
+        // Simulate reading through timestamp 2000 on another device
+        app.handle_signal_event(SignalEvent::ReadSyncReceived {
+            read_messages: vec![("+15551234567".to_string(), 2000)],
+        });
+
+        // Read marker should advance to index 2 (after msg "one" and "two")
+        assert_eq!(app.last_read_index["+15551234567"], 2);
+        // Only "three" should remain unread
+        assert_eq!(app.conversations["+15551234567"].unread, 1);
+    }
+
+    #[test]
+    fn read_sync_does_not_retreat_read_marker() {
+        let mut app = test_app();
+
+        let msg = |body: &str, ts_ms: i64| SignalMessage {
+            source: "+15551234567".to_string(),
+            source_name: Some("Alice".to_string()),
+            timestamp: DateTime::from_timestamp_millis(ts_ms).unwrap(),
+            body: Some(body.to_string()),
+            attachments: vec![],
+            group_id: None,
+            group_name: None,
+            is_outgoing: false,
+            destination: None,
+            mentions: vec![],
+            quote: None,
+        };
+        app.handle_signal_event(SignalEvent::MessageReceived(msg("one", 1000)));
+        app.handle_signal_event(SignalEvent::MessageReceived(msg("two", 2000)));
+        app.handle_signal_event(SignalEvent::MessageReceived(msg("three", 3000)));
+
+        // First sync reads up to ts 3000 (all messages)
+        app.handle_signal_event(SignalEvent::ReadSyncReceived {
+            read_messages: vec![("+15551234567".to_string(), 3000)],
+        });
+        assert_eq!(app.last_read_index["+15551234567"], 3);
+        assert_eq!(app.conversations["+15551234567"].unread, 0);
+
+        // A stale sync for ts 1000 should NOT retreat the read marker
+        app.handle_signal_event(SignalEvent::ReadSyncReceived {
+            read_messages: vec![("+15551234567".to_string(), 1000)],
+        });
+        assert_eq!(app.last_read_index["+15551234567"], 3);
+        assert_eq!(app.conversations["+15551234567"].unread, 0);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -553,6 +553,17 @@ impl Database {
         Ok(rows)
     }
 
+    /// Find the max rowid for messages up to (and including) a given timestamp.
+    /// Uses the idx_messages_conv_ts_ms index for efficient lookup.
+    pub fn max_rowid_up_to_timestamp(&self, conv_id: &str, timestamp_ms: i64) -> Result<Option<i64>> {
+        let result = self.conn.query_row(
+            "SELECT MAX(rowid) FROM messages WHERE conversation_id = ?1 AND timestamp_ms <= ?2",
+            params![conv_id, timestamp_ms],
+            |row| row.get::<_, Option<i64>>(0),
+        )?;
+        Ok(result)
+    }
+
     // --- Muted conversations ---
 
     pub fn set_muted(&self, conv_id: &str, muted: bool) -> Result<()> {
@@ -692,6 +703,31 @@ mod tests {
         let r2 = db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "msg2", false, None, 0).unwrap();
 
         assert_eq!(db.last_message_rowid("+1").unwrap(), Some(r2));
+    }
+
+    #[test]
+    fn max_rowid_up_to_timestamp() {
+        let db = test_db();
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+
+        // No messages → None
+        assert_eq!(db.max_rowid_up_to_timestamp("+1", 5000).unwrap(), None);
+
+        let r1 = db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "msg1", false, None, 1000).unwrap();
+        let r2 = db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "msg2", false, None, 2000).unwrap();
+        let _r3 = db.insert_message("+1", "Alice", "2025-01-01T00:02:00Z", "msg3", false, None, 3000).unwrap();
+
+        // Timestamp before all messages → None
+        assert_eq!(db.max_rowid_up_to_timestamp("+1", 500).unwrap(), None);
+
+        // Timestamp matching first message
+        assert_eq!(db.max_rowid_up_to_timestamp("+1", 1000).unwrap(), Some(r1));
+
+        // Timestamp matching second message
+        assert_eq!(db.max_rowid_up_to_timestamp("+1", 2000).unwrap(), Some(r2));
+
+        // Timestamp between second and third
+        assert_eq!(db.max_rowid_up_to_timestamp("+1", 2500).unwrap(), Some(r2));
     }
 
     #[test]

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -707,10 +707,32 @@ fn parse_receive_event(
             }
             return parse_sent_sync(envelope, sent, download_dir);
         }
+        if let Some(event) = parse_read_sync(sync) {
+            return Some(event);
+        }
         return None;
     }
 
     parse_data_message(envelope, download_dir)
+}
+
+fn parse_read_sync(sync: &serde_json::Value) -> Option<SignalEvent> {
+    let read_messages = sync.get("readMessages")?.as_array()?;
+    if read_messages.is_empty() {
+        return None;
+    }
+    let entries: Vec<(String, i64)> = read_messages
+        .iter()
+        .filter_map(|entry| {
+            let sender = entry.get("sender").and_then(|v| v.as_str())?.to_string();
+            let timestamp = entry.get("timestamp").and_then(|v| v.as_i64())?;
+            Some((sender, timestamp))
+        })
+        .collect();
+    if entries.is_empty() {
+        return None;
+    }
+    Some(SignalEvent::ReadSyncReceived { read_messages: entries })
 }
 
 fn parse_typing_indicator(envelope: &serde_json::Value) -> Option<SignalEvent> {
@@ -2106,5 +2128,59 @@ mod tests {
             }
             _ => panic!("Expected SystemMessage, got {:?}", event),
         }
+    }
+
+    #[test]
+    fn parse_read_sync_basic() {
+        let resp = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+            method: Some("receive".to_string()),
+            params: Some(json!({
+                "envelope": {
+                    "sourceNumber": "+10000000000",
+                    "timestamp": 1700000000000_i64,
+                    "syncMessage": {
+                        "readMessages": [
+                            {"sender": "+15551234567", "timestamp": 1700000000001_i64},
+                            {"sender": "+15559876543", "timestamp": 1700000000002_i64}
+                        ]
+                    }
+                }
+            })),
+        };
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::ReadSyncReceived { read_messages } => {
+                assert_eq!(read_messages.len(), 2);
+                assert_eq!(read_messages[0], ("+15551234567".to_string(), 1700000000001));
+                assert_eq!(read_messages[1], ("+15559876543".to_string(), 1700000000002));
+            }
+            _ => panic!("Expected ReadSyncReceived, got {:?}", event),
+        }
+    }
+
+    #[test]
+    fn parse_read_sync_empty_array_returns_none() {
+        let resp = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+            method: Some("receive".to_string()),
+            params: Some(json!({
+                "envelope": {
+                    "sourceNumber": "+10000000000",
+                    "timestamp": 1700000000000_i64,
+                    "syncMessage": {
+                        "readMessages": []
+                    }
+                }
+            })),
+        };
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp"));
+        assert!(event.is_none());
     }
 }

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -102,6 +102,9 @@ pub enum SignalEvent {
         timestamp: DateTime<Utc>,
         timestamp_ms: i64,
     },
+    ReadSyncReceived {
+        read_messages: Vec<(String, i64)>,
+    },
     ContactList(Vec<Contact>),
     GroupList(Vec<Group>),
     Error(String),


### PR DESCRIPTION
## Summary
- Parse `syncMessage.readMessages` from signal-cli to detect when messages are read on another linked device
- Advance read markers and clear unread counts accordingly, with safeguard against retreating markers
- Add `max_rowid_up_to_timestamp` DB helper for persisting read state efficiently

closes #71

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (155 tests, 5 new)
- [ ] Manual: read a message on phone, verify TUI unread count drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)