### PR TITLE
Render text styling (bold, italic, strikethrough, monospace, spoiler)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use crate::db::Database;
 use crate::image_render;
 use crate::image_render::ImageProtocol;
 use crate::input::{self, InputAction, COMMANDS};
-use crate::signal::types::{Contact, Group, Mention, MessageStatus, Reaction, SignalEvent, SignalMessage};
+use crate::signal::types::{Contact, Group, Mention, MessageStatus, Reaction, SignalEvent, SignalMessage, StyleType, TextStyle};
 
 /// Log a database error via debug_log (no-op when --debug is off).
 fn db_warn<T>(result: Result<T, impl std::fmt::Display>, context: &str) {
@@ -76,6 +76,8 @@ pub struct DisplayMessage {
     pub reactions: Vec<Reaction>,
     /// Byte ranges of @mentions in body (for styling)
     pub mention_ranges: Vec<(usize, usize)>,
+    /// Byte ranges + style type for text styling (bold, italic, etc.)
+    pub style_ranges: Vec<(usize, usize, StyleType)>,
     /// Quoted reply context
     pub quote: Option<Quote>,
     /// Whether this message has been edited
@@ -1934,6 +1936,11 @@ impl App {
             self.resolve_mentions(body, &msg.mentions)
         });
 
+        // Resolve text styles (UTF-16 → byte offsets, accounting for mention replacements)
+        let resolved_styles = resolved_body.as_ref().map(|(resolved, _)| {
+            self.resolve_text_styles(resolved, &msg.text_styles, &msg.mentions)
+        }).unwrap_or_default();
+
         // Resolve quote from wire format
         let msg_quote = msg.quote.as_ref().map(|(ts, author_phone, body)| {
             let author_display = self.contact_names.get(author_phone)
@@ -1951,6 +1958,7 @@ impl App {
                             image_lines: Option<Vec<Line<'static>>>,
                             image_path: Option<String>,
                             mention_ranges: Vec<(usize, usize)>,
+                            style_ranges: Vec<(usize, usize, StyleType)>,
                             quote: Option<Quote>| {
             if let Some(conv) = self.conversations.get_mut(&conv_id) {
                 let pos = conv.messages.partition_point(|m| m.timestamp_ms <= msg_ts_ms);
@@ -1965,6 +1973,7 @@ impl App {
                     timestamp_ms: msg_ts_ms,
                     reactions: Vec::new(),
                     mention_ranges,
+                    style_ranges,
                     quote,
                     is_edited: false,
                     is_deleted: false,
@@ -1989,9 +1998,9 @@ impl App {
             );
         };
 
-        // Add text body (with resolved @mentions)
+        // Add text body (with resolved @mentions and text styles)
         if let Some((resolved, ranges)) = resolved_body {
-            push_msg(resolved, None, None, ranges, display_quote);
+            push_msg(resolved, None, None, ranges, resolved_styles, display_quote);
         }
 
         // Add attachment notices
@@ -2021,10 +2030,11 @@ impl App {
                     rendered,
                     att.local_path.clone(),
                     Vec::new(),
+                    Vec::new(),
                     None,
                 );
             } else {
-                push_msg(format!("[attachment: {label}]{path_info}"), None, None, Vec::new(), None);
+                push_msg(format!("[attachment: {label}]{path_info}"), None, None, Vec::new(), Vec::new(), None);
             }
         }
 
@@ -2081,6 +2091,7 @@ impl App {
                 timestamp_ms,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -2528,6 +2539,84 @@ impl App {
         (resolved, ranges)
     }
 
+    /// Convert text style ranges from UTF-16 offsets (on the original body) to byte offsets
+    /// on the resolved body (after mention replacement). Mentions may change the body length,
+    /// so we need to account for the offset shift caused by mention replacements.
+    fn resolve_text_styles(
+        &self,
+        resolved_body: &str,
+        text_styles: &[TextStyle],
+        mentions: &[Mention],
+    ) -> Vec<(usize, usize, StyleType)> {
+        if text_styles.is_empty() {
+            return Vec::new();
+        }
+
+        // Calculate how mention replacements shift UTF-16 offsets.
+        // Build a sorted list of (original_utf16_start, original_utf16_len, replacement_utf16_len)
+        let mut mention_shifts: Vec<(usize, i64)> = Vec::new(); // (original_start, cumulative_shift_after)
+        if !mentions.is_empty() {
+            let mut sorted_mentions: Vec<&Mention> = mentions.iter().collect();
+            sorted_mentions.sort_by_key(|m| m.start);
+            let mut cumulative: i64 = 0;
+            for m in &sorted_mentions {
+                let name = self
+                    .uuid_to_name
+                    .get(&m.uuid)
+                    .cloned()
+                    .unwrap_or_else(|| {
+                        let short = if m.uuid.len() > 8 { &m.uuid[..8] } else { &m.uuid };
+                        short.to_string()
+                    });
+                let replacement_utf16_len = format!("@{name}").encode_utf16().count() as i64;
+                let original_len = m.length as i64;
+                cumulative += replacement_utf16_len - original_len;
+                mention_shifts.push((m.start + m.length, cumulative));
+            }
+        }
+
+        // For a given original UTF-16 offset, compute the shifted offset after mention replacements
+        let shift_offset = |orig: usize| -> usize {
+            let mut shift: i64 = 0;
+            for &(boundary, cum_shift) in &mention_shifts {
+                if orig >= boundary {
+                    shift = cum_shift;
+                } else {
+                    break;
+                }
+            }
+            (orig as i64 + shift) as usize
+        };
+
+        // Build UTF-16 to byte offset mapping for the resolved body
+        let mut utf16_to_byte: Vec<usize> = Vec::new();
+        let mut byte_pos = 0;
+        for ch in resolved_body.chars() {
+            for _ in 0..ch.len_utf16() {
+                utf16_to_byte.push(byte_pos);
+            }
+            byte_pos += ch.len_utf8();
+        }
+        utf16_to_byte.push(byte_pos); // sentinel
+
+        let body_byte_len = resolved_body.len();
+
+        text_styles
+            .iter()
+            .filter_map(|ts| {
+                let shifted_start = shift_offset(ts.start);
+                let shifted_end = shift_offset(ts.start + ts.length);
+                let byte_start = utf16_to_byte.get(shifted_start).copied().unwrap_or(body_byte_len);
+                let byte_end = utf16_to_byte.get(shifted_end).copied().unwrap_or(body_byte_len);
+                if byte_start < byte_end && byte_end <= body_byte_len {
+                    Some((byte_start, byte_end, ts.style))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Prepare outgoing mentions: replace @Name with U+FFFC and compute UTF-16 offsets.
     /// Returns (wire_body, mentions_for_rpc).
     fn prepare_outgoing_mentions(&self, text: &str) -> (String, Vec<(usize, String)>) {
@@ -2844,6 +2933,7 @@ impl App {
                             timestamp_ms: local_ts_ms,
                             reactions: Vec::new(),
                             mention_ranges,
+                            style_ranges: Vec::new(),
                             quote,
                             is_edited: false,
                             is_deleted: false,
@@ -3547,7 +3637,7 @@ fn file_uri_to_path(uri: &str) -> String {
 mod tests {
     use super::*;
     use crate::db::Database;
-    use crate::signal::types::{Contact, Group, SignalEvent, SignalMessage};
+    use crate::signal::types::{Contact, Group, Mention, SignalEvent, SignalMessage, StyleType, TextStyle};
 
     fn test_app() -> App {
         let db = Database::open_in_memory().unwrap();
@@ -3610,6 +3700,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -3639,6 +3730,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -3676,6 +3768,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -3707,6 +3800,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -3739,6 +3833,7 @@ mod tests {
                 is_outgoing: false,
                 destination: None,
                 mentions: vec![],
+                text_styles: vec![],
                 quote: None,
             };
             app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -4220,6 +4315,7 @@ mod tests {
                 timestamp_ms: ts_ms,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -4269,6 +4365,7 @@ mod tests {
                 timestamp_ms: ts_ms,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -4309,6 +4406,7 @@ mod tests {
                 timestamp_ms: local_ts,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -4349,6 +4447,7 @@ mod tests {
                 timestamp_ms: local_ts,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -4383,6 +4482,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -4412,6 +4512,7 @@ mod tests {
                 timestamp_ms: local_ts,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -4465,6 +4566,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -4502,6 +4604,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -4547,6 +4650,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -4596,6 +4700,7 @@ mod tests {
                 timestamp_ms: ts_ms,
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -4661,6 +4766,7 @@ mod tests {
             timestamp_ms: 900,
             reactions: Vec::new(),
             mention_ranges: Vec::new(),
+            style_ranges: Vec::new(),
             quote: None,
             is_edited: false,
             is_deleted: false,
@@ -4681,6 +4787,7 @@ mod tests {
                 Reaction { emoji: "\u{1f602}".to_string(), sender: "+3".to_string() },        // non-contact
             ],
             mention_ranges: Vec::new(),
+            style_ranges: Vec::new(),
             // Quote from own account (should become "you")
             quote: Some(Quote { author: "+10000000000".to_string(), body: "quoted".to_string(), timestamp_ms: 500, author_id: "+10000000000".to_string() }),
             is_edited: false,
@@ -4699,6 +4806,7 @@ mod tests {
             timestamp_ms: 1100,
             reactions: Vec::new(),
             mention_ranges: Vec::new(),
+            style_ranges: Vec::new(),
             quote: Some(Quote { author: "+3".to_string(), body: "hey".to_string(), timestamp_ms: 900, author_id: "+3".to_string() }),
             is_edited: false,
             is_deleted: false,
@@ -4920,6 +5028,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![Mention { start: 0, length: 1, uuid: "uuid-bob".to_string() }],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -5086,6 +5195,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg1));
@@ -5110,6 +5220,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg2));
@@ -5137,6 +5248,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg("one", 1000)));
@@ -5172,6 +5284,7 @@ mod tests {
             is_outgoing: false,
             destination: None,
             mentions: vec![],
+            text_styles: vec![],
             quote: None,
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg("one", 1000)));
@@ -5191,5 +5304,77 @@ mod tests {
         });
         assert_eq!(app.last_read_index["+15551234567"], 3);
         assert_eq!(app.conversations["+15551234567"].unread, 0);
+    }
+
+    // --- Text style resolution tests ---
+
+    #[test]
+    fn text_style_ranges_resolved_to_byte_offsets() {
+        let app = test_app();
+
+        // ASCII body: "hello bold world"
+        // "bold" is at UTF-16 offset 6, length 4
+        let body = "hello bold world";
+        let styles = vec![
+            TextStyle { start: 6, length: 4, style: StyleType::Bold },
+            TextStyle { start: 11, length: 5, style: StyleType::Italic },
+        ];
+        let resolved = app.resolve_text_styles(body, &styles, &[]);
+
+        // In pure ASCII, UTF-16 offsets == byte offsets
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(resolved[0], (6, 10, StyleType::Bold));      // "bold"
+        assert_eq!(resolved[1], (11, 16, StyleType::Italic));    // "world"
+    }
+
+    #[test]
+    fn text_style_ranges_with_multibyte_chars() {
+        let app = test_app();
+
+        // Body with multi-byte chars: "Hi \u{1F600} bold" (emoji is 4 bytes UTF-8, 2 units UTF-16)
+        // UTF-16: H(1) i(1) ' '(1) \u{1F600}(2) ' '(1) b(1) o(1) l(1) d(1) = offsets
+        // "bold" starts at UTF-16 offset 6, length 4
+        let body = "Hi \u{1F600} bold";
+        let styles = vec![
+            TextStyle { start: 6, length: 4, style: StyleType::Bold },
+        ];
+        let resolved = app.resolve_text_styles(body, &styles, &[]);
+
+        // "Hi " = 3 bytes, emoji = 4 bytes, " " = 1 byte => "bold" starts at byte 8
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].0, 8);  // byte start of "bold"
+        assert_eq!(resolved[0].1, 12); // byte end of "bold"
+        assert_eq!(resolved[0].2, StyleType::Bold);
+    }
+
+    #[test]
+    fn text_style_ranges_with_mentions() {
+        let mut app = test_app();
+        app.uuid_to_name.insert("uuid-bob".to_string(), "Bob".to_string());
+
+        // Original body: "\u{FFFC} is bold"
+        // After mention resolution: "@Bob is bold"
+        // Mention at UTF-16 offset 0, length 1 => replaced with "@Bob" (4 chars)
+        // "bold" is at original UTF-16 offset 5, length 4
+        // After resolution shift: offset 5 + 3 (replacement grew by 3) = 8
+        let resolved_body = "@Bob is bold";
+        let mentions = vec![Mention { start: 0, length: 1, uuid: "uuid-bob".to_string() }];
+        let styles = vec![
+            TextStyle { start: 5, length: 4, style: StyleType::Strikethrough },
+        ];
+        let resolved = app.resolve_text_styles(resolved_body, &styles, &mentions);
+
+        assert_eq!(resolved.len(), 1);
+        // "bold" in "@Bob is bold" starts at byte 8
+        assert_eq!(resolved[0].0, 8);
+        assert_eq!(resolved[0].1, 12);
+        assert_eq!(resolved[0].2, StyleType::Strikethrough);
+    }
+
+    #[test]
+    fn text_style_ranges_empty_styles() {
+        let app = test_app();
+        let resolved = app.resolve_text_styles("hello world", &[], &[]);
+        assert!(resolved.is_empty());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -231,6 +231,7 @@ impl Database {
                         timestamp_ms,
                         reactions: Vec::new(),
                         mention_ranges: Vec::new(),
+                        style_ranges: Vec::new(),
                         quote,
                         is_edited,
                         is_deleted,

--- a/src/main.rs
+++ b/src/main.rs
@@ -749,6 +749,7 @@ fn populate_demo_data(app: &mut App) {
             timestamp_ms: time.timestamp_millis(),
             reactions: Vec::new(),
             mention_ranges: Vec::new(),
+            style_ranges: Vec::new(),
             quote: None,
             is_edited: false,
             is_deleted: false,

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -959,6 +959,8 @@ fn parse_data_message(
         })
         .unwrap_or_default();
 
+    let text_styles = parse_text_styles(data);
+
     // Parse quoted reply (strip U+FFFC mention placeholders from quote text)
     let quote = data.get("quote").and_then(|q| {
         let q_ts = q.get("id").and_then(|v| v.as_i64())?;
@@ -979,6 +981,7 @@ fn parse_data_message(
         is_outgoing: false,
         destination: None,
         mentions,
+        text_styles,
         quote,
     }))
 }
@@ -1143,6 +1146,8 @@ fn parse_sent_sync(
         })
         .unwrap_or_default();
 
+    let text_styles = parse_text_styles(sent);
+
     // Parse quoted reply (strip U+FFFC mention placeholders from quote text)
     let quote = sent.get("quote").and_then(|q| {
         let q_ts = q.get("id").and_then(|v| v.as_i64())?;
@@ -1163,6 +1168,7 @@ fn parse_sent_sync(
         is_outgoing: true,
         destination,
         mentions,
+        text_styles,
         quote,
     }))
 }
@@ -1434,6 +1440,36 @@ fn format_expiration(seconds: i64) -> String {
     };
     let plural = if n == 1 { "" } else { "s" };
     format!("Disappearing messages set to {n} {unit}{plural}")
+}
+
+/// Parse text styles from a data message's textStyles array (or bodyRanges style entries).
+fn parse_text_styles(data: &serde_json::Value) -> Vec<TextStyle> {
+    // Try textStyles array first, then fall back to bodyRanges entries with "style" field
+    let arr = data
+        .get("textStyles")
+        .and_then(|v| v.as_array())
+        .or_else(|| data.get("bodyRanges").and_then(|v| v.as_array()));
+
+    arr.map(|items| {
+        items
+            .iter()
+            .filter_map(|r| {
+                let start = r.get("start").and_then(|v| v.as_u64())? as usize;
+                let length = r.get("length").and_then(|v| v.as_u64())? as usize;
+                let style_str = r.get("style").and_then(|v| v.as_str())?;
+                let style = match style_str {
+                    "BOLD" => StyleType::Bold,
+                    "ITALIC" => StyleType::Italic,
+                    "STRIKETHROUGH" => StyleType::Strikethrough,
+                    "MONOSPACE" => StyleType::Monospace,
+                    "SPOILER" => StyleType::Spoiler,
+                    _ => return None,
+                };
+                Some(TextStyle { start, length, style })
+            })
+            .collect()
+    })
+    .unwrap_or_default()
 }
 
 #[cfg(test)]
@@ -2420,6 +2456,103 @@ mod tests {
                 assert!(msg.attachments.is_empty());
             }
             _ => panic!("Expected MessageReceived, got {:?}", event),
+        }
+    }
+
+    // --- Text style parsing tests ---
+
+    #[test]
+    fn parse_text_styles_basic() {
+        let resp = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+            method: Some("receive".to_string()),
+            params: Some(json!({
+                "envelope": {
+                    "sourceNumber": "+15551234567",
+                    "sourceName": "Alice",
+                    "timestamp": 1700000000000_i64,
+                    "dataMessage": {
+                        "timestamp": 1700000000000_i64,
+                        "message": "hello bold world",
+                        "textStyles": [
+                            {"start": 6, "length": 4, "style": "BOLD"},
+                            {"start": 11, "length": 5, "style": "ITALIC"}
+                        ]
+                    }
+                }
+            })),
+        };
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::MessageReceived(msg) => {
+                assert_eq!(msg.text_styles.len(), 2);
+                assert_eq!(msg.text_styles[0].start, 6);
+                assert_eq!(msg.text_styles[0].length, 4);
+                assert_eq!(msg.text_styles[0].style, StyleType::Bold);
+                assert_eq!(msg.text_styles[1].start, 11);
+                assert_eq!(msg.text_styles[1].length, 5);
+                assert_eq!(msg.text_styles[1].style, StyleType::Italic);
+            }
+            _ => panic!("Expected MessageReceived, got {:?}", event),
+        }
+    }
+
+    #[test]
+    fn parse_text_styles_empty_or_missing() {
+        // No textStyles array at all
+        let resp = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+            method: Some("receive".to_string()),
+            params: Some(json!({
+                "envelope": {
+                    "sourceNumber": "+15551234567",
+                    "timestamp": 1700000000000_i64,
+                    "dataMessage": {
+                        "timestamp": 1700000000000_i64,
+                        "message": "plain text"
+                    }
+                }
+            })),
+        };
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::MessageReceived(msg) => {
+                assert!(msg.text_styles.is_empty());
+            }
+            _ => panic!("Expected MessageReceived, got {:?}", event),
+        }
+
+        // Empty textStyles array
+        let resp2 = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+            method: Some("receive".to_string()),
+            params: Some(json!({
+                "envelope": {
+                    "sourceNumber": "+15551234567",
+                    "timestamp": 1700000000000_i64,
+                    "dataMessage": {
+                        "timestamp": 1700000000000_i64,
+                        "message": "plain text",
+                        "textStyles": []
+                    }
+                }
+            })),
+        };
+        let event2 = parse_signal_event(&resp2, std::path::Path::new("/tmp")).unwrap();
+        match event2 {
+            SignalEvent::MessageReceived(msg) => {
+                assert!(msg.text_styles.is_empty());
+            }
+            _ => panic!("Expected MessageReceived, got {:?}", event2),
         }
     }
 }

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -125,6 +125,8 @@ pub struct SignalMessage {
     pub destination: Option<String>,
     /// Body range mentions from signal-cli (for resolving U+FFFC placeholders)
     pub mentions: Vec<Mention>,
+    /// Text style ranges from signal-cli (bold, italic, etc.)
+    pub text_styles: Vec<TextStyle>,
     /// Quoted reply context: (timestamp_ms, author_phone, body)
     pub quote: Option<(i64, String, String)>,
 }
@@ -174,6 +176,24 @@ pub struct Mention {
     pub start: usize,  // UTF-16 offset in body
     pub length: usize,  // Always 1 (U+FFFC)
     pub uuid: String,   // ACI UUID of mentioned user
+}
+
+/// A text style range from signal-cli's textStyles/bodyRanges array.
+#[derive(Debug, Clone)]
+pub struct TextStyle {
+    pub start: usize,  // UTF-16 offset in body
+    pub length: usize, // UTF-16 length
+    pub style: StyleType,
+}
+
+/// Type of text styling applied to a range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StyleType {
+    Bold,
+    Italic,
+    Strikethrough,
+    Monospace,
+    Spoiler,
 }
 
 /// Contact info from signal-cli

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,7 +11,7 @@ use ratatui::{
 };
 
 use crate::app::{App, AutocompleteMode, InputMode, VisibleImage, QUICK_REACTIONS, SETTINGS};
-use crate::signal::types::{MessageStatus, Reaction};
+use crate::signal::types::{MessageStatus, Reaction, StyleType};
 use crate::image_render::ImageProtocol;
 use crate::input::COMMANDS;
 
@@ -230,7 +230,11 @@ fn collect_link_regions(buf: &Buffer, area: Rect) -> Vec<LinkRegion> {
 /// Returns `(spans, Option<hidden_url>)`. For attachment bodies like
 /// `[image: label](file:///path)`, the bracket text is the visible link and
 /// the URI inside parens is returned separately (not displayed).
-fn styled_uri_spans(body: &str, mention_ranges: &[(usize, usize)]) -> (Vec<Span<'static>>, Option<String>) {
+fn styled_uri_spans(
+    body: &str,
+    mention_ranges: &[(usize, usize)],
+    style_ranges: &[(usize, usize, StyleType)],
+) -> (Vec<Span<'static>>, Option<String>) {
     let link_style = Style::default()
         .fg(Color::Blue)
         .add_modifier(Modifier::UNDERLINED);
@@ -307,18 +311,97 @@ fn styled_uri_spans(body: &str, mention_ranges: &[(usize, usize)]) -> (Vec<Span<
     // Sort regions by start position
     regions.sort_by_key(|r| r.0);
 
-    // Build spans by interleaving plain text and styled regions
-    let mut spans: Vec<Span<'static>> = Vec::new();
-    let mut pos = 0;
-    for (start, end, style) in &regions {
-        if *start > pos {
-            spans.push(Span::raw(body[pos..*start].to_string()));
+    // If no text styles, use the simple path
+    if style_ranges.is_empty() {
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        let mut pos = 0;
+        for (start, end, style) in &regions {
+            if *start > pos {
+                spans.push(Span::raw(body[pos..*start].to_string()));
+            }
+            spans.push(Span::styled(body[*start..*end].to_string(), *style));
+            pos = *end;
         }
-        spans.push(Span::styled(body[*start..*end].to_string(), *style));
-        pos = *end;
+        if pos < body.len() {
+            spans.push(Span::raw(body[pos..].to_string()));
+        }
+        return (spans, None);
     }
-    if pos < body.len() {
-        spans.push(Span::raw(body[pos..].to_string()));
+
+    // With text styles: collect all boundary points and build segments where
+    // the active set of styles is constant
+    let mut boundaries: Vec<usize> = Vec::new();
+    boundaries.push(0);
+    boundaries.push(body.len());
+    for &(start, end, _) in &regions {
+        boundaries.push(start);
+        boundaries.push(end);
+    }
+    for &(start, end, _) in style_ranges {
+        if start <= body.len() {
+            boundaries.push(start);
+        }
+        if end <= body.len() {
+            boundaries.push(end);
+        }
+    }
+    boundaries.sort();
+    boundaries.dedup();
+
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    for window in boundaries.windows(2) {
+        let seg_start = window[0];
+        let seg_end = window[1];
+        if seg_start >= seg_end || seg_start >= body.len() {
+            continue;
+        }
+        let seg_end = seg_end.min(body.len());
+
+        // Determine base style from mention/URI regions
+        let mut style = Style::default();
+        for &(rs, re, ref_style) in &regions {
+            if seg_start >= rs && seg_end <= re {
+                style = ref_style;
+                break;
+            }
+        }
+
+        // Check for spoiler first — if any spoiler range covers this segment,
+        // replace the text with block characters
+        let mut is_spoiler = false;
+        for &(ss, se, st) in style_ranges {
+            if st == StyleType::Spoiler && seg_start >= ss && seg_end <= se {
+                is_spoiler = true;
+                break;
+            }
+        }
+
+        let segment_text = &body[seg_start..seg_end];
+        if is_spoiler {
+            // Replace each character with a block character
+            let block_text: String = segment_text.chars().map(|_| '\u{2588}').collect();
+            let spoiler_style = style.fg(Color::DarkGray);
+            spans.push(Span::styled(block_text, spoiler_style));
+        } else {
+            // Apply text style modifiers
+            for &(ss, se, st) in style_ranges {
+                if seg_start >= ss && seg_end <= se {
+                    match st {
+                        StyleType::Bold => style = style.add_modifier(Modifier::BOLD),
+                        StyleType::Italic => style = style.add_modifier(Modifier::ITALIC),
+                        StyleType::Strikethrough => style = style.add_modifier(Modifier::CROSSED_OUT),
+                        StyleType::Monospace => style = style.fg(Color::DarkGray),
+                        StyleType::Spoiler => {} // handled above
+                    }
+                }
+            }
+
+            if style == Style::default() {
+                spans.push(Span::raw(segment_text.to_string()));
+            } else {
+                spans.push(Span::styled(segment_text.to_string(), style));
+            }
+        }
     }
 
     (spans, None)
@@ -693,7 +776,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 ));
             } else {
                 // Style URIs and @mentions
-                let (body_spans, hidden_url) = styled_uri_spans(&msg.body, &msg.mention_ranges);
+                let (body_spans, hidden_url) = styled_uri_spans(&msg.body, &msg.mention_ranges, &msg.style_ranges);
                 if let Some(url) = hidden_url {
                     // Collect display text for link_url_map lookup
                     let display_text: String = body_spans.iter().map(|s| s.content.as_ref()).collect();


### PR DESCRIPTION
## Summary
- Parse `textStyles` array (and `bodyRanges` style entries) from signal-cli messages
- Add `TextStyle`/`StyleType` types and `text_styles` field on `SignalMessage`
- Resolve UTF-16 style offsets to byte ranges, accounting for mention replacement shifts
- Render in ui.rs: Bold, Italic, CrossedOut modifiers; DarkGray for monospace; block chars for spoiler
- Styles compose with existing mention and URI highlighting via boundary-based segmentation

closes #66

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (161 tests, 6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)