### PR TITLE
Update docs for v0.7.0 release

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,53 @@
 # Changelog
 
+## v0.7.0
+
+### Text styling
+
+- **Rich text rendering** -- messages with Signal formatting now display with
+  proper styling: **bold**, *italic*, ~~strikethrough~~, `monospace`, and spoiler
+  text. Spoiler content is hidden behind block characters (closes #66)
+
+### Sticker messages
+
+- **Sticker display** -- incoming stickers are now shown as `[Sticker: emoji]`
+  in the chat area instead of being silently dropped (closes #67)
+
+### View-once messages
+
+- **View-once handling** -- view-once messages display as `[View-once message]`
+  with attachments suppressed, respecting the ephemeral intent (closes #68)
+
+### Cross-device read sync
+
+- **Read state sync** -- when you read messages on your phone or another linked
+  device, signal-tui marks those conversations as read and updates unread counts
+  automatically (closes #71)
+
+### System messages
+
+- **Missed calls** -- missed voice and video calls now show as system messages
+- **Safety number changes** -- a warning appears when a contact's safety number
+  changes
+- **Group updates** -- group metadata changes (member adds/removes) display as
+  system messages
+- **Disappearing message timer** -- changes to the expiration timer show a
+  human-readable message (e.g. "Disappearing messages set to 1 day")
+
+### Message action menu
+
+- **Enter key menu** -- press Enter in Normal mode on a focused message to open
+  a contextual action menu. Available actions (shown with key hints): Reply (q),
+  Edit (e), React (r), Copy (y), Delete (d). Navigate with j/k, press Enter to
+  execute, or use the shortcut key directly (closes #85)
+
+### Bug fixes
+
+- **"New messages" bar** -- the unread separator no longer persists after viewing
+  a conversation with new messages (#90)
+
+---
+
 ## v0.6.1
 
 ### Bug fixes
@@ -212,7 +260,7 @@
   restored on reload (stale "Sending" messages are promoted to "Sent")
 - **Nerd Font icons** -- optional Nerd Font glyphs available via
   `/settings` > "Nerd Font icons"
-- **Configurable** -- three new settings toggles: "Read receipts" (on/off),
+- **Configurable** -- three new settings toggles: "Show read receipts" (on/off),
   "Receipt colors" (colored/monochrome), "Nerd Font icons" (unicode/nerd)
 
 ### Debug logging

--- a/docs/src/dev-guide/modules.md
+++ b/docs/src/dev-guide/modules.md
@@ -43,8 +43,9 @@ original method (e.g., mapping a response ID back to `listContacts`).
 
 Shared types for signal-cli communication:
 
-- `SignalEvent` -- enum of all events the backend can produce
-- `SignalMessage` -- a message with source, timestamp, body, attachments, group info
+- `SignalEvent` -- enum of all events the backend can produce (messages, receipts, typing, read sync, system messages)
+- `SignalMessage` -- a message with source, timestamp, body, attachments, group info, text styles
+- `TextStyle` / `StyleType` -- text formatting ranges (bold, italic, strikethrough, monospace, spoiler)
 - `Attachment` -- file metadata (content type, filename, local path)
 - `JsonRpcRequest` / `JsonRpcResponse` -- JSON-RPC protocol structs
 - `Contact` / `Group` -- address book and group info

--- a/docs/src/dev-guide/protocol.md
+++ b/docs/src/dev-guide/protocol.md
@@ -113,6 +113,10 @@ Incoming `receive` envelopes may also contain:
 | `dataMessage.quote` | Quoted reply metadata | `quote` field on `SignalMessage` |
 | `editMessage` | Edited message | `SignalEvent::EditReceived` |
 | `syncMessage.sentMessage` | Outgoing sync (own messages from other devices) | Same as above, with `is_outgoing = true` |
+| `syncMessage.readMessages` | Read sync from other devices | `SignalEvent::ReadSyncReceived` |
+| `dataMessage.sticker` | Sticker message | Body set to `[Sticker: emoji]` |
+| `dataMessage.textStyles` / `bodyRanges` | Text formatting (bold, italic, etc.) | `text_styles` field on `SignalMessage` |
+| `callMessage` | Missed call notification | `SignalEvent::SystemMessage` |
 
 ## Parsing logic
 

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -39,6 +39,12 @@
 - [x] `/join` autocomplete (contacts and groups with Tab completion)
 - [x] Send typing indicators (auto-start/stop on keypress)
 - [x] Send read receipts (automatic on conversation view, configurable)
+- [x] System messages (missed calls, safety number changes, group updates, expiration timer)
+- [x] Message action menu (Enter in Normal mode, contextual actions on focused message)
+- [x] Text styling (bold, italic, strikethrough, monospace, spoiler rendering)
+- [x] Display stickers (shown as `[Sticker: emoji]` in chat)
+- [x] View-once messages (shown as `[View-once message]` placeholder)
+- [x] Cross-device read sync (sync read state across linked devices)
 
 ## Up next
 
@@ -63,18 +69,12 @@
 - [ ] Link previews -- display URL previews for shared links (#63)
 - [ ] Polls -- create and vote in Signal polls (#64)
 - [ ] Pinned messages -- view and manage pinned messages (#65)
-- [ ] Text styling -- render bold, italic, strikethrough, monospace, and
-  spoiler formatting (#66)
-- [ ] Cross-device read sync -- sync read state across linked devices (#71)
 
 ### Low priority
 
 - [ ] Publish to crates.io (#11)
-- [ ] Display stickers (#67)
-- [ ] View-once messages (#68)
 - [ ] Update profile from TUI (#69)
 - [ ] Identity key verification (#70)
-- [ ] Missed call notifications (#72)
 - [ ] Multi-line message input (Shift+Enter for newlines)
 - [ ] Message history pagination (scroll-up to load older messages)
 - [ ] Scroll position memory per conversation

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -59,7 +59,7 @@ toggles for runtime settings:
 - Notification toggles (direct / group)
 - Sidebar visibility
 - Inline image previews
-- Read receipts / receipt colors / nerd font icons
+- Show read receipts / receipt colors / nerd font icons
 - Verbose reactions
 - Send read receipts
 

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -125,11 +125,65 @@ Press Enter to jump to the message in context.
 After searching, use `n`/`N` in Normal mode to cycle through matches without
 re-opening the overlay.
 
+## Text styling
+
+Signal formatting is rendered in the chat area:
+
+- **Bold** -- displayed with terminal bold
+- **Italic** -- displayed with terminal italic
+- **Strikethrough** -- displayed with terminal strikethrough
+- **Monospace** -- displayed in gray
+- **Spoiler** -- hidden behind block characters (`████`)
+
+Styles compose correctly with @mentions and link highlighting.
+
+## Sticker messages
+
+Incoming stickers display as `[Sticker: emoji]` in the chat area (e.g.
+`[Sticker: 👍]`). If the sticker has no associated emoji, it shows as
+`[Sticker]`.
+
+## View-once messages
+
+View-once messages display as `[View-once message]` with any attachments
+suppressed, respecting the sender's ephemeral intent.
+
+## System messages
+
+Certain Signal events display as system messages (dimmed, centered) in the chat:
+
+- **Missed calls** -- "Missed voice call" / "Missed video call"
+- **Safety number changes** -- warning when a contact's safety number changes
+- **Group updates** -- group metadata changes (member adds/removes)
+- **Disappearing message timer** -- e.g. "Disappearing messages set to 1 day"
+
+## Message action menu
+
+Press `Enter` in Normal mode on a focused message to open a contextual action
+menu. Available actions depend on the message type:
+
+| Action | Key | Available on |
+|---|---|---|
+| Reply | `q` | Non-deleted messages |
+| Edit | `e` | Your own outgoing messages |
+| React | `r` | All messages |
+| Copy | `y` | All messages |
+| Delete | `d` | Non-deleted messages |
+
+Navigate with `j`/`k`, press Enter to execute, or press the shortcut key
+directly. Press `Esc` to close.
+
 ## Read receipts
 
 signal-tui sends read receipts to message senders when you view a conversation,
 letting them know you've read their messages. This can be toggled off via
 `/settings` > "Send read receipts".
+
+## Cross-device read sync
+
+When you read messages on your phone or another linked device, signal-tui
+receives the read sync and marks those conversations as read. Unread counts
+update automatically.
 
 ## Demo mode
 

--- a/docs/src/user-guide/keybindings.md
+++ b/docs/src/user-guide/keybindings.md
@@ -32,6 +32,7 @@ changes in the status bar.
 |---|---|
 | `y` | Copy message body to clipboard |
 | `Y` | Copy full line (`[HH:MM] <sender> body`) to clipboard |
+| `Enter` | Open action menu on focused message |
 | `r` | Open reaction picker on focused message |
 | `q` | Reply to focused message (quote reply) |
 | `e` | Edit own outgoing message |


### PR DESCRIPTION
## Summary
- Add v0.7.0 changelog entry covering all features merged since v0.6.1
- Add feature docs: text styling, stickers, view-once, system messages, message action menu, cross-device read sync
- Update dev guide: modules, protocol table, roadmap checklist
- Minor wording fix in settings docs ("Read receipts" → "Show read receipts")

## Test plan
- [ ] Verify docs build cleanly with `mdbook build docs/`
- [ ] Check GitHub Pages deployment after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)