### PR TITLE
Add group management via /group command (#26)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -40,6 +40,18 @@ pub enum AutocompleteMode {
     Join,
 }
 
+/// Which sub-overlay of the /group menu is currently active.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupMenuState {
+    Menu,           // top-level flyout
+    Members,        // read-only member list
+    AddMember,      // contact picker (type-to-filter)
+    RemoveMember,   // member picker (type-to-filter)
+    Rename,         // text input (pre-filled)
+    Create,         // text input (empty)
+    LeaveConfirm,   // y/n confirmation
+}
+
 /// An action available in the message action menu.
 pub struct MenuAction {
     pub label: &'static str,
@@ -287,6 +299,16 @@ pub struct App {
     pub show_action_menu: bool,
     /// Cursor position in action menu
     pub action_menu_index: usize,
+    /// Group management menu state (None = closed)
+    pub group_menu_state: Option<GroupMenuState>,
+    /// Cursor position in group menu / member lists
+    pub group_menu_index: usize,
+    /// Type-to-filter text for add/remove member pickers
+    pub group_menu_filter: String,
+    /// Filtered list of (phone, display_name) for add/remove member pickers
+    pub group_menu_filtered: Vec<(String, String)>,
+    /// Separate text input buffer for rename/create (avoids disturbing input_buffer)
+    pub group_menu_input: String,
 }
 
 /// A search result entry.
@@ -351,6 +373,24 @@ pub enum SendRequest {
         conv_id: String,
         is_group: bool,
         seconds: i64,
+    },
+    CreateGroup {
+        name: String,
+    },
+    AddGroupMembers {
+        group_id: String,
+        members: Vec<String>,
+    },
+    RemoveGroupMembers {
+        group_id: String,
+        members: Vec<String>,
+    },
+    RenameGroup {
+        group_id: String,
+        name: String,
+    },
+    LeaveGroup {
+        group_id: String,
     },
 }
 
@@ -531,6 +571,347 @@ impl App {
             self.contacts_index = 0;
         } else if self.contacts_index >= self.contacts_filtered.len() {
             self.contacts_index = self.contacts_filtered.len() - 1;
+        }
+    }
+
+    /// Build the list of available group menu actions (context-dependent).
+    pub fn group_menu_items(&self) -> Vec<MenuAction> {
+        let is_group = self.active_conversation.as_ref()
+            .and_then(|id| self.conversations.get(id))
+            .is_some_and(|c| c.is_group);
+        if is_group {
+            vec![
+                MenuAction { label: "Members",       key_hint: "m", nerd_icon: "\u{f0849}" },
+                MenuAction { label: "Add member",    key_hint: "a", nerd_icon: "\u{f0234}" },
+                MenuAction { label: "Remove member", key_hint: "r", nerd_icon: "\u{f0235}" },
+                MenuAction { label: "Rename",        key_hint: "n", nerd_icon: "\u{f03eb}" },
+                MenuAction { label: "Leave",         key_hint: "l", nerd_icon: "\u{f0a79}" },
+            ]
+        } else {
+            vec![
+                MenuAction { label: "Create group",  key_hint: "c", nerd_icon: "\u{f0234}" },
+            ]
+        }
+    }
+
+    /// Build filtered contacts list for the "Add member" picker (excludes existing group members).
+    pub fn refresh_group_add_filter(&mut self) {
+        let filter_lower = self.group_menu_filter.to_lowercase();
+        let existing_members: HashSet<&str> = self.active_conversation.as_ref()
+            .and_then(|id| self.groups.get(id))
+            .map(|g| g.members.iter().map(|s| s.as_str()).collect())
+            .unwrap_or_default();
+        let mut contacts: Vec<(String, String)> = self
+            .contact_names
+            .iter()
+            .filter(|(_, name)| !name.is_empty())
+            .filter(|(number, _)| !existing_members.contains(number.as_str()))
+            .filter(|(number, name)| {
+                if filter_lower.is_empty() {
+                    return true;
+                }
+                name.to_lowercase().contains(&filter_lower)
+                    || number.to_lowercase().contains(&filter_lower)
+            })
+            .map(|(number, name)| (number.clone(), name.clone()))
+            .collect();
+        contacts.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+        self.group_menu_filtered = contacts;
+        if self.group_menu_filtered.is_empty() {
+            self.group_menu_index = 0;
+        } else if self.group_menu_index >= self.group_menu_filtered.len() {
+            self.group_menu_index = self.group_menu_filtered.len() - 1;
+        }
+    }
+
+    /// Build filtered member list for the "Remove member" picker (excludes self).
+    pub fn refresh_group_remove_filter(&mut self) {
+        let filter_lower = self.group_menu_filter.to_lowercase();
+        let members: Vec<String> = self.active_conversation.as_ref()
+            .and_then(|id| self.groups.get(id))
+            .map(|g| g.members.clone())
+            .unwrap_or_default();
+        let mut result: Vec<(String, String)> = members
+            .into_iter()
+            .filter(|phone| *phone != self.account)
+            .map(|phone| {
+                let name = self.contact_names.get(&phone)
+                    .cloned()
+                    .unwrap_or_else(|| phone.clone());
+                (phone, name)
+            })
+            .filter(|(phone, name)| {
+                if filter_lower.is_empty() {
+                    return true;
+                }
+                name.to_lowercase().contains(&filter_lower)
+                    || phone.to_lowercase().contains(&filter_lower)
+            })
+            .collect();
+        result.sort_by(|a, b| a.1.to_lowercase().cmp(&b.1.to_lowercase()));
+        self.group_menu_filtered = result;
+        if self.group_menu_filtered.is_empty() {
+            self.group_menu_index = 0;
+        } else if self.group_menu_index >= self.group_menu_filtered.len() {
+            self.group_menu_index = self.group_menu_filtered.len() - 1;
+        }
+    }
+
+    /// Handle a key press while the group management menu is open.
+    pub fn handle_group_menu_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        let state = self.group_menu_state.clone()?;
+        match state {
+            GroupMenuState::Menu => {
+                let items = self.group_menu_items();
+                let item_count = items.len();
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if self.group_menu_index < item_count.saturating_sub(1) {
+                            self.group_menu_index += 1;
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.group_menu_index = self.group_menu_index.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        if let Some(action) = items.get(self.group_menu_index) {
+                            self.transition_group_menu(action.key_hint);
+                        }
+                    }
+                    KeyCode::Char(c) => {
+                        let hint = match c {
+                            'm' => "m", 'a' => "a", 'r' => "r",
+                            'n' => "n", 'l' => "l", 'c' => "c",
+                            _ => "",
+                        };
+                        if !hint.is_empty() && items.iter().any(|a| a.key_hint == hint) {
+                            self.transition_group_menu(hint);
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.group_menu_state = None;
+                    }
+                    _ => {}
+                }
+                None
+            }
+            GroupMenuState::Members => {
+                let member_count = self.group_menu_filtered.len();
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if self.group_menu_index < member_count.saturating_sub(1) {
+                            self.group_menu_index += 1;
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.group_menu_index = self.group_menu_index.saturating_sub(1);
+                    }
+                    KeyCode::Esc => {
+                        self.group_menu_state = Some(GroupMenuState::Menu);
+                        self.group_menu_index = 0;
+                    }
+                    _ => {}
+                }
+                None
+            }
+            GroupMenuState::AddMember => {
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if !self.group_menu_filtered.is_empty()
+                            && self.group_menu_index < self.group_menu_filtered.len() - 1
+                        {
+                            self.group_menu_index += 1;
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.group_menu_index = self.group_menu_index.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        if let Some((phone, _)) = self.group_menu_filtered.get(self.group_menu_index) {
+                            let phone = phone.clone();
+                            let group_id = self.active_conversation.clone()?;
+                            self.group_menu_state = None;
+                            self.group_menu_filter.clear();
+                            return Some(SendRequest::AddGroupMembers {
+                                group_id,
+                                members: vec![phone],
+                            });
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.group_menu_state = Some(GroupMenuState::Menu);
+                        self.group_menu_index = 0;
+                        self.group_menu_filter.clear();
+                    }
+                    KeyCode::Backspace => {
+                        self.group_menu_filter.pop();
+                        self.group_menu_index = 0;
+                        self.refresh_group_add_filter();
+                    }
+                    KeyCode::Char(c) if c != 'j' && c != 'k' => {
+                        self.group_menu_filter.push(c);
+                        self.group_menu_index = 0;
+                        self.refresh_group_add_filter();
+                    }
+                    _ => {}
+                }
+                None
+            }
+            GroupMenuState::RemoveMember => {
+                match code {
+                    KeyCode::Char('j') | KeyCode::Down => {
+                        if !self.group_menu_filtered.is_empty()
+                            && self.group_menu_index < self.group_menu_filtered.len() - 1
+                        {
+                            self.group_menu_index += 1;
+                        }
+                    }
+                    KeyCode::Char('k') | KeyCode::Up => {
+                        self.group_menu_index = self.group_menu_index.saturating_sub(1);
+                    }
+                    KeyCode::Enter => {
+                        if let Some((phone, _)) = self.group_menu_filtered.get(self.group_menu_index) {
+                            let phone = phone.clone();
+                            let group_id = self.active_conversation.clone()?;
+                            self.group_menu_state = None;
+                            self.group_menu_filter.clear();
+                            return Some(SendRequest::RemoveGroupMembers {
+                                group_id,
+                                members: vec![phone],
+                            });
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.group_menu_state = Some(GroupMenuState::Menu);
+                        self.group_menu_index = 0;
+                        self.group_menu_filter.clear();
+                    }
+                    KeyCode::Backspace => {
+                        self.group_menu_filter.pop();
+                        self.group_menu_index = 0;
+                        self.refresh_group_remove_filter();
+                    }
+                    KeyCode::Char(c) if c != 'j' && c != 'k' => {
+                        self.group_menu_filter.push(c);
+                        self.group_menu_index = 0;
+                        self.refresh_group_remove_filter();
+                    }
+                    _ => {}
+                }
+                None
+            }
+            GroupMenuState::Rename => {
+                match code {
+                    KeyCode::Enter => {
+                        let name = self.group_menu_input.trim().to_string();
+                        if !name.is_empty() {
+                            let group_id = self.active_conversation.clone()?;
+                            self.group_menu_state = None;
+                            self.group_menu_input.clear();
+                            return Some(SendRequest::RenameGroup { group_id, name });
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.group_menu_state = Some(GroupMenuState::Menu);
+                        self.group_menu_index = 0;
+                        self.group_menu_input.clear();
+                    }
+                    KeyCode::Backspace => {
+                        self.group_menu_input.pop();
+                    }
+                    KeyCode::Char(c) => {
+                        self.group_menu_input.push(c);
+                    }
+                    _ => {}
+                }
+                None
+            }
+            GroupMenuState::Create => {
+                match code {
+                    KeyCode::Enter => {
+                        let name = self.group_menu_input.trim().to_string();
+                        if !name.is_empty() {
+                            self.group_menu_state = None;
+                            self.group_menu_input.clear();
+                            return Some(SendRequest::CreateGroup { name });
+                        }
+                    }
+                    KeyCode::Esc => {
+                        self.group_menu_state = None;
+                        self.group_menu_input.clear();
+                    }
+                    KeyCode::Backspace => {
+                        self.group_menu_input.pop();
+                    }
+                    KeyCode::Char(c) => {
+                        self.group_menu_input.push(c);
+                    }
+                    _ => {}
+                }
+                None
+            }
+            GroupMenuState::LeaveConfirm => {
+                match code {
+                    KeyCode::Char('y') => {
+                        let group_id = self.active_conversation.clone()?;
+                        self.group_menu_state = None;
+                        return Some(SendRequest::LeaveGroup { group_id });
+                    }
+                    KeyCode::Char('n') | KeyCode::Esc => {
+                        self.group_menu_state = Some(GroupMenuState::Menu);
+                        self.group_menu_index = 0;
+                    }
+                    _ => {}
+                }
+                None
+            }
+        }
+    }
+
+    /// Transition from the top-level group menu to a sub-state.
+    fn transition_group_menu(&mut self, hint: &str) {
+        self.group_menu_index = 0;
+        self.group_menu_filter.clear();
+        self.group_menu_input.clear();
+        match hint {
+            "m" => {
+                // Populate member list for display
+                let members: Vec<(String, String)> = self.active_conversation.as_ref()
+                    .and_then(|id| self.groups.get(id))
+                    .map(|g| g.members.iter().map(|phone| {
+                        let name = self.contact_names.get(phone)
+                            .cloned()
+                            .unwrap_or_else(|| phone.clone());
+                        (phone.clone(), name)
+                    }).collect())
+                    .unwrap_or_default();
+                self.group_menu_filtered = members;
+                self.group_menu_state = Some(GroupMenuState::Members);
+            }
+            "a" => {
+                self.refresh_group_add_filter();
+                self.group_menu_state = Some(GroupMenuState::AddMember);
+            }
+            "r" => {
+                self.refresh_group_remove_filter();
+                self.group_menu_state = Some(GroupMenuState::RemoveMember);
+            }
+            "n" => {
+                // Pre-fill with current group name
+                let name = self.active_conversation.as_ref()
+                    .and_then(|id| self.conversations.get(id))
+                    .map(|c| c.name.clone())
+                    .unwrap_or_default();
+                self.group_menu_input = name;
+                self.group_menu_state = Some(GroupMenuState::Rename);
+            }
+            "l" => {
+                self.group_menu_state = Some(GroupMenuState::LeaveConfirm);
+            }
+            "c" => {
+                self.group_menu_state = Some(GroupMenuState::Create);
+            }
+            _ => {}
         }
     }
 
@@ -1259,6 +1640,11 @@ impl App {
             pending_read_receipts: Vec::new(),
             show_action_menu: false,
             action_menu_index: 0,
+            group_menu_state: None,
+            group_menu_index: 0,
+            group_menu_filter: String::new(),
+            group_menu_filtered: Vec::new(),
+            group_menu_input: String::new(),
         }
     }
 
@@ -1507,6 +1893,10 @@ impl App {
         }
         if self.show_reaction_picker {
             let send = self.handle_reaction_picker_key(code);
+            return (true, send);
+        }
+        if self.group_menu_state.is_some() {
+            let send = self.handle_group_menu_key(code);
             return (true, send);
         }
         if self.show_help {
@@ -3138,6 +3528,12 @@ impl App {
                 self.contacts_index = 0;
                 self.contacts_filter.clear();
                 self.refresh_contacts_filter();
+            }
+            InputAction::Group => {
+                self.group_menu_state = Some(GroupMenuState::Menu);
+                self.group_menu_index = 0;
+                self.group_menu_filter.clear();
+                self.group_menu_input.clear();
             }
             InputAction::Help => {
                 self.show_help = true;
@@ -5521,5 +5917,170 @@ mod tests {
         let app = test_app();
         let resolved = app.resolve_text_styles("hello world", &[], &[]);
         assert!(resolved.is_empty());
+    }
+
+    // --- Group management tests ---
+
+    #[test]
+    fn group_command_parsed() {
+        assert!(matches!(crate::input::parse_input("/group"), crate::input::InputAction::Group));
+        assert!(matches!(crate::input::parse_input("/g"), crate::input::InputAction::Group));
+    }
+
+    #[test]
+    fn group_menu_items_in_group_context() {
+        let mut app = test_app();
+        app.get_or_create_conversation("g1", "Family", true);
+        app.active_conversation = Some("g1".to_string());
+        let items = app.group_menu_items();
+        assert_eq!(items.len(), 5);
+        assert_eq!(items[0].label, "Members");
+        assert_eq!(items[4].label, "Leave");
+    }
+
+    #[test]
+    fn group_menu_items_not_in_group() {
+        let mut app = test_app();
+        app.get_or_create_conversation("+1", "Alice", false);
+        app.active_conversation = Some("+1".to_string());
+        let items = app.group_menu_items();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, "Create group");
+    }
+
+    #[test]
+    fn group_menu_items_no_conversation() {
+        let app = test_app();
+        let items = app.group_menu_items();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].label, "Create group");
+    }
+
+    #[test]
+    fn group_add_filter_excludes_existing_members() {
+        let mut app = test_app();
+        app.get_or_create_conversation("g1", "Family", true);
+        app.active_conversation = Some("g1".to_string());
+        app.groups.insert("g1".to_string(), Group {
+            id: "g1".to_string(),
+            name: "Family".to_string(),
+            members: vec!["+1".to_string(), "+2".to_string()],
+            member_uuids: vec![],
+        });
+        app.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.contact_names.insert("+2".to_string(), "Bob".to_string());
+        app.contact_names.insert("+3".to_string(), "Charlie".to_string());
+
+        app.refresh_group_add_filter();
+
+        // Only Charlie should appear (not Alice or Bob who are already members)
+        assert_eq!(app.group_menu_filtered.len(), 1);
+        assert_eq!(app.group_menu_filtered[0].0, "+3");
+    }
+
+    #[test]
+    fn group_remove_filter_excludes_self() {
+        let mut app = test_app();
+        app.get_or_create_conversation("g1", "Family", true);
+        app.active_conversation = Some("g1".to_string());
+        app.groups.insert("g1".to_string(), Group {
+            id: "g1".to_string(),
+            name: "Family".to_string(),
+            members: vec!["+10000000000".to_string(), "+1".to_string(), "+2".to_string()],
+            member_uuids: vec![],
+        });
+        app.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.contact_names.insert("+2".to_string(), "Bob".to_string());
+
+        app.refresh_group_remove_filter();
+
+        // Self (+10000000000) should be excluded
+        assert_eq!(app.group_menu_filtered.len(), 2);
+        let phones: Vec<&str> = app.group_menu_filtered.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(!phones.contains(&"+10000000000"));
+        assert!(phones.contains(&"+1"));
+        assert!(phones.contains(&"+2"));
+    }
+
+    #[test]
+    fn group_menu_state_transitions() {
+        let mut app = test_app();
+        app.get_or_create_conversation("g1", "Family", true);
+        app.active_conversation = Some("g1".to_string());
+        app.groups.insert("g1".to_string(), Group {
+            id: "g1".to_string(),
+            name: "Family".to_string(),
+            members: vec!["+1".to_string()],
+            member_uuids: vec![],
+        });
+
+        // Open group menu via handle_input
+        app.input_buffer = "/group".to_string();
+        app.input_cursor = 6;
+        app.handle_input();
+        assert_eq!(app.group_menu_state, Some(GroupMenuState::Menu));
+
+        // Press 'm' to go to Members
+        app.handle_group_menu_key(KeyCode::Char('m'));
+        assert_eq!(app.group_menu_state, Some(GroupMenuState::Members));
+
+        // Esc goes back to Menu
+        app.handle_group_menu_key(KeyCode::Esc);
+        assert_eq!(app.group_menu_state, Some(GroupMenuState::Menu));
+
+        // Press 'l' to go to LeaveConfirm
+        app.handle_group_menu_key(KeyCode::Char('l'));
+        assert_eq!(app.group_menu_state, Some(GroupMenuState::LeaveConfirm));
+
+        // Press 'n' to cancel leave
+        app.handle_group_menu_key(KeyCode::Char('n'));
+        assert_eq!(app.group_menu_state, Some(GroupMenuState::Menu));
+
+        // Esc closes the menu entirely
+        app.handle_group_menu_key(KeyCode::Esc);
+        assert_eq!(app.group_menu_state, None);
+    }
+
+    #[test]
+    fn group_leave_produces_send_request() {
+        let mut app = test_app();
+        app.get_or_create_conversation("g1", "Family", true);
+        app.active_conversation = Some("g1".to_string());
+        app.groups.insert("g1".to_string(), Group {
+            id: "g1".to_string(),
+            name: "Family".to_string(),
+            members: vec![],
+            member_uuids: vec![],
+        });
+
+        app.group_menu_state = Some(GroupMenuState::LeaveConfirm);
+        let req = app.handle_group_menu_key(KeyCode::Char('y'));
+        assert!(req.is_some());
+        assert!(matches!(req, Some(SendRequest::LeaveGroup { group_id }) if group_id == "g1"));
+        assert_eq!(app.group_menu_state, None);
+    }
+
+    #[test]
+    fn group_create_produces_send_request() {
+        let mut app = test_app();
+        app.group_menu_state = Some(GroupMenuState::Create);
+        app.group_menu_input = "New Group".to_string();
+        let req = app.handle_group_menu_key(KeyCode::Enter);
+        assert!(req.is_some());
+        assert!(matches!(req, Some(SendRequest::CreateGroup { name }) if name == "New Group"));
+        assert_eq!(app.group_menu_state, None);
+    }
+
+    #[test]
+    fn group_rename_produces_send_request() {
+        let mut app = test_app();
+        app.get_or_create_conversation("g1", "Old Name", true);
+        app.active_conversation = Some("g1".to_string());
+        app.group_menu_state = Some(GroupMenuState::Rename);
+        app.group_menu_input = "New Name".to_string();
+        let req = app.handle_group_menu_key(KeyCode::Enter);
+        assert!(req.is_some());
+        assert!(matches!(req, Some(SendRequest::RenameGroup { group_id, name }) if group_id == "g1" && name == "New Name"));
+        assert_eq!(app.group_menu_state, None);
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -17,6 +17,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo { name: "/contacts", alias: "/c",  args: "",        description: "Browse contacts" },
     CommandInfo { name: "/settings", alias: "",    args: "",        description: "Open settings" },
     CommandInfo { name: "/disappearing", alias: "/dm", args: "<duration>", description: "Set disappearing timer (off/30s/5m/1h/1d/1w)" },
+    CommandInfo { name: "/group",    alias: "/g",  args: "",        description: "Group management" },
     CommandInfo { name: "/help",     alias: "/h",  args: "",        description: "Show help" },
     CommandInfo { name: "/quit",     alias: "/q",  args: "",        description: "Exit signal-tui" },
 ];
@@ -50,6 +51,8 @@ pub enum InputAction {
     Search(String),
     /// Set disappearing message timer (raw duration string)
     SetDisappearing(String),
+    /// Open group management menu
+    Group,
     /// Unknown command
     Unknown(String),
 }
@@ -105,6 +108,7 @@ pub fn parse_input(input: &str) -> InputAction {
                 InputAction::SetDisappearing(arg)
             }
         }
+        "/group" | "/g" => InputAction::Group,
         "/help" | "/h" => InputAction::Help,
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }
@@ -367,5 +371,15 @@ mod tests {
         assert!(parse_duration_to_seconds("").is_err());
         assert!(parse_duration_to_seconds("0s").is_err());
         assert!(parse_duration_to_seconds("-1h").is_err());
+    }
+
+    #[test]
+    fn group_command() {
+        assert!(matches!(parse_input("/group"), InputAction::Group));
+    }
+
+    #[test]
+    fn group_alias() {
+        assert!(matches!(parse_input("/g"), InputAction::Group));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -527,6 +527,65 @@ async fn dispatch_send(
                 );
             }
         }
+        SendRequest::CreateGroup { name } => {
+            if let Err(e) = signal_client.create_group(&name, &[]).await {
+                app.status_message = format!("create group error: {e}");
+            } else {
+                app.status_message = format!("Created group \"{}\"", name);
+                let _ = signal_client.list_groups().await;
+            }
+        }
+        SendRequest::AddGroupMembers { group_id, members } => {
+            if let Err(e) = signal_client.add_group_members(&group_id, &members).await {
+                app.status_message = format!("add member error: {e}");
+            } else {
+                let names: Vec<String> = members.iter()
+                    .map(|m| app.contact_names.get(m).cloned().unwrap_or_else(|| m.clone()))
+                    .collect();
+                app.status_message = format!("Added {}", names.join(", "));
+                let _ = signal_client.list_groups().await;
+            }
+        }
+        SendRequest::RemoveGroupMembers { group_id, members } => {
+            if let Err(e) = signal_client.remove_group_members(&group_id, &members).await {
+                app.status_message = format!("remove member error: {e}");
+            } else {
+                let names: Vec<String> = members.iter()
+                    .map(|m| app.contact_names.get(m).cloned().unwrap_or_else(|| m.clone()))
+                    .collect();
+                app.status_message = format!("Removed {}", names.join(", "));
+                let _ = signal_client.list_groups().await;
+            }
+        }
+        SendRequest::RenameGroup { group_id, name } => {
+            if let Err(e) = signal_client.rename_group(&group_id, &name).await {
+                app.status_message = format!("rename group error: {e}");
+            } else {
+                // Update locally for instant visual feedback
+                if let Some(conv) = app.conversations.get_mut(&group_id) {
+                    conv.name = name.clone();
+                }
+                app.contact_names.insert(group_id.clone(), name.clone());
+                app.status_message = format!("Renamed group to \"{}\"", name);
+                let _ = signal_client.list_groups().await;
+            }
+        }
+        SendRequest::LeaveGroup { group_id } => {
+            if let Err(e) = signal_client.quit_group(&group_id).await {
+                app.status_message = format!("leave group error: {e}");
+            } else {
+                let name = app.conversations.get(&group_id)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_else(|| group_id.clone());
+                app.conversations.remove(&group_id);
+                app.conversation_order.retain(|id| id != &group_id);
+                app.groups.remove(&group_id);
+                if app.active_conversation.as_ref() == Some(&group_id) {
+                    app.active_conversation = None;
+                }
+                app.status_message = format!("Left group \"{}\"", name);
+            }
+        }
     }
 }
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -542,6 +542,117 @@ impl SignalClient {
         Ok(())
     }
 
+    /// Create a new group with the given name (optionally with initial members).
+    pub async fn create_group(&self, name: &str, members: &[String]) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("updateGroup".to_string(), Instant::now()));
+        }
+        let mut params = serde_json::json!({
+            "name": name,
+            "account": self.account,
+        });
+        if !members.is_empty() {
+            params["members"] = serde_json::json!(members);
+        }
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "updateGroup".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send createGroup to signal-cli stdin")?;
+        Ok(())
+    }
+
+    /// Add members to an existing group.
+    pub async fn add_group_members(&self, group_id: &str, members: &[String]) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("updateGroup".to_string(), Instant::now()));
+        }
+        let params = serde_json::json!({
+            "groupId": group_id,
+            "members": members,
+            "account": self.account,
+        });
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "updateGroup".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send addGroupMembers to signal-cli stdin")?;
+        Ok(())
+    }
+
+    /// Remove members from an existing group.
+    pub async fn remove_group_members(&self, group_id: &str, members: &[String]) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("updateGroup".to_string(), Instant::now()));
+        }
+        let params = serde_json::json!({
+            "groupId": group_id,
+            "removeMembers": members,
+            "account": self.account,
+        });
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "updateGroup".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send removeGroupMembers to signal-cli stdin")?;
+        Ok(())
+    }
+
+    /// Rename an existing group.
+    pub async fn rename_group(&self, group_id: &str, name: &str) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("updateGroup".to_string(), Instant::now()));
+        }
+        let params = serde_json::json!({
+            "groupId": group_id,
+            "name": name,
+            "account": self.account,
+        });
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "updateGroup".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send renameGroup to signal-cli stdin")?;
+        Ok(())
+    }
+
+    /// Leave (quit) a group.
+    pub async fn quit_group(&self, group_id: &str) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("quitGroup".to_string(), Instant::now()));
+        }
+        let params = serde_json::json!({
+            "groupId": group_id,
+            "account": self.account,
+        });
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "quitGroup".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send quitGroup to signal-cli stdin")?;
+        Ok(())
+    }
+
     /// Set the disappearing message timer for a group.
     pub async fn send_update_group_expiration(
         &self,
@@ -661,7 +772,7 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
                 .collect();
             Some(SignalEvent::GroupList(groups))
         }
-        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" => None, // fire-and-forget, no action needed
+        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" => None, // fire-and-forget, no action needed
         _ => None,
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, AutocompleteMode, InputMode, VisibleImage, QUICK_REACTIONS, SETTINGS};
+use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, VisibleImage, QUICK_REACTIONS, SETTINGS};
 use crate::signal::types::{MessageStatus, Reaction, StyleType};
 use crate::image_render::ImageProtocol;
 use crate::input::{COMMANDS, format_compact_duration};
@@ -29,6 +29,8 @@ const FILE_BROWSER_POPUP_WIDTH: u16 = 60;
 const FILE_BROWSER_MAX_VISIBLE: usize = 20;
 const SEARCH_POPUP_WIDTH: u16 = 60;
 const SEARCH_MAX_VISIBLE: usize = 15;
+const GROUP_MENU_POPUP_WIDTH: u16 = 40;
+const GROUP_MEMBER_MAX_VISIBLE: usize = 15;
 
 /// Map a MessageStatus to its display symbol and color.
 fn status_symbol(status: MessageStatus, nerd_fonts: bool, color: bool) -> (&'static str, Color) {
@@ -481,6 +483,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // File browser overlay
     if app.show_file_browser {
         draw_file_browser(frame, app, size);
+    }
+
+    // Group management menu overlay
+    if app.group_menu_state.is_some() {
+        draw_group_menu(frame, app, size);
     }
 
     // Action menu overlay
@@ -1050,6 +1057,241 @@ fn build_reaction_summary(reactions: &[Reaction], verbose: bool) -> Line<'static
             ));
         }
         Line::from(spans)
+    }
+}
+
+fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
+    let state = match &app.group_menu_state {
+        Some(s) => s,
+        None => return,
+    };
+    match state {
+        GroupMenuState::Menu => {
+            let items = app.group_menu_items();
+            if items.is_empty() {
+                return;
+            }
+            let popup_height = items.len() as u16 + 4;
+            let title = app.active_conversation.as_ref()
+                .and_then(|id| app.conversations.get(id))
+                .filter(|c| c.is_group)
+                .map(|c| format!(" #{} ", c.name))
+                .unwrap_or_else(|| " Group ".to_string());
+            let (popup_area, block) = centered_popup(
+                frame, area, GROUP_MENU_POPUP_WIDTH, popup_height, &title,
+            );
+            let inner = block.inner(popup_area);
+            frame.render_widget(block, popup_area);
+            let content_width = inner.width as usize;
+            let mut lines: Vec<Line> = Vec::new();
+            for (i, action) in items.iter().enumerate() {
+                let is_selected = i == app.group_menu_index;
+                let icon = if app.nerd_fonts {
+                    format!("{} ", action.nerd_icon)
+                } else {
+                    String::new()
+                };
+                let label_part = format!("  {icon}{}", action.label);
+                let hint_width = action.key_hint.len();
+                let pad = content_width.saturating_sub(label_part.chars().count() + hint_width + 2);
+                let padding = " ".repeat(pad);
+                let row_style = if is_selected {
+                    Style::default().bg(Color::DarkGray)
+                } else {
+                    Style::default()
+                };
+                let hint_style = if is_selected {
+                    Style::default().bg(Color::DarkGray).fg(Color::DarkGray).add_modifier(Modifier::DIM)
+                } else {
+                    Style::default().fg(Color::DarkGray)
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(format!("{label_part}{padding}"), row_style),
+                    Span::styled(format!("{} ", action.key_hint), hint_style),
+                ]));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  Esc to close",
+                Style::default().fg(Color::DarkGray),
+            )));
+            let popup = Paragraph::new(lines);
+            frame.render_widget(popup, inner);
+        }
+        GroupMenuState::Members => {
+            let max_visible = GROUP_MEMBER_MAX_VISIBLE.min(app.group_menu_filtered.len().max(1));
+            let pref_height = max_visible as u16 + 5;
+            let title = " Members ".to_string();
+            let (popup_area, block) = centered_popup(
+                frame, area, GROUP_MENU_POPUP_WIDTH, pref_height, &title,
+            );
+            let inner_height = popup_area.height.saturating_sub(2) as usize;
+            let footer_lines = 2;
+            let visible_rows = inner_height.saturating_sub(footer_lines);
+            let scroll_offset = if app.group_menu_index >= visible_rows {
+                app.group_menu_index - visible_rows + 1
+            } else {
+                0
+            };
+            let mut lines: Vec<Line> = Vec::new();
+            if app.group_menu_filtered.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "  No members",
+                    Style::default().fg(Color::DarkGray),
+                )));
+            } else {
+                let end = (scroll_offset + visible_rows).min(app.group_menu_filtered.len());
+                for (i, (phone, name)) in app.group_menu_filtered[scroll_offset..end].iter().enumerate() {
+                    let actual_index = scroll_offset + i;
+                    let is_selected = actual_index == app.group_menu_index;
+                    let is_self = *phone == app.account;
+                    let display = if is_self {
+                        format!("  {} (you)", name)
+                    } else {
+                        format!("  {}", name)
+                    };
+                    let name_style = if is_selected {
+                        Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+                    let phone_style = if is_selected {
+                        Style::default().bg(Color::DarkGray).fg(Color::DarkGray)
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(display, name_style),
+                        Span::styled(format!("  {}", phone), phone_style),
+                    ]));
+                }
+            }
+            while lines.len() < visible_rows {
+                lines.push(Line::from(""));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  Esc to go back",
+                Style::default().fg(Color::DarkGray),
+            )));
+            let popup = Paragraph::new(lines).block(block);
+            frame.render_widget(popup, popup_area);
+        }
+        GroupMenuState::AddMember | GroupMenuState::RemoveMember => {
+            let is_add = *state == GroupMenuState::AddMember;
+            let max_visible = GROUP_MEMBER_MAX_VISIBLE.min(app.group_menu_filtered.len().max(1));
+            let pref_height = max_visible as u16 + 5;
+            let title = if is_add {
+                if app.group_menu_filter.is_empty() {
+                    " Add Member ".to_string()
+                } else {
+                    format!(" Add Member [{}] ", app.group_menu_filter)
+                }
+            } else if app.group_menu_filter.is_empty() {
+                " Remove Member ".to_string()
+            } else {
+                format!(" Remove Member [{}] ", app.group_menu_filter)
+            };
+            let (popup_area, block) = centered_popup(
+                frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title,
+            );
+            let inner_height = popup_area.height.saturating_sub(2) as usize;
+            let footer_lines = 2;
+            let visible_rows = inner_height.saturating_sub(footer_lines);
+            let scroll_offset = if app.group_menu_index >= visible_rows {
+                app.group_menu_index - visible_rows + 1
+            } else {
+                0
+            };
+            let mut lines: Vec<Line> = Vec::new();
+            if app.group_menu_filtered.is_empty() {
+                let msg = if is_add { "  No contacts to add" } else { "  No members to remove" };
+                lines.push(Line::from(Span::styled(
+                    msg,
+                    Style::default().fg(Color::DarkGray),
+                )));
+            } else {
+                let end = (scroll_offset + visible_rows).min(app.group_menu_filtered.len());
+                let inner_w = popup_area.width.saturating_sub(2) as usize;
+                for (i, (phone, name)) in app.group_menu_filtered[scroll_offset..end].iter().enumerate() {
+                    let actual_index = scroll_offset + i;
+                    let is_selected = actual_index == app.group_menu_index;
+                    let number_display = format!("  {}", phone);
+                    let name_max = inner_w.saturating_sub(number_display.len() + 2);
+                    let display_name = truncate(name, name_max);
+                    let name_style = if is_selected {
+                        Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(Color::White)
+                    };
+                    let number_style = if is_selected {
+                        Style::default().bg(Color::DarkGray).fg(Color::Cyan)
+                    } else {
+                        Style::default().fg(Color::DarkGray)
+                    };
+                    lines.push(Line::from(vec![
+                        Span::styled(format!("  {}", display_name), name_style),
+                        Span::styled(number_display, number_style),
+                    ]));
+                }
+            }
+            while lines.len() < visible_rows {
+                lines.push(Line::from(""));
+            }
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  Enter to select \u{00b7} Esc to cancel",
+                Style::default().fg(Color::DarkGray),
+            )));
+            let popup = Paragraph::new(lines).block(block);
+            frame.render_widget(popup, popup_area);
+        }
+        GroupMenuState::Rename | GroupMenuState::Create => {
+            let is_rename = *state == GroupMenuState::Rename;
+            let title = if is_rename { " Rename Group " } else { " Create Group " };
+            let (popup_area, block) = centered_popup(
+                frame, area, GROUP_MENU_POPUP_WIDTH, 6, title,
+            );
+            let inner = block.inner(popup_area);
+            frame.render_widget(block, popup_area);
+            let mut lines: Vec<Line> = Vec::new();
+            let input_display = format!("  {}\u{2588}", app.group_menu_input);
+            lines.push(Line::from(Span::styled(
+                input_display,
+                Style::default().fg(Color::White),
+            )));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  Enter to confirm \u{00b7} Esc to cancel",
+                Style::default().fg(Color::DarkGray),
+            )));
+            let popup = Paragraph::new(lines);
+            frame.render_widget(popup, inner);
+        }
+        GroupMenuState::LeaveConfirm => {
+            let group_name = app.active_conversation.as_ref()
+                .and_then(|id| app.conversations.get(id))
+                .map(|c| c.name.clone())
+                .unwrap_or_else(|| "this group".to_string());
+            let prompt = format!("Leave #{}?", group_name);
+            let (popup_area, block) = centered_popup(
+                frame, area, GROUP_MENU_POPUP_WIDTH, 5, " Leave Group ",
+            );
+            let inner = block.inner(popup_area);
+            frame.render_widget(block, popup_area);
+            let mut lines: Vec<Line> = Vec::new();
+            lines.push(Line::from(Span::styled(
+                format!("  {}", prompt),
+                Style::default().fg(Color::Yellow),
+            )));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  (y)es / (n)o",
+                Style::default().fg(Color::DarkGray),
+            )));
+            let popup = Paragraph::new(lines);
+            frame.render_widget(popup, inner);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds `/group` (alias `/g`) command with a flyout menu for group management
- In a group conversation: view members, add/remove members, rename group, leave group
- Outside a group: create a new group
- 5 new signal-cli RPC methods (`updateGroup` variants + `quitGroup`)
- Post-mutation `list_groups()` refresh keeps sidebar in sync
- 12 new unit tests, all 189 tests pass, clippy clean

## UX Flow
- `/group` opens a flyout menu (reuses the action menu pattern)
- Sub-flows: Members list (j/k scroll), Add/Remove member (type-to-filter picker), Rename/Create (text input), Leave (y/n confirmation)
- Esc navigates back through sub-states → menu → closed

## Test plan
- [ ] `/group` in a group → flyout with 5 actions (Members, Add, Remove, Rename, Leave)
- [ ] `/group` in a 1:1 → flyout with "Create group"
- [ ] Members → shows member list with (you) marker, Esc returns to menu
- [ ] Add member → contact picker excluding existing members, Enter adds
- [ ] Remove member → member picker excluding self, Enter removes
- [ ] Rename → pre-filled input, edit, Enter confirms, sidebar updates
- [ ] Leave → confirmation prompt, y leaves and removes from sidebar
- [ ] Create group → type name, Enter creates, group appears after refresh
- [ ] `cargo clippy --tests -- -D warnings` clean
- [ ] `cargo test` — 189 tests pass

closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)