### PR TITLE
Add message requests (#62)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -123,6 +123,8 @@ pub struct Conversation {
     pub is_group: bool,
     /// Disappearing message timer in seconds (0 = off)
     pub expiration_timer: i64,
+    /// Whether this conversation has been accepted (message requests are unaccepted)
+    pub accepted: bool,
 }
 
 /// Application state
@@ -309,6 +311,8 @@ pub struct App {
     pub group_menu_filtered: Vec<(String, String)>,
     /// Separate text input buffer for rename/create (avoids disturbing input_buffer)
     pub group_menu_input: String,
+    /// Message request overlay visible
+    pub show_message_request: bool,
 }
 
 /// A search result entry.
@@ -391,6 +395,11 @@ pub enum SendRequest {
     },
     LeaveGroup {
         group_id: String,
+    },
+    MessageRequestResponse {
+        recipient: String,
+        is_group: bool,
+        response_type: String,
     },
 }
 
@@ -916,6 +925,50 @@ impl App {
     }
 
     /// Handle a key press while the reaction picker overlay is open.
+    fn handle_message_request_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        let conv_id = match self.active_conversation.clone() {
+            Some(id) => id,
+            None => {
+                self.show_message_request = false;
+                return None;
+            }
+        };
+        match code {
+            KeyCode::Char('a') => {
+                let is_group = self.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                if let Some(conv) = self.conversations.get_mut(&conv_id) {
+                    conv.accepted = true;
+                }
+                db_warn(self.db.update_accepted(&conv_id, true), "update_accepted");
+                self.show_message_request = false;
+                Some(SendRequest::MessageRequestResponse {
+                    recipient: conv_id,
+                    is_group,
+                    response_type: "accept".to_string(),
+                })
+            }
+            KeyCode::Char('d') => {
+                let is_group = self.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                self.conversations.remove(&conv_id);
+                self.conversation_order.retain(|id| id != &conv_id);
+                db_warn(self.db.delete_conversation(&conv_id), "delete_conversation");
+                self.show_message_request = false;
+                self.active_conversation = None;
+                Some(SendRequest::MessageRequestResponse {
+                    recipient: conv_id,
+                    is_group,
+                    response_type: "delete".to_string(),
+                })
+            }
+            KeyCode::Esc => {
+                self.show_message_request = false;
+                self.active_conversation = None;
+                None
+            }
+            _ => None,
+        }
+    }
+
     fn handle_reaction_picker_key(&mut self, code: KeyCode) -> Option<SendRequest> {
         match code {
             KeyCode::Char('h') | KeyCode::Left => {
@@ -1645,6 +1698,7 @@ impl App {
             group_menu_filter: String::new(),
             group_menu_filtered: Vec::new(),
             group_menu_input: String::new(),
+            show_message_request: false,
         }
     }
 
@@ -1751,6 +1805,9 @@ impl App {
             Some(c) => c,
             None => return,
         };
+        if !conv.accepted {
+            return;
+        }
         // Collect timestamps grouped by sender phone number
         let mut by_sender: HashMap<String, Vec<i64>> = HashMap::new();
         for msg in conv.messages.iter().skip(start_index) {
@@ -1893,6 +1950,10 @@ impl App {
         }
         if self.show_reaction_picker {
             let send = self.handle_reaction_picker_key(code);
+            return (true, send);
+        }
+        if self.show_message_request {
+            let send = self.handle_message_request_key(code);
             return (true, send);
         }
         if self.group_menu_state.is_some() {
@@ -2336,8 +2397,15 @@ impl App {
             msg.source.clone()
         };
 
-        // Ensure conversation exists (drop the mutable ref immediately)
+        // Ensure conversation exists; detect message requests for new 1:1 from unknown senders
+        let is_new = !self.conversations.contains_key(&conv_id);
         self.get_or_create_conversation(&conv_id, &conv_name, is_group);
+        if is_new && !msg.is_outgoing && !is_group && !self.contact_names.contains_key(&conv_id) {
+            if let Some(conv) = self.conversations.get_mut(&conv_id) {
+                conv.accepted = false;
+                db_warn(self.db.update_accepted(&conv_id, false), "update_accepted");
+            }
+        }
 
         let ts_rfc3339 = msg.timestamp.to_rfc3339();
         let msg_ts_ms = msg.timestamp.timestamp_millis();
@@ -2482,15 +2550,17 @@ impl App {
             if let Some(c) = self.conversations.get_mut(&conv_id) {
                 c.unread += 1;
             }
+            let conv_accepted = self.conversations.get(&conv_id).map(|c| c.accepted).unwrap_or(true);
             let type_enabled = if is_group { self.notify_group } else { self.notify_direct };
-            if type_enabled && !self.muted_conversations.contains(&conv_id) {
+            if type_enabled && conv_accepted && !self.muted_conversations.contains(&conv_id) {
                 self.pending_bell = true;
             }
         }
 
         // Active conversation: send read receipt and advance read marker
+        let conv_accepted = self.conversations.get(&conv_id).map(|c| c.accepted).unwrap_or(true);
         if is_active {
-            if !msg.is_outgoing {
+            if !msg.is_outgoing && conv_accepted {
                 self.queue_single_read_receipt(&sender_id, msg_ts_ms);
             }
             if let Some(conv) = self.conversations.get(&conv_id) {
@@ -2834,6 +2904,18 @@ impl App {
                 }
             }
         }
+        // Auto-accept unaccepted 1:1 conversations whose sender is now a known contact
+        let to_accept: Vec<String> = self.conversations.iter()
+            .filter(|(_, c)| !c.accepted && !c.is_group && self.contact_names.contains_key(&c.id))
+            .map(|(id, _)| id.clone())
+            .collect();
+        for id in to_accept {
+            if let Some(conv) = self.conversations.get_mut(&id) {
+                conv.accepted = true;
+                db_warn(self.db.update_accepted(&id, true), "update_accepted");
+            }
+        }
+
         // Re-resolve reaction senders: DB stores phone numbers but display
         // needs contact names (or "you" for own reactions).
         self.resolve_stored_names();
@@ -3268,6 +3350,7 @@ impl App {
                     unread: 0,
                     is_group,
                     expiration_timer: 0,
+                    accepted: true,
                 },
             );
             self.conversation_order.push(id.to_string());
@@ -4005,8 +4088,13 @@ impl App {
                 let prefix = if conv.is_group { "#" } else { "" };
                 self.status_message = format!("connected | {}{}", prefix, conv.name);
             }
+            // Show message request overlay for unaccepted conversations
+            self.show_message_request = self.active_conversation.as_ref()
+                .and_then(|id| self.conversations.get(id))
+                .is_some_and(|c| !c.accepted);
         } else {
             self.status_message = "connected | no conversation selected".to_string();
+            self.show_message_request = false;
         }
     }
 
@@ -6082,5 +6170,147 @@ mod tests {
         assert!(req.is_some());
         assert!(matches!(req, Some(SendRequest::RenameGroup { group_id, name }) if group_id == "g1" && name == "New Name"));
         assert_eq!(app.group_menu_state, None);
+    }
+
+    // --- Message request tests ---
+
+    fn msg_from(source: &str) -> SignalMessage {
+        SignalMessage {
+            source: source.to_string(),
+            source_name: None,
+            timestamp: chrono::Utc::now(),
+            body: Some("hello".to_string()),
+            attachments: vec![],
+            group_id: None,
+            group_name: None,
+            is_outgoing: false,
+            destination: None,
+            mentions: vec![],
+            text_styles: vec![],
+            quote: None,
+            expires_in_seconds: 0,
+        }
+    }
+
+    #[test]
+    fn unknown_sender_creates_unaccepted_conversation() {
+        let mut app = test_app();
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        assert!(!app.conversations["+1"].accepted);
+    }
+
+    #[test]
+    fn outgoing_sync_creates_accepted_conversation() {
+        let mut app = test_app();
+        let msg = SignalMessage {
+            source: "+10000000000".to_string(),
+            source_name: None,
+            timestamp: chrono::Utc::now(),
+            body: Some("hey".to_string()),
+            attachments: vec![],
+            group_id: None,
+            group_name: None,
+            is_outgoing: true,
+            destination: Some("+1".to_string()),
+            mentions: vec![],
+            text_styles: vec![],
+            quote: None,
+            expires_in_seconds: 0,
+        };
+        app.handle_signal_event(SignalEvent::MessageReceived(msg));
+        assert!(app.conversations["+1"].accepted);
+    }
+
+    #[test]
+    fn known_contact_creates_accepted_conversation() {
+        let mut app = test_app();
+        app.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        assert!(app.conversations["+1"].accepted);
+    }
+
+    #[test]
+    fn contact_sync_auto_accepts_matching_conversations() {
+        let mut app = test_app();
+        // Message from unknown creates unaccepted
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        assert!(!app.conversations["+1"].accepted);
+
+        // Contact list arrives with +1 → auto-accept
+        app.handle_signal_event(SignalEvent::ContactList(vec![
+            Contact { number: "+1".to_string(), name: Some("Alice".to_string()), uuid: None },
+        ]));
+        assert!(app.conversations["+1"].accepted);
+    }
+
+    #[test]
+    fn accept_key_returns_send_request_and_marks_accepted() {
+        let mut app = test_app();
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        app.active_conversation = Some("+1".to_string());
+        app.show_message_request = true;
+
+        let req = app.handle_message_request_key(KeyCode::Char('a'));
+        assert!(app.conversations["+1"].accepted);
+        assert!(!app.show_message_request);
+        assert!(matches!(
+            req,
+            Some(SendRequest::MessageRequestResponse { ref response_type, .. })
+            if response_type == "accept"
+        ));
+    }
+
+    #[test]
+    fn delete_key_removes_conversation() {
+        let mut app = test_app();
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        app.active_conversation = Some("+1".to_string());
+        app.show_message_request = true;
+
+        let req = app.handle_message_request_key(KeyCode::Char('d'));
+        assert!(!app.conversations.contains_key("+1"));
+        assert!(!app.conversation_order.contains(&"+1".to_string()));
+        assert!(app.active_conversation.is_none());
+        assert!(!app.show_message_request);
+        assert!(matches!(
+            req,
+            Some(SendRequest::MessageRequestResponse { ref response_type, .. })
+            if response_type == "delete"
+        ));
+    }
+
+    #[test]
+    fn esc_closes_message_request_overlay() {
+        let mut app = test_app();
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        app.active_conversation = Some("+1".to_string());
+        app.show_message_request = true;
+
+        let req = app.handle_message_request_key(KeyCode::Esc);
+        assert!(req.is_none());
+        assert!(!app.show_message_request);
+        assert!(app.active_conversation.is_none());
+    }
+
+    #[test]
+    fn bell_skipped_for_unaccepted_conversations() {
+        let mut app = test_app();
+        // First message creates the conversation (unaccepted)
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        // Bell should NOT have been set
+        assert!(!app.pending_bell);
+    }
+
+    #[test]
+    fn read_receipts_not_sent_for_unaccepted_conversations() {
+        let mut app = test_app();
+        app.send_read_receipts = true;
+        // Create unaccepted conversation and switch to it
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        assert!(!app.conversations["+1"].accepted);
+
+        // Try to queue read receipts — should be empty since conv is unaccepted
+        app.queue_read_receipts_for_conv("+1", 0);
+        assert!(app.pending_read_receipts.is_empty());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -162,6 +162,17 @@ impl Database {
             )?;
         }
 
+        if version < 8 {
+            self.conn.execute_batch(
+                "
+                BEGIN;
+                ALTER TABLE conversations ADD COLUMN accepted INTEGER NOT NULL DEFAULT 1;
+                UPDATE schema_version SET version = 8;
+                COMMIT;
+                ",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -177,26 +188,43 @@ impl Database {
         Ok(())
     }
 
+    pub fn update_accepted(&self, id: &str, accepted: bool) -> Result<()> {
+        self.conn.execute(
+            "UPDATE conversations SET accepted = ?2 WHERE id = ?1",
+            params![id, accepted as i32],
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_conversation(&self, id: &str) -> Result<()> {
+        self.conn.execute("DELETE FROM reactions WHERE conversation_id = ?1", params![id])?;
+        self.conn.execute("DELETE FROM messages WHERE conversation_id = ?1", params![id])?;
+        self.conn.execute("DELETE FROM read_markers WHERE conversation_id = ?1", params![id])?;
+        self.conn.execute("DELETE FROM conversations WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+
     /// Load all conversations with their most recent messages (up to `msg_limit`).
     pub fn load_conversations(&self, msg_limit: usize) -> Result<Vec<Conversation>> {
         let mut stmt = self
             .conn
-            .prepare("SELECT id, name, is_group, expiration_timer FROM conversations")?;
+            .prepare("SELECT id, name, is_group, expiration_timer, accepted FROM conversations")?;
 
-        let convs: Vec<(String, String, bool, i64)> = stmt
+        let convs: Vec<(String, String, bool, i64, bool)> = stmt
             .query_map([], |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,
                     row.get::<_, i32>(2)? != 0,
                     row.get::<_, i64>(3)?,
+                    row.get::<_, i32>(4)? != 0,
                 ))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
 
         let mut result = Vec::with_capacity(convs.len());
 
-        for (id, name, is_group, expiration_timer) in convs {
+        for (id, name, is_group, expiration_timer, accepted) in convs {
             // Load last N messages
             let mut msg_stmt = self.conn.prepare(
                 "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms FROM messages
@@ -293,6 +321,7 @@ impl Database {
                 unread,
                 is_group,
                 expiration_timer,
+                accepted,
             });
         }
 
@@ -857,6 +886,42 @@ mod tests {
         let results = db.search_messages("+1", "hello", 50).unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].1, "real hello");
+    }
+
+    #[test]
+    fn migration_v8_defaults_accepted_to_1() {
+        let db = test_db();
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        let convs = db.load_conversations(100).unwrap();
+        assert!(convs[0].accepted);
+    }
+
+    #[test]
+    fn update_accepted_round_trip() {
+        let db = test_db();
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        db.update_accepted("+1", false).unwrap();
+        let convs = db.load_conversations(100).unwrap();
+        assert!(!convs[0].accepted);
+
+        db.update_accepted("+1", true).unwrap();
+        let convs = db.load_conversations(100).unwrap();
+        assert!(convs[0].accepted);
+    }
+
+    #[test]
+    fn delete_conversation_removes_all_data() {
+        let db = test_db();
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello", false, None, 1000).unwrap();
+        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍").unwrap();
+        db.save_read_marker("+1", 1).unwrap();
+
+        db.delete_conversation("+1").unwrap();
+
+        let convs = db.load_conversations(100).unwrap();
+        assert!(convs.is_empty());
+        assert_eq!(db.load_reactions("+1").unwrap().len(), 0);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -586,6 +586,17 @@ async fn dispatch_send(
                 app.status_message = format!("Left group \"{}\"", name);
             }
         }
+        SendRequest::MessageRequestResponse { recipient, is_group, response_type } => {
+            if let Err(e) = signal_client.send_message_request_response(&recipient, is_group, &response_type).await {
+                app.status_message = format!("message request error: {e}");
+            } else {
+                app.status_message = match response_type.as_str() {
+                    "accept" => "Message request accepted".to_string(),
+                    "delete" => "Message request deleted".to_string(),
+                    _ => String::new(),
+                };
+            }
+        }
     }
 }
 
@@ -862,6 +873,7 @@ fn populate_demo_data(app: &mut App) {
         unread: 0,
         is_group: false,
         expiration_timer: 0,
+        accepted: true,
     };
 
     // --- Bob: code review ---
@@ -877,6 +889,7 @@ fn populate_demo_data(app: &mut App) {
         unread: 0,
         is_group: false,
         expiration_timer: 0,
+        accepted: true,
     };
 
     // --- Carol: single unread ---
@@ -890,6 +903,7 @@ fn populate_demo_data(app: &mut App) {
         unread: 1,
         is_group: false,
         expiration_timer: 0,
+        accepted: true,
     };
 
     // --- Dave: older meetup conversation ---
@@ -905,6 +919,7 @@ fn populate_demo_data(app: &mut App) {
         unread: 0,
         is_group: false,
         expiration_timer: 0,
+        accepted: true,
     };
 
     // --- #Rust Devs: group technical discussion with @mentions ---
@@ -926,6 +941,7 @@ fn populate_demo_data(app: &mut App) {
         unread: 0,
         is_group: true,
         expiration_timer: 0,
+        accepted: true,
     };
 
     // --- #Family: group with unread ---
@@ -943,6 +959,7 @@ fn populate_demo_data(app: &mut App) {
         unread: 2,
         is_group: true,
         expiration_timer: 0,
+        accepted: true,
     };
 
     // Insert conversations and set ordering

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -513,6 +513,40 @@ impl SignalClient {
         Ok(())
     }
 
+    /// Accept or delete a message request.
+    pub async fn send_message_request_response(
+        &self,
+        recipient: &str,
+        is_group: bool,
+        response_type: &str,
+    ) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("sendMessageRequestResponse".to_string(), Instant::now()));
+        }
+        let mut params = serde_json::json!({
+            "type": response_type,
+            "account": self.account,
+        });
+        if is_group {
+            params["groupId"] = serde_json::json!(recipient);
+        } else {
+            params["recipient"] = serde_json::json!([recipient]);
+        }
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "sendMessageRequestResponse".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send message request response to signal-cli stdin")?;
+        Ok(())
+    }
+
     /// Set the disappearing message timer for a 1:1 contact.
     pub async fn send_update_contact_expiration(
         &self,
@@ -772,7 +806,7 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
                 .collect();
             Some(SignalEvent::GroupList(groups))
         }
-        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" => None, // fire-and-forget, no action needed
+        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" => None, // fire-and-forget, no action needed
         _ => None,
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -490,6 +490,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_group_menu(frame, app, size);
     }
 
+    // Message request overlay
+    if app.show_message_request {
+        draw_message_request(frame, app, size);
+    }
+
     // Action menu overlay
     if app.show_action_menu {
         draw_action_menu(frame, app, size);
@@ -548,8 +553,10 @@ fn draw_sidebar(frame: &mut Frame, app: &App, area: Rect) {
                 spans.push(Span::raw("  "));
             }
 
-            // Unread dot
-            if has_unread && !is_active {
+            // Unread / message request marker
+            if !conv.accepted {
+                spans.push(Span::styled("? ", Style::default().fg(Color::Magenta)));
+            } else if has_unread && !is_active {
                 spans.push(Span::styled("• ", Style::default().fg(Color::Yellow)));
             } else {
                 spans.push(Span::raw("  "));
@@ -1293,6 +1300,45 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             frame.render_widget(popup, inner);
         }
     }
+}
+
+fn draw_message_request(frame: &mut Frame, app: &App, area: Rect) {
+    let conv_id = match app.active_conversation.as_ref() {
+        Some(id) => id,
+        None => return,
+    };
+    let conv = match app.conversations.get(conv_id) {
+        Some(c) => c,
+        None => return,
+    };
+
+    let msg_count = conv.messages.len();
+    let name = &conv.name;
+    let phone = &conv.id;
+
+    let (popup_area, block) = centered_popup(frame, area, 36, 9, " Message Request ");
+    frame.render_widget(block, popup_area);
+
+    let inner = popup_area.inner(ratatui::layout::Margin { vertical: 1, horizontal: 2 });
+    let lines = vec![
+        Line::from(Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(phone.as_str(), Style::default().fg(Color::DarkGray))),
+        Line::from(Span::styled(
+            format!("{} message{}", msg_count, if msg_count == 1 { "" } else { "s" }),
+            Style::default().fg(Color::Gray),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("(a)", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled("ccept / ", Style::default().fg(Color::Gray)),
+            Span::styled("(d)", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
+            Span::styled("elete", Style::default().fg(Color::Gray)),
+        ]),
+        Line::from(Span::styled("Esc to go back", Style::default().fg(Color::DarkGray))),
+    ];
+
+    let text = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
+    frame.render_widget(text, inner);
 }
 
 fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary
- Detect message requests: incoming 1:1 messages from unknown senders create unaccepted conversations
- Sidebar shows `?` in Magenta for unaccepted conversations instead of the unread dot
- Dialog overlay on unaccepted conversations: **(a)ccept** / **(d)elete** / **Esc**
- Accept sends `sendMessageRequestResponse` RPC with type=accept, marks conversation accepted
- Delete sends RPC with type=delete, removes conversation entirely from state and DB
- Contact sync auto-accepts unaccepted conversations whose sender appears in the contact list
- Notifications (bell) and read receipts suppressed for unaccepted conversations
- DB schema v8: `accepted` column on conversations (defaults to 1 for existing data)
- `delete_conversation()` cascade-deletes messages, reactions, and read markers
- 11 new unit tests covering detection, key handling, guards, and DB operations

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` — all 201 tests pass (11 new)
- [ ] Manual: receive a message from an unknown number, verify `?` marker and overlay
- [ ] Manual: press `a` to accept, verify conversation becomes normal
- [ ] Manual: press `d` to delete, verify conversation removed
- [ ] Manual: verify no bell rings for unaccepted conversations
- [ ] Manual: verify contact sync auto-accepts matching conversations

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)