### PR TITLE
Add /block and /unblock commands (#60)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -181,6 +181,8 @@ pub struct App {
     pub notify_group: bool,
     /// Conversations muted from notifications
     pub muted_conversations: HashSet<String>,
+    /// Conversations blocked via signal-cli
+    pub blocked_conversations: HashSet<String>,
     /// Autocomplete popup visible
     pub autocomplete_visible: bool,
     /// Indices into COMMANDS for current matches
@@ -400,6 +402,14 @@ pub enum SendRequest {
         recipient: String,
         is_group: bool,
         response_type: String,
+    },
+    Block {
+        recipient: String,
+        is_group: bool,
+    },
+    Unblock {
+        recipient: String,
+        is_group: bool,
     },
 }
 
@@ -1633,6 +1643,7 @@ impl App {
             notify_direct: true,
             notify_group: true,
             muted_conversations: HashSet::new(),
+            blocked_conversations: HashSet::new(),
             autocomplete_visible: false,
             autocomplete_candidates: Vec::new(),
             autocomplete_index: 0,
@@ -1754,6 +1765,7 @@ impl App {
 
         self.conversation_order = order;
         self.muted_conversations = self.db.load_muted()?;
+        self.blocked_conversations = self.db.load_blocked()?;
 
         // Fix 1:1 conversations still named as phone numbers: scan message senders
         // for a real display name (from source_name in previous sessions).
@@ -1806,6 +1818,9 @@ impl App {
             None => return,
         };
         if !conv.accepted {
+            return;
+        }
+        if self.blocked_conversations.contains(conv_id) {
             return;
         }
         // Collect timestamps grouped by sender phone number
@@ -2264,11 +2279,11 @@ impl App {
                         return self.build_typing_request(true);
                     }
                     // Send typing start if not already sent, buffer is non-empty,
-                    // input is not a command, and there's an active conversation
+                    // input is not a command, conversation is active and not blocked
                     if !self.typing_sent
                         && !self.input_buffer.is_empty()
                         && !self.input_buffer.starts_with('/')
-                        && self.active_conversation.is_some()
+                        && self.active_conversation.as_ref().is_some_and(|id| !self.blocked_conversations.contains(id))
                     {
                         self.typing_sent = true;
                         return self.build_typing_request(false);
@@ -2552,7 +2567,7 @@ impl App {
             }
             let conv_accepted = self.conversations.get(&conv_id).map(|c| c.accepted).unwrap_or(true);
             let type_enabled = if is_group { self.notify_group } else { self.notify_direct };
-            if type_enabled && conv_accepted && !self.muted_conversations.contains(&conv_id) {
+            if type_enabled && conv_accepted && !self.muted_conversations.contains(&conv_id) && !self.blocked_conversations.contains(&conv_id) {
                 self.pending_bell = true;
             }
         }
@@ -2560,7 +2575,7 @@ impl App {
         // Active conversation: send read receipt and advance read marker
         let conv_accepted = self.conversations.get(&conv_id).map(|c| c.accepted).unwrap_or(true);
         if is_active {
-            if !msg.is_outgoing && conv_accepted {
+            if !msg.is_outgoing && conv_accepted && !self.blocked_conversations.contains(&conv_id) {
                 self.queue_single_read_receipt(&sender_id, msg_ts_ms);
             }
             if let Some(conv) = self.conversations.get(&conv_id) {
@@ -3591,6 +3606,45 @@ impl App {
                     }
                 } else {
                     self.status_message = "no active conversation to mute".to_string();
+                }
+            }
+            InputAction::Block => {
+                if let Some(ref conv_id) = self.active_conversation {
+                    let conv_id = conv_id.clone();
+                    let is_group = self.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                    if self.blocked_conversations.contains(&conv_id) {
+                        let name = self.conversations.get(&conv_id)
+                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        self.status_message = format!("{name} is already blocked");
+                    } else {
+                        let name = self.conversations.get(&conv_id)
+                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        self.status_message = format!("blocked {name}");
+                        self.blocked_conversations.insert(conv_id.clone());
+                        db_warn(self.db.set_blocked(&conv_id, true), "set_blocked");
+                        return Some(SendRequest::Block { recipient: conv_id, is_group });
+                    }
+                } else {
+                    self.status_message = "no active conversation to block".to_string();
+                }
+            }
+            InputAction::Unblock => {
+                if let Some(ref conv_id) = self.active_conversation {
+                    let conv_id = conv_id.clone();
+                    let is_group = self.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                    if self.blocked_conversations.remove(&conv_id) {
+                        let name = self.conversations.get(&conv_id)
+                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        self.status_message = format!("unblocked {name}");
+                        db_warn(self.db.set_blocked(&conv_id, false), "set_blocked");
+                        return Some(SendRequest::Unblock { recipient: conv_id, is_group });
+                    } else {
+                        let name = self.conversations.get(&conv_id)
+                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        self.status_message = format!("{name} is not blocked");
+                    }
+                } else {
+                    self.status_message = "no active conversation to unblock".to_string();
                 }
             }
             InputAction::Settings => {
@@ -6310,6 +6364,105 @@ mod tests {
         assert!(!app.conversations["+1"].accepted);
 
         // Try to queue read receipts — should be empty since conv is unaccepted
+        app.queue_read_receipts_for_conv("+1", 0);
+        assert!(app.pending_read_receipts.is_empty());
+    }
+
+    // --- Block / Unblock tests ---
+
+    #[test]
+    fn block_adds_to_set_and_returns_send_request() {
+        let mut app = test_app();
+        app.get_or_create_conversation("+1", "Alice", false);
+        app.active_conversation = Some("+1".to_string());
+        app.input_buffer = "/block".to_string();
+        let req = app.handle_input();
+        assert!(app.blocked_conversations.contains("+1"));
+        assert!(matches!(req, Some(SendRequest::Block { ref recipient, is_group }) if recipient == "+1" && !is_group));
+        assert!(app.status_message.contains("blocked"));
+    }
+
+    #[test]
+    fn unblock_removes_from_set_and_returns_send_request() {
+        let mut app = test_app();
+        app.get_or_create_conversation("+1", "Alice", false);
+        app.active_conversation = Some("+1".to_string());
+        app.blocked_conversations.insert("+1".to_string());
+        app.input_buffer = "/unblock".to_string();
+        let req = app.handle_input();
+        assert!(!app.blocked_conversations.contains("+1"));
+        assert!(matches!(req, Some(SendRequest::Unblock { ref recipient, is_group }) if recipient == "+1" && !is_group));
+        assert!(app.status_message.contains("unblocked"));
+    }
+
+    #[test]
+    fn block_already_blocked_shows_status() {
+        let mut app = test_app();
+        app.get_or_create_conversation("+1", "Alice", false);
+        app.active_conversation = Some("+1".to_string());
+        app.blocked_conversations.insert("+1".to_string());
+        app.input_buffer = "/block".to_string();
+        let req = app.handle_input();
+        assert!(req.is_none());
+        assert!(app.status_message.contains("already blocked"));
+    }
+
+    #[test]
+    fn unblock_not_blocked_shows_status() {
+        let mut app = test_app();
+        app.get_or_create_conversation("+1", "Alice", false);
+        app.active_conversation = Some("+1".to_string());
+        app.input_buffer = "/unblock".to_string();
+        let req = app.handle_input();
+        assert!(req.is_none());
+        assert!(app.status_message.contains("not blocked"));
+    }
+
+    #[test]
+    fn block_no_active_conversation() {
+        let mut app = test_app();
+        app.input_buffer = "/block".to_string();
+        let req = app.handle_input();
+        assert!(req.is_none());
+        assert!(app.status_message.contains("no active conversation"));
+    }
+
+    #[test]
+    fn unblock_no_active_conversation() {
+        let mut app = test_app();
+        app.input_buffer = "/unblock".to_string();
+        let req = app.handle_input();
+        assert!(req.is_none());
+        assert!(app.status_message.contains("no active conversation"));
+    }
+
+    #[test]
+    fn bell_skipped_for_blocked_conversations() {
+        let mut app = test_app();
+        // Create accepted conversation first, then block it
+        app.get_or_create_conversation("+1", "Alice", false);
+        if let Some(conv) = app.conversations.get_mut("+1") {
+            conv.accepted = true;
+        }
+        app.blocked_conversations.insert("+1".to_string());
+        // Receive a message — bell should NOT fire
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+        assert!(!app.pending_bell);
+    }
+
+    #[test]
+    fn read_receipts_not_sent_for_blocked_conversations() {
+        let mut app = test_app();
+        app.send_read_receipts = true;
+        // Create accepted conversation, block it, add a message
+        app.get_or_create_conversation("+1", "Alice", false);
+        if let Some(conv) = app.conversations.get_mut("+1") {
+            conv.accepted = true;
+        }
+        app.blocked_conversations.insert("+1".to_string());
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
+
+        // Try to queue read receipts — should be empty since conv is blocked
         app.queue_read_receipts_for_conv("+1", 0);
         assert!(app.pending_read_receipts.is_empty());
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -173,6 +173,17 @@ impl Database {
             )?;
         }
 
+        if version < 9 {
+            self.conn.execute_batch(
+                "
+                BEGIN;
+                ALTER TABLE conversations ADD COLUMN blocked INTEGER NOT NULL DEFAULT 0;
+                UPDATE schema_version SET version = 9;
+                COMMIT;
+                ",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -635,6 +646,26 @@ impl Database {
         Ok(ids.into_iter().collect())
     }
 
+    // --- Blocked conversations ---
+
+    pub fn set_blocked(&self, conv_id: &str, blocked: bool) -> Result<()> {
+        self.conn.execute(
+            "UPDATE conversations SET blocked = ?2 WHERE id = ?1",
+            params![conv_id, blocked as i32],
+        )?;
+        Ok(())
+    }
+
+    pub fn load_blocked(&self) -> Result<std::collections::HashSet<String>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id FROM conversations WHERE blocked = 1",
+        )?;
+        let ids: Vec<String> = stmt
+            .query_map([], |row| row.get(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(ids.into_iter().collect())
+    }
+
     // --- Disappearing messages ---
 
     pub fn update_expiration_timer(&self, conv_id: &str, seconds: i64) -> Result<()> {
@@ -922,6 +953,30 @@ mod tests {
         let convs = db.load_conversations(100).unwrap();
         assert!(convs.is_empty());
         assert_eq!(db.load_reactions("+1").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn migration_v9_defaults_blocked_to_0() {
+        let db = test_db();
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        let blocked = db.load_blocked().unwrap();
+        assert!(!blocked.contains("+1"));
+    }
+
+    #[test]
+    fn blocked_round_trip() {
+        let db = test_db();
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        db.upsert_conversation("+2", "Bob", false).unwrap();
+
+        db.set_blocked("+1", true).unwrap();
+        let blocked = db.load_blocked().unwrap();
+        assert!(blocked.contains("+1"));
+        assert!(!blocked.contains("+2"));
+
+        db.set_blocked("+1", false).unwrap();
+        let blocked = db.load_blocked().unwrap();
+        assert!(!blocked.contains("+1"));
     }
 
     #[test]

--- a/src/input.rs
+++ b/src/input.rs
@@ -12,6 +12,8 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo { name: "/sidebar",  alias: "/sb", args: "",        description: "Toggle sidebar" },
     CommandInfo { name: "/bell",     alias: "",    args: "[type]",  description: "Toggle notifications (direct/group)" },
     CommandInfo { name: "/mute",     alias: "",    args: "",        description: "Mute/unmute current chat" },
+    CommandInfo { name: "/block",    alias: "",    args: "",        description: "Block current contact/group" },
+    CommandInfo { name: "/unblock",  alias: "",    args: "",        description: "Unblock current contact/group" },
     CommandInfo { name: "/attach",   alias: "/a",  args: "",        description: "Attach a file" },
     CommandInfo { name: "/search",   alias: "/s",  args: "<query>", description: "Search messages" },
     CommandInfo { name: "/contacts", alias: "/c",  args: "",        description: "Browse contacts" },
@@ -39,6 +41,10 @@ pub enum InputAction {
     ToggleBell(Option<String>),
     /// Mute/unmute the current conversation
     ToggleMute,
+    /// Block the current contact/group
+    Block,
+    /// Unblock the current contact/group
+    Unblock,
     /// Show help text
     Help,
     /// Open settings overlay
@@ -91,6 +97,8 @@ pub fn parse_input(input: &str) -> InputAction {
             }
         }
         "/mute" => InputAction::ToggleMute,
+        "/block" => InputAction::Block,
+        "/unblock" => InputAction::Unblock,
         "/attach" | "/a" => InputAction::Attach,
         "/search" | "/s" => {
             if arg.is_empty() {
@@ -371,6 +379,16 @@ mod tests {
         assert!(parse_duration_to_seconds("").is_err());
         assert!(parse_duration_to_seconds("0s").is_err());
         assert!(parse_duration_to_seconds("-1h").is_err());
+    }
+
+    #[test]
+    fn block_command() {
+        assert!(matches!(parse_input("/block"), InputAction::Block));
+    }
+
+    #[test]
+    fn unblock_command() {
+        assert!(matches!(parse_input("/unblock"), InputAction::Unblock));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -586,6 +586,16 @@ async fn dispatch_send(
                 app.status_message = format!("Left group \"{}\"", name);
             }
         }
+        SendRequest::Block { recipient, is_group } => {
+            if let Err(e) = signal_client.block_contact(&recipient, is_group).await {
+                app.status_message = format!("block error: {e}");
+            }
+        }
+        SendRequest::Unblock { recipient, is_group } => {
+            if let Err(e) = signal_client.unblock_contact(&recipient, is_group).await {
+                app.status_message = format!("unblock error: {e}");
+            }
+        }
         SendRequest::MessageRequestResponse { recipient, is_group, response_type } => {
             if let Err(e) = signal_client.send_message_request_response(&recipient, is_group, &response_type).await {
                 app.status_message = format!("message request error: {e}");

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -666,6 +666,62 @@ impl SignalClient {
         Ok(())
     }
 
+    /// Block a contact or group.
+    pub async fn block_contact(&self, recipient: &str, is_group: bool) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("block".to_string(), Instant::now()));
+        }
+        let params = if is_group {
+            serde_json::json!({
+                "groupId": [recipient],
+                "account": self.account,
+            })
+        } else {
+            serde_json::json!({
+                "recipient": [recipient],
+                "account": self.account,
+            })
+        };
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "block".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send block to signal-cli stdin")?;
+        Ok(())
+    }
+
+    /// Unblock a contact or group.
+    pub async fn unblock_contact(&self, recipient: &str, is_group: bool) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("unblock".to_string(), Instant::now()));
+        }
+        let params = if is_group {
+            serde_json::json!({
+                "groupId": [recipient],
+                "account": self.account,
+            })
+        } else {
+            serde_json::json!({
+                "recipient": [recipient],
+                "account": self.account,
+            })
+        };
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "unblock".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send unblock to signal-cli stdin")?;
+        Ok(())
+    }
+
     /// Leave (quit) a group.
     pub async fn quit_group(&self, group_id: &str) -> Result<()> {
         let id = Uuid::new_v4().to_string();
@@ -806,7 +862,7 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
                 .collect();
             Some(SignalEvent::GroupList(groups))
         }
-        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" => None, // fire-and-forget, no action needed
+        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" | "block" | "unblock" => None, // fire-and-forget, no action needed
         _ => None,
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -588,6 +588,9 @@ fn draw_sidebar(frame: &mut Frame, app: &App, area: Rect) {
             if is_muted {
                 spans.push(Span::styled(" ~", Style::default().fg(Color::DarkGray)));
             }
+            if app.blocked_conversations.contains(id) {
+                spans.push(Span::styled(" x", Style::default().fg(Color::Red)));
+            }
 
             ListItem::new(Line::from(spans))
         })


### PR DESCRIPTION
## Summary
- Adds `/block` and `/unblock` slash commands that call signal-cli's `block`/`unblock` JSON-RPC methods
- Persists blocked state in SQLite via schema v9 migration (`blocked` column on `conversations`)
- Guards bells, read receipts, and typing indicators for blocked conversations
- Shows red `x` indicator in sidebar for blocked conversations (can appear alongside `~` for muted)

## Changes
| File | What |
|------|------|
| `src/input.rs` | `/block`, `/unblock` in COMMANDS, InputAction enum, parse_input |
| `src/db.rs` | Schema v9 migration, `set_blocked()`, `load_blocked()` |
| `src/app.rs` | `blocked_conversations` HashSet, `SendRequest::Block`/`Unblock`, handle_input arms, bell/receipt/typing guards |
| `src/signal/client.rs` | `block_contact()`, `unblock_contact()` RPC methods, fire-and-forget in parse_rpc_result |
| `src/main.rs` | `Block`/`Unblock` arms in `dispatch_send()` |
| `src/ui.rs` | Red ` x` sidebar indicator |

## Test plan
- [x] `cargo clippy --tests -- -D warnings` — zero warnings
- [x] `cargo test` — all 213 tests pass (12 new tests added)
- [ ] Manual: `/block` on a contact shows "blocked {name}", sidebar shows red `x`
- [ ] Manual: `/unblock` reverses the block, removes sidebar indicator
- [ ] Manual: Blocked conversation does not trigger bell on incoming message
- [ ] Manual: No read receipts sent for messages in blocked conversations
- [ ] Manual: No typing indicator sent when typing in blocked conversation

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)