### PR TITLE
Add selectable color themes (#18)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use crate::db::Database;
 use crate::image_render;
 use crate::image_render::ImageProtocol;
 use crate::input::{self, InputAction, COMMANDS};
+use crate::theme::{self, Theme};
 use crate::signal::types::{Contact, Group, Mention, MessageStatus, Reaction, SignalEvent, SignalMessage, StyleType, TextStyle};
 
 /// Log a database error via debug_log (no-op when --debug is off).
@@ -326,6 +327,14 @@ pub struct App {
     pub mouse_input_prefix_len: u16,
     /// Enable mouse support (click sidebar, scroll messages, click links)
     pub mouse_enabled: bool,
+    /// Active color theme
+    pub theme: Theme,
+    /// Theme picker overlay visible
+    pub show_theme_picker: bool,
+    /// Cursor position in theme picker
+    pub theme_index: usize,
+    /// All available themes (built-in + custom)
+    pub available_themes: Vec<Theme>,
 }
 
 /// A search result entry.
@@ -535,6 +544,7 @@ impl App {
         }
         let mut config = crate::config::Config::load(None).unwrap_or_default();
         config.account = self.account.clone();
+        config.theme = self.theme.name.clone();
         for def in SETTINGS {
             if let Some(save_fn) = def.save {
                 save_fn(&mut config, (def.get)(self));
@@ -564,10 +574,12 @@ impl App {
     }
 
     /// Handle a key press while the settings overlay is open.
+    /// The last entry (index == SETTINGS.len()) is the Theme selector.
     pub fn handle_settings_key(&mut self, code: KeyCode) {
+        let max_index = SETTINGS.len(); // toggles 0..len-1, theme at len
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
-                if self.settings_index < SETTINGS.len() - 1 {
+                if self.settings_index < max_index {
                     self.settings_index += 1;
                 }
             }
@@ -575,11 +587,46 @@ impl App {
                 self.settings_index = self.settings_index.saturating_sub(1);
             }
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
-                self.toggle_setting(self.settings_index);
+                if self.settings_index == SETTINGS.len() {
+                    // Theme entry — open picker
+                    self.show_settings = false;
+                    self.save_settings();
+                    self.show_theme_picker = true;
+                    self.theme_index = self.available_themes.iter()
+                        .position(|t| t.name == self.theme.name)
+                        .unwrap_or(0);
+                } else {
+                    self.toggle_setting(self.settings_index);
+                }
             }
             KeyCode::Esc | KeyCode::Char('q') => {
                 self.show_settings = false;
                 self.save_settings();
+            }
+            _ => {}
+        }
+    }
+
+    /// Handle a key press while the theme picker overlay is open.
+    pub fn handle_theme_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.theme_index < self.available_themes.len().saturating_sub(1) {
+                    self.theme_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.theme_index = self.theme_index.saturating_sub(1);
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => {
+                if let Some(selected) = self.available_themes.get(self.theme_index) {
+                    self.theme = selected.clone();
+                    self.save_settings();
+                }
+                self.show_theme_picker = false;
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.show_theme_picker = false;
             }
             _ => {}
         }
@@ -1733,6 +1780,10 @@ impl App {
             mouse_input_area: Rect::default(),
             mouse_input_prefix_len: 0,
             mouse_enabled: true,
+            theme: theme::default_theme(),
+            show_theme_picker: false,
+            theme_index: 0,
+            available_themes: theme::all_themes(),
         }
     }
 
@@ -2008,6 +2059,10 @@ impl App {
         }
         if self.show_search {
             self.handle_search_key(code);
+            return (true, None);
+        }
+        if self.show_theme_picker {
+            self.handle_theme_key(code);
             return (true, None);
         }
         if self.show_settings {
@@ -3689,6 +3744,12 @@ impl App {
                 self.contacts_filter.clear();
                 self.refresh_contacts_filter();
             }
+            InputAction::Theme => {
+                self.show_theme_picker = true;
+                self.theme_index = self.available_themes.iter()
+                    .position(|t| t.name == self.theme.name)
+                    .unwrap_or(0);
+            }
             InputAction::Group => {
                 self.group_menu_state = Some(GroupMenuState::Menu);
                 self.group_menu_index = 0;
@@ -4290,6 +4351,7 @@ impl App {
             || self.show_delete_confirm
             || self.group_menu_state.is_some()
             || self.show_message_request
+            || self.show_theme_picker
             || self.autocomplete_visible
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,10 +55,18 @@ pub struct Config {
     /// Enable mouse support (click sidebar, scroll messages, click links)
     #[serde(default = "default_true")]
     pub mouse_enabled: bool,
+
+    /// Color theme name (matches a built-in or custom theme)
+    #[serde(default = "default_theme")]
+    pub theme: String,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_theme() -> String {
+    "Default".to_string()
 }
 
 fn default_signal_cli_path() -> String {
@@ -87,6 +95,7 @@ impl Default for Config {
             reaction_verbose: false,
             send_read_receipts: true,
             mouse_enabled: true,
+            theme: default_theme(),
         }
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -20,6 +20,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo { name: "/settings", alias: "",    args: "",        description: "Open settings" },
     CommandInfo { name: "/disappearing", alias: "/dm", args: "<duration>", description: "Set disappearing timer (off/30s/5m/1h/1d/1w)" },
     CommandInfo { name: "/group",    alias: "/g",  args: "",        description: "Group management" },
+    CommandInfo { name: "/theme",    alias: "/t",  args: "",        description: "Change color theme" },
     CommandInfo { name: "/help",     alias: "/h",  args: "",        description: "Show help" },
     CommandInfo { name: "/quit",     alias: "/q",  args: "",        description: "Exit signal-tui" },
 ];
@@ -59,6 +60,8 @@ pub enum InputAction {
     SetDisappearing(String),
     /// Open group management menu
     Group,
+    /// Open theme picker
+    Theme,
     /// Unknown command
     Unknown(String),
 }
@@ -117,6 +120,7 @@ pub fn parse_input(input: &str) -> InputAction {
             }
         }
         "/group" | "/g" => InputAction::Group,
+        "/theme" | "/t" => InputAction::Theme,
         "/help" | "/h" => InputAction::Help,
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod input;
 mod link;
 mod setup;
 mod signal;
+mod theme;
 mod ui;
 
 use std::io;
@@ -342,6 +343,7 @@ fn ratatui_color_to_crossterm(c: Color) -> crossterm::style::Color {
 fn emit_osc8_links(
     backend: &mut CrosstermBackend<io::Stdout>,
     links: &[ui::LinkRegion],
+    link_color: Color,
 ) -> Result<()> {
     if links.is_empty() {
         return Ok(());
@@ -353,7 +355,7 @@ fn emit_osc8_links(
         queue!(backend, MoveTo(link.x, link.y))?;
         queue!(
             backend,
-            SetForegroundColor(crossterm::style::Color::Blue)
+            SetForegroundColor(ratatui_color_to_crossterm(link_color))
         )?;
         if let Some(bg) = link.bg {
             // Preserve the background color (e.g. highlight) that ratatui rendered.
@@ -629,6 +631,8 @@ async fn run_app(
     app.reaction_verbose = config.reaction_verbose;
     app.send_read_receipts = config.send_read_receipts;
     app.mouse_enabled = config.mouse_enabled;
+    app.available_themes = theme::all_themes();
+    app.theme = theme::find_theme(&config.theme);
     app.load_from_db()?;
     app.set_connected();
 
@@ -651,7 +655,7 @@ async fn run_app(
 
         // Render
         terminal.draw(|frame| ui::draw(frame, &mut app))?;
-        emit_osc8_links(terminal.backend_mut(), &app.link_regions)?;
+        emit_osc8_links(terminal.backend_mut(), &app.link_regions, app.theme.link)?;
         if app.native_images {
             emit_native_images(terminal.backend_mut(), &mut app)?;
         }
@@ -795,7 +799,7 @@ async fn run_demo_app(
         }
 
         terminal.draw(|frame| ui::draw(frame, &mut app))?;
-        emit_osc8_links(terminal.backend_mut(), &app.link_regions)?;
+        emit_osc8_links(terminal.backend_mut(), &app.link_regions, app.theme.link)?;
         if app.native_images {
             emit_native_images(terminal.backend_mut(), &mut app)?;
         }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,684 @@
+use ratatui::style::Color;
+use serde::{Deserialize, Serialize};
+
+/// A complete color theme for the UI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Theme {
+    pub name: String,
+
+    // Base
+    #[serde(with = "color_serde")]
+    pub bg: Color,
+    #[serde(with = "color_serde")]
+    pub bg_selected: Color,
+    #[serde(with = "color_serde")]
+    pub fg: Color,
+    #[serde(with = "color_serde")]
+    pub fg_secondary: Color,
+    #[serde(with = "color_serde")]
+    pub fg_muted: Color,
+
+    // Accent
+    #[serde(with = "color_serde")]
+    pub accent: Color,
+    #[serde(with = "color_serde")]
+    pub accent_secondary: Color,
+
+    // Status indicators
+    #[serde(with = "color_serde")]
+    pub success: Color,
+    #[serde(with = "color_serde")]
+    pub error: Color,
+    #[serde(with = "color_serde")]
+    pub warning: Color,
+
+    // Messages
+    #[serde(with = "color_serde")]
+    pub sender_self: Color,
+    #[serde(with = "color_array_serde")]
+    pub sender_palette: [Color; 8],
+    #[serde(with = "color_serde")]
+    pub link: Color,
+    #[serde(with = "color_serde")]
+    pub mention: Color,
+    #[serde(with = "color_serde")]
+    pub quote: Color,
+    #[serde(with = "color_serde")]
+    pub system_msg: Color,
+    #[serde(with = "color_serde")]
+    pub msg_selected_bg: Color,
+
+    // Input box
+    #[serde(with = "color_serde")]
+    pub input_insert: Color,
+    #[serde(with = "color_serde")]
+    pub input_normal: Color,
+
+    // Status bar
+    #[serde(with = "color_serde")]
+    pub statusbar_bg: Color,
+    #[serde(with = "color_serde")]
+    pub statusbar_fg: Color,
+
+    // Receipt status colors
+    #[serde(with = "color_serde")]
+    pub receipt_failed: Color,
+    #[serde(with = "color_serde")]
+    pub receipt_sending: Color,
+    #[serde(with = "color_serde")]
+    pub receipt_sent: Color,
+    #[serde(with = "color_serde")]
+    pub receipt_delivered: Color,
+    #[serde(with = "color_serde")]
+    pub receipt_read: Color,
+    #[serde(with = "color_serde")]
+    pub receipt_viewed: Color,
+}
+
+// ---------------------------------------------------------------------------
+// Built-in themes
+// ---------------------------------------------------------------------------
+
+/// The default theme matching the original hardcoded colors.
+/// Uses named 16-color values so it adapts to the terminal palette.
+pub fn default_theme() -> Theme {
+    Theme {
+        name: "Default".into(),
+        bg: Color::Black,
+        bg_selected: Color::DarkGray,
+        fg: Color::White,
+        fg_secondary: Color::Gray,
+        fg_muted: Color::DarkGray,
+        accent: Color::Cyan,
+        accent_secondary: Color::Yellow,
+        success: Color::Green,
+        error: Color::Red,
+        warning: Color::Yellow,
+        sender_self: Color::Green,
+        sender_palette: [
+            Color::Cyan,
+            Color::Magenta,
+            Color::Yellow,
+            Color::Blue,
+            Color::LightRed,
+            Color::LightGreen,
+            Color::LightCyan,
+            Color::LightMagenta,
+        ],
+        link: Color::Blue,
+        mention: Color::Cyan,
+        quote: Color::DarkGray,
+        system_msg: Color::DarkGray,
+        msg_selected_bg: Color::Indexed(236),
+        input_insert: Color::Cyan,
+        input_normal: Color::Yellow,
+        statusbar_bg: Color::DarkGray,
+        statusbar_fg: Color::White,
+        receipt_failed: Color::Red,
+        receipt_sending: Color::DarkGray,
+        receipt_sent: Color::DarkGray,
+        receipt_delivered: Color::White,
+        receipt_read: Color::Green,
+        receipt_viewed: Color::Cyan,
+    }
+}
+
+fn catppuccin_mocha() -> Theme {
+    Theme {
+        name: "Catppuccin Mocha".into(),
+        bg: Color::Rgb(30, 30, 46),          // base
+        bg_selected: Color::Rgb(69, 71, 90), // surface1
+        fg: Color::Rgb(205, 214, 244),        // text
+        fg_secondary: Color::Rgb(166, 173, 200), // subtext0
+        fg_muted: Color::Rgb(108, 112, 134),  // overlay0
+        accent: Color::Rgb(203, 166, 247),     // mauve
+        accent_secondary: Color::Rgb(249, 226, 175), // yellow
+        success: Color::Rgb(166, 227, 161),    // green
+        error: Color::Rgb(243, 139, 168),      // red
+        warning: Color::Rgb(249, 226, 175),    // yellow
+        sender_self: Color::Rgb(166, 227, 161), // green
+        sender_palette: [
+            Color::Rgb(137, 180, 250), // blue
+            Color::Rgb(245, 194, 231), // pink
+            Color::Rgb(249, 226, 175), // yellow
+            Color::Rgb(116, 199, 236), // sapphire
+            Color::Rgb(243, 139, 168), // red
+            Color::Rgb(166, 227, 161), // green
+            Color::Rgb(148, 226, 213), // teal
+            Color::Rgb(203, 166, 247), // mauve
+        ],
+        link: Color::Rgb(137, 180, 250),       // blue
+        mention: Color::Rgb(203, 166, 247),    // mauve
+        quote: Color::Rgb(108, 112, 134),      // overlay0
+        system_msg: Color::Rgb(108, 112, 134), // overlay0
+        msg_selected_bg: Color::Rgb(49, 50, 68), // surface0
+        input_insert: Color::Rgb(203, 166, 247), // mauve
+        input_normal: Color::Rgb(249, 226, 175), // yellow
+        statusbar_bg: Color::Rgb(24, 24, 37),  // mantle
+        statusbar_fg: Color::Rgb(205, 214, 244), // text
+        receipt_failed: Color::Rgb(243, 139, 168),
+        receipt_sending: Color::Rgb(108, 112, 134),
+        receipt_sent: Color::Rgb(108, 112, 134),
+        receipt_delivered: Color::Rgb(205, 214, 244),
+        receipt_read: Color::Rgb(166, 227, 161),
+        receipt_viewed: Color::Rgb(137, 180, 250),
+    }
+}
+
+fn catppuccin_latte() -> Theme {
+    Theme {
+        name: "Catppuccin Latte".into(),
+        bg: Color::Rgb(239, 241, 245),        // base
+        bg_selected: Color::Rgb(188, 192, 204), // surface1
+        fg: Color::Rgb(76, 79, 105),           // text
+        fg_secondary: Color::Rgb(108, 111, 133), // subtext0
+        fg_muted: Color::Rgb(140, 143, 161),   // overlay0
+        accent: Color::Rgb(136, 57, 239),      // mauve
+        accent_secondary: Color::Rgb(223, 142, 29), // yellow
+        success: Color::Rgb(64, 160, 43),       // green
+        error: Color::Rgb(210, 15, 57),         // red
+        warning: Color::Rgb(223, 142, 29),      // yellow
+        sender_self: Color::Rgb(64, 160, 43),   // green
+        sender_palette: [
+            Color::Rgb(30, 102, 245),  // blue
+            Color::Rgb(234, 118, 203), // pink
+            Color::Rgb(223, 142, 29),  // yellow
+            Color::Rgb(32, 159, 181),  // sapphire
+            Color::Rgb(210, 15, 57),   // red
+            Color::Rgb(64, 160, 43),   // green
+            Color::Rgb(23, 146, 153),  // teal
+            Color::Rgb(136, 57, 239),  // mauve
+        ],
+        link: Color::Rgb(30, 102, 245),         // blue
+        mention: Color::Rgb(136, 57, 239),      // mauve
+        quote: Color::Rgb(140, 143, 161),       // overlay0
+        system_msg: Color::Rgb(140, 143, 161),  // overlay0
+        msg_selected_bg: Color::Rgb(204, 208, 218), // surface0
+        input_insert: Color::Rgb(136, 57, 239), // mauve
+        input_normal: Color::Rgb(223, 142, 29), // yellow
+        statusbar_bg: Color::Rgb(230, 233, 239), // mantle
+        statusbar_fg: Color::Rgb(76, 79, 105),  // text
+        receipt_failed: Color::Rgb(210, 15, 57),
+        receipt_sending: Color::Rgb(140, 143, 161),
+        receipt_sent: Color::Rgb(140, 143, 161),
+        receipt_delivered: Color::Rgb(76, 79, 105),
+        receipt_read: Color::Rgb(64, 160, 43),
+        receipt_viewed: Color::Rgb(30, 102, 245),
+    }
+}
+
+fn dracula() -> Theme {
+    Theme {
+        name: "Dracula".into(),
+        bg: Color::Rgb(40, 42, 54),           // background
+        bg_selected: Color::Rgb(68, 71, 90),  // current line
+        fg: Color::Rgb(248, 248, 242),         // foreground
+        fg_secondary: Color::Rgb(189, 147, 249), // purple (secondary info)
+        fg_muted: Color::Rgb(98, 114, 164),   // comment
+        accent: Color::Rgb(189, 147, 249),     // purple
+        accent_secondary: Color::Rgb(241, 250, 140), // yellow
+        success: Color::Rgb(80, 250, 123),     // green
+        error: Color::Rgb(255, 85, 85),        // red
+        warning: Color::Rgb(241, 250, 140),    // yellow
+        sender_self: Color::Rgb(80, 250, 123), // green
+        sender_palette: [
+            Color::Rgb(139, 233, 253), // cyan
+            Color::Rgb(255, 121, 198), // pink
+            Color::Rgb(241, 250, 140), // yellow
+            Color::Rgb(189, 147, 249), // purple
+            Color::Rgb(255, 85, 85),   // red
+            Color::Rgb(80, 250, 123),  // green
+            Color::Rgb(255, 184, 108), // orange
+            Color::Rgb(139, 233, 253), // cyan (alt)
+        ],
+        link: Color::Rgb(139, 233, 253),       // cyan
+        mention: Color::Rgb(255, 121, 198),    // pink
+        quote: Color::Rgb(98, 114, 164),       // comment
+        system_msg: Color::Rgb(98, 114, 164),  // comment
+        msg_selected_bg: Color::Rgb(55, 57, 69),
+        input_insert: Color::Rgb(189, 147, 249), // purple
+        input_normal: Color::Rgb(241, 250, 140), // yellow
+        statusbar_bg: Color::Rgb(33, 34, 44),
+        statusbar_fg: Color::Rgb(248, 248, 242),
+        receipt_failed: Color::Rgb(255, 85, 85),
+        receipt_sending: Color::Rgb(98, 114, 164),
+        receipt_sent: Color::Rgb(98, 114, 164),
+        receipt_delivered: Color::Rgb(248, 248, 242),
+        receipt_read: Color::Rgb(80, 250, 123),
+        receipt_viewed: Color::Rgb(139, 233, 253),
+    }
+}
+
+fn nord() -> Theme {
+    Theme {
+        name: "Nord".into(),
+        bg: Color::Rgb(46, 52, 64),           // nord0 polar night
+        bg_selected: Color::Rgb(67, 76, 94),  // nord2
+        fg: Color::Rgb(236, 239, 244),         // nord6 snow storm
+        fg_secondary: Color::Rgb(216, 222, 233), // nord4
+        fg_muted: Color::Rgb(76, 86, 106),    // nord3
+        accent: Color::Rgb(136, 192, 208),     // nord8 frost
+        accent_secondary: Color::Rgb(235, 203, 139), // nord13 aurora yellow
+        success: Color::Rgb(163, 190, 140),    // nord14 aurora green
+        error: Color::Rgb(191, 97, 106),       // nord11 aurora red
+        warning: Color::Rgb(235, 203, 139),    // nord13 aurora yellow
+        sender_self: Color::Rgb(163, 190, 140), // nord14
+        sender_palette: [
+            Color::Rgb(136, 192, 208), // nord8
+            Color::Rgb(180, 142, 173), // nord15 purple
+            Color::Rgb(235, 203, 139), // nord13
+            Color::Rgb(129, 161, 193), // nord9
+            Color::Rgb(191, 97, 106),  // nord11
+            Color::Rgb(163, 190, 140), // nord14
+            Color::Rgb(143, 188, 187), // nord7
+            Color::Rgb(208, 135, 112), // nord12 orange
+        ],
+        link: Color::Rgb(129, 161, 193),       // nord9
+        mention: Color::Rgb(180, 142, 173),    // nord15
+        quote: Color::Rgb(76, 86, 106),        // nord3
+        system_msg: Color::Rgb(76, 86, 106),   // nord3
+        msg_selected_bg: Color::Rgb(59, 66, 82), // nord1
+        input_insert: Color::Rgb(136, 192, 208), // nord8
+        input_normal: Color::Rgb(235, 203, 139), // nord13
+        statusbar_bg: Color::Rgb(59, 66, 82),  // nord1
+        statusbar_fg: Color::Rgb(236, 239, 244), // nord6
+        receipt_failed: Color::Rgb(191, 97, 106),
+        receipt_sending: Color::Rgb(76, 86, 106),
+        receipt_sent: Color::Rgb(76, 86, 106),
+        receipt_delivered: Color::Rgb(236, 239, 244),
+        receipt_read: Color::Rgb(163, 190, 140),
+        receipt_viewed: Color::Rgb(136, 192, 208),
+    }
+}
+
+fn gruvbox_dark() -> Theme {
+    Theme {
+        name: "Gruvbox Dark".into(),
+        bg: Color::Rgb(40, 40, 40),           // bg
+        bg_selected: Color::Rgb(80, 73, 69),  // bg2
+        fg: Color::Rgb(235, 219, 178),         // fg
+        fg_secondary: Color::Rgb(189, 174, 147), // fg3
+        fg_muted: Color::Rgb(124, 111, 100),  // bg4
+        accent: Color::Rgb(254, 128, 25),      // orange
+        accent_secondary: Color::Rgb(250, 189, 47), // yellow
+        success: Color::Rgb(184, 187, 38),     // green
+        error: Color::Rgb(251, 73, 52),        // red
+        warning: Color::Rgb(250, 189, 47),     // yellow
+        sender_self: Color::Rgb(184, 187, 38), // green
+        sender_palette: [
+            Color::Rgb(131, 165, 152), // aqua
+            Color::Rgb(211, 134, 155), // purple
+            Color::Rgb(250, 189, 47),  // yellow
+            Color::Rgb(69, 133, 136),  // dark aqua
+            Color::Rgb(251, 73, 52),   // red
+            Color::Rgb(184, 187, 38),  // green
+            Color::Rgb(254, 128, 25),  // orange
+            Color::Rgb(142, 192, 124), // bright green
+        ],
+        link: Color::Rgb(131, 165, 152),       // aqua
+        mention: Color::Rgb(211, 134, 155),    // purple
+        quote: Color::Rgb(124, 111, 100),      // bg4
+        system_msg: Color::Rgb(124, 111, 100), // bg4
+        msg_selected_bg: Color::Rgb(60, 56, 54), // bg1
+        input_insert: Color::Rgb(254, 128, 25), // orange
+        input_normal: Color::Rgb(250, 189, 47), // yellow
+        statusbar_bg: Color::Rgb(50, 48, 47),  // bg0_h
+        statusbar_fg: Color::Rgb(235, 219, 178), // fg
+        receipt_failed: Color::Rgb(251, 73, 52),
+        receipt_sending: Color::Rgb(124, 111, 100),
+        receipt_sent: Color::Rgb(124, 111, 100),
+        receipt_delivered: Color::Rgb(235, 219, 178),
+        receipt_read: Color::Rgb(184, 187, 38),
+        receipt_viewed: Color::Rgb(131, 165, 152),
+    }
+}
+
+fn mirc_dark() -> Theme {
+    Theme {
+        name: "mIRC Dark".into(),
+        bg: Color::Black,
+        bg_selected: Color::DarkGray,
+        fg: Color::White,
+        fg_secondary: Color::Gray,
+        fg_muted: Color::DarkGray,
+        accent: Color::LightGreen,
+        accent_secondary: Color::LightYellow,
+        success: Color::LightGreen,
+        error: Color::LightRed,
+        warning: Color::LightYellow,
+        sender_self: Color::LightGreen,
+        sender_palette: [
+            Color::LightCyan,
+            Color::LightMagenta,
+            Color::LightYellow,
+            Color::LightBlue,
+            Color::LightRed,
+            Color::LightGreen,
+            Color::Cyan,
+            Color::Magenta,
+        ],
+        link: Color::LightBlue,
+        mention: Color::LightCyan,
+        quote: Color::DarkGray,
+        system_msg: Color::DarkGray,
+        msg_selected_bg: Color::Indexed(236),
+        input_insert: Color::LightGreen,
+        input_normal: Color::LightYellow,
+        statusbar_bg: Color::DarkGray,
+        statusbar_fg: Color::White,
+        receipt_failed: Color::LightRed,
+        receipt_sending: Color::DarkGray,
+        receipt_sent: Color::DarkGray,
+        receipt_delivered: Color::White,
+        receipt_read: Color::LightGreen,
+        receipt_viewed: Color::LightCyan,
+    }
+}
+
+fn mirc_light() -> Theme {
+    Theme {
+        name: "mIRC Light".into(),
+        bg: Color::White,
+        bg_selected: Color::Gray,
+        fg: Color::Black,
+        fg_secondary: Color::DarkGray,
+        fg_muted: Color::Gray,
+        accent: Color::Green,
+        accent_secondary: Color::Yellow,
+        success: Color::Green,
+        error: Color::Red,
+        warning: Color::Yellow,
+        sender_self: Color::Green,
+        sender_palette: [
+            Color::Cyan,
+            Color::Magenta,
+            Color::Blue,
+            Color::Red,
+            Color::Green,
+            Color::Yellow,
+            Color::DarkGray,
+            Color::Blue,
+        ],
+        link: Color::Blue,
+        mention: Color::Magenta,
+        quote: Color::Gray,
+        system_msg: Color::Gray,
+        msg_selected_bg: Color::Indexed(254),
+        input_insert: Color::Green,
+        input_normal: Color::Yellow,
+        statusbar_bg: Color::Gray,
+        statusbar_fg: Color::Black,
+        receipt_failed: Color::Red,
+        receipt_sending: Color::Gray,
+        receipt_sent: Color::Gray,
+        receipt_delivered: Color::Black,
+        receipt_read: Color::Green,
+        receipt_viewed: Color::Cyan,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Theme discovery
+// ---------------------------------------------------------------------------
+
+fn builtin_themes() -> Vec<Theme> {
+    vec![
+        default_theme(),
+        catppuccin_mocha(),
+        catppuccin_latte(),
+        dracula(),
+        nord(),
+        gruvbox_dark(),
+        mirc_dark(),
+        mirc_light(),
+    ]
+}
+
+/// Load custom themes from `~/.config/signal-tui/themes/*.toml`.
+pub fn load_custom_themes() -> Vec<Theme> {
+    let dir = match dirs::config_dir() {
+        Some(d) => d.join("signal-tui").join("themes"),
+        None => return Vec::new(),
+    };
+    if !dir.is_dir() {
+        return Vec::new();
+    }
+    let mut themes = Vec::new();
+    let entries = match std::fs::read_dir(&dir) {
+        Ok(e) => e,
+        Err(e) => {
+            crate::debug_log::logf(format_args!("custom themes dir read error: {e}"));
+            return Vec::new();
+        }
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+            continue;
+        }
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match toml::from_str::<Theme>(&contents) {
+                Ok(theme) => themes.push(theme),
+                Err(e) => {
+                    crate::debug_log::logf(format_args!(
+                        "custom theme parse error {}: {e}",
+                        path.display()
+                    ));
+                }
+            },
+            Err(e) => {
+                crate::debug_log::logf(format_args!(
+                    "custom theme read error {}: {e}",
+                    path.display()
+                ));
+            }
+        }
+    }
+    themes
+}
+
+/// All available themes: built-ins followed by custom themes.
+pub fn all_themes() -> Vec<Theme> {
+    let mut themes = builtin_themes();
+    themes.extend(load_custom_themes());
+    themes
+}
+
+/// Find a theme by name. Falls back to Default if not found.
+pub fn find_theme(name: &str) -> Theme {
+    all_themes()
+        .into_iter()
+        .find(|t| t.name == name)
+        .unwrap_or_else(default_theme)
+}
+
+// ---------------------------------------------------------------------------
+// Color serde helpers
+// ---------------------------------------------------------------------------
+
+mod color_serde {
+    use ratatui::style::Color;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(color: &Color, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&super::color_to_string(color))
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Color, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        super::string_to_color(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+mod color_array_serde {
+    use ratatui::style::Color;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(colors: &[Color; 8], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(8))?;
+        for c in colors {
+            seq.serialize_element(&super::color_to_string(c))?;
+        }
+        seq.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<[Color; 8], D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let strings: Vec<String> = Vec::deserialize(deserializer)?;
+        if strings.len() != 8 {
+            return Err(serde::de::Error::custom(format!(
+                "expected 8 colors, got {}",
+                strings.len()
+            )));
+        }
+        let mut colors = [Color::Reset; 8];
+        for (i, s) in strings.iter().enumerate() {
+            colors[i] = super::string_to_color(s).map_err(serde::de::Error::custom)?;
+        }
+        Ok(colors)
+    }
+}
+
+fn color_to_string(color: &Color) -> String {
+    match color {
+        Color::Rgb(r, g, b) => format!("#{r:02x}{g:02x}{b:02x}"),
+        Color::Indexed(i) => format!("indexed({i})"),
+        Color::Reset => "reset".into(),
+        Color::Black => "black".into(),
+        Color::Red => "red".into(),
+        Color::Green => "green".into(),
+        Color::Yellow => "yellow".into(),
+        Color::Blue => "blue".into(),
+        Color::Magenta => "magenta".into(),
+        Color::Cyan => "cyan".into(),
+        Color::Gray => "gray".into(),
+        Color::DarkGray => "dark_gray".into(),
+        Color::LightRed => "light_red".into(),
+        Color::LightGreen => "light_green".into(),
+        Color::LightYellow => "light_yellow".into(),
+        Color::LightBlue => "light_blue".into(),
+        Color::LightMagenta => "light_magenta".into(),
+        Color::LightCyan => "light_cyan".into(),
+        Color::White => "white".into(),
+    }
+}
+
+fn string_to_color(s: &str) -> Result<Color, String> {
+    let s = s.trim();
+    // Hex: #rrggbb
+    if let Some(hex) = s.strip_prefix('#') {
+        if hex.len() == 6 {
+            let r = u8::from_str_radix(&hex[0..2], 16)
+                .map_err(|e| format!("bad hex red: {e}"))?;
+            let g = u8::from_str_radix(&hex[2..4], 16)
+                .map_err(|e| format!("bad hex green: {e}"))?;
+            let b = u8::from_str_radix(&hex[4..6], 16)
+                .map_err(|e| format!("bad hex blue: {e}"))?;
+            return Ok(Color::Rgb(r, g, b));
+        }
+        return Err(format!("hex color must be 6 digits: {s}"));
+    }
+    // Indexed: indexed(N)
+    if let Some(inner) = s.strip_prefix("indexed(").and_then(|s| s.strip_suffix(')')) {
+        let i: u8 = inner.parse().map_err(|e| format!("bad index: {e}"))?;
+        return Ok(Color::Indexed(i));
+    }
+    // Named
+    match s.to_lowercase().as_str() {
+        "reset" => Ok(Color::Reset),
+        "black" => Ok(Color::Black),
+        "red" => Ok(Color::Red),
+        "green" => Ok(Color::Green),
+        "yellow" => Ok(Color::Yellow),
+        "blue" => Ok(Color::Blue),
+        "magenta" => Ok(Color::Magenta),
+        "cyan" => Ok(Color::Cyan),
+        "gray" | "grey" => Ok(Color::Gray),
+        "dark_gray" | "dark_grey" | "darkgray" | "darkgrey" => Ok(Color::DarkGray),
+        "light_red" | "lightred" => Ok(Color::LightRed),
+        "light_green" | "lightgreen" => Ok(Color::LightGreen),
+        "light_yellow" | "lightyellow" => Ok(Color::LightYellow),
+        "light_blue" | "lightblue" => Ok(Color::LightBlue),
+        "light_magenta" | "lightmagenta" => Ok(Color::LightMagenta),
+        "light_cyan" | "lightcyan" => Ok(Color::LightCyan),
+        "white" => Ok(Color::White),
+        _ => Err(format!("unknown color: {s}")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_theme_has_correct_name() {
+        assert_eq!(default_theme().name, "Default");
+    }
+
+    #[test]
+    fn all_builtin_themes_have_unique_names() {
+        let themes = all_themes();
+        let mut names: Vec<&str> = themes.iter().map(|t| t.name.as_str()).collect();
+        let len = names.len();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), len, "duplicate theme names found");
+    }
+
+    #[test]
+    fn find_theme_returns_default_for_unknown() {
+        let t = find_theme("nonexistent");
+        assert_eq!(t.name, "Default");
+    }
+
+    #[test]
+    fn color_serde_roundtrip_hex() {
+        let s = color_to_string(&Color::Rgb(205, 214, 244));
+        assert_eq!(s, "#cdd6f4");
+        let c = string_to_color(&s).unwrap();
+        assert_eq!(c, Color::Rgb(205, 214, 244));
+    }
+
+    #[test]
+    fn color_serde_roundtrip_named() {
+        let s = color_to_string(&Color::Cyan);
+        assert_eq!(s, "cyan");
+        let c = string_to_color(&s).unwrap();
+        assert_eq!(c, Color::Cyan);
+    }
+
+    #[test]
+    fn color_serde_roundtrip_indexed() {
+        let s = color_to_string(&Color::Indexed(236));
+        assert_eq!(s, "indexed(236)");
+        let c = string_to_color(&s).unwrap();
+        assert_eq!(c, Color::Indexed(236));
+    }
+
+    #[test]
+    fn theme_toml_roundtrip() {
+        let theme = default_theme();
+        let toml_str = toml::to_string_pretty(&theme).unwrap();
+        let parsed: Theme = toml::from_str(&toml_str).unwrap();
+        assert_eq!(parsed.name, theme.name);
+        assert_eq!(parsed.bg, theme.bg);
+        assert_eq!(parsed.sender_palette, theme.sender_palette);
+        assert_eq!(parsed.receipt_viewed, theme.receipt_viewed);
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -14,6 +14,7 @@ use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, VisibleImage,
 use crate::signal::types::{MessageStatus, Reaction, StyleType};
 use crate::image_render::ImageProtocol;
 use crate::input::{COMMANDS, format_compact_duration};
+use crate::theme::Theme;
 
 // Layout constants
 const SIDEBAR_AUTO_HIDE_WIDTH: u16 = 60;
@@ -33,37 +34,27 @@ const GROUP_MENU_POPUP_WIDTH: u16 = 40;
 const GROUP_MEMBER_MAX_VISIBLE: usize = 15;
 
 /// Map a MessageStatus to its display symbol and color.
-fn status_symbol(status: MessageStatus, nerd_fonts: bool, color: bool) -> (&'static str, Color) {
+fn status_symbol(status: MessageStatus, nerd_fonts: bool, color: bool, theme: &Theme) -> (&'static str, Color) {
     let (unicode_sym, nerd_sym, colored) = match status {
-        MessageStatus::Failed   => ("\u{2717}", "\u{f055c}", Color::Red),       // ✗ / 󰅜
-        MessageStatus::Sending  => ("\u{25cc}", "\u{f0996}", Color::DarkGray),  // ◌ / 󰦖
-        MessageStatus::Sent     => ("\u{25cb}", "\u{f0954}", Color::DarkGray),  // ○ / 󰥔
-        MessageStatus::Delivered=> ("\u{2713}", "\u{f012c}", Color::White),     // ✓ / 󰄬
-        MessageStatus::Read     => ("\u{25cf}", "\u{f012d}", Color::Green),     // ● / 󰄭
-        MessageStatus::Viewed   => ("\u{25c9}", "\u{f0208}", Color::Cyan),     // ◉ / 󰈈
+        MessageStatus::Failed   => ("\u{2717}", "\u{f055c}", theme.receipt_failed),
+        MessageStatus::Sending  => ("\u{25cc}", "\u{f0996}", theme.receipt_sending),
+        MessageStatus::Sent     => ("\u{25cb}", "\u{f0954}", theme.receipt_sent),
+        MessageStatus::Delivered=> ("\u{2713}", "\u{f012c}", theme.receipt_delivered),
+        MessageStatus::Read     => ("\u{25cf}", "\u{f012d}", theme.receipt_read),
+        MessageStatus::Viewed   => ("\u{25c9}", "\u{f0208}", theme.receipt_viewed),
     };
     let sym = if nerd_fonts { nerd_sym } else { unicode_sym };
-    let fg = if color { colored } else { Color::DarkGray };
+    let fg = if color { colored } else { theme.fg_muted };
     (sym, fg)
 }
 
-/// Hash a sender name to one of ~8 distinct colors. "you" always gets Green.
-fn sender_color(name: &str) -> Color {
+/// Hash a sender name to one of ~8 distinct colors. "you" always gets sender_self.
+fn sender_color(name: &str, theme: &Theme) -> Color {
     if name == "you" {
-        return Color::Green;
+        return theme.sender_self;
     }
     let hash: u32 = name.bytes().fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
-    const COLORS: [Color; 8] = [
-        Color::Cyan,
-        Color::Magenta,
-        Color::Yellow,
-        Color::Blue,
-        Color::LightRed,
-        Color::LightGreen,
-        Color::LightCyan,
-        Color::LightMagenta,
-    ];
-    COLORS[(hash as usize) % COLORS.len()]
+    theme.sender_palette[(hash as usize) % theme.sender_palette.len()]
 }
 
 /// Truncate a string to fit within `max_width`, appending `…` if truncated.
@@ -94,6 +85,7 @@ fn build_separator(label: &str, width: usize, style: Style) -> Line<'static> {
 /// Preferred width/height are clamped to fit within the terminal.
 fn centered_popup(
     frame: &mut Frame, area: Rect, pref_width: u16, pref_height: u16, title: &str,
+    theme: &Theme,
 ) -> (Rect, Block<'static>) {
     let w = pref_width.min(area.width.saturating_sub(4));
     let h = pref_height.min(area.height.saturating_sub(2));
@@ -104,10 +96,10 @@ fn centered_popup(
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::Cyan))
+        .border_style(Style::default().fg(theme.accent))
         .title(title.to_string())
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD))
-        .style(Style::default().bg(Color::Black));
+        .title_style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD))
+        .style(Style::default().bg(theme.bg));
     (popup_area, block)
 }
 
@@ -137,14 +129,14 @@ fn extract_url(text: &str) -> String {
     text.to_string()
 }
 
-/// Check if a cell's style matches the link style (Blue fg + UNDERLINED).
-fn is_link_style(style: &Style) -> bool {
-    style.fg == Some(Color::Blue) && style.add_modifier.contains(Modifier::UNDERLINED)
+/// Check if a cell's style matches the link style (link color fg + UNDERLINED).
+fn is_link_style(style: &Style, link_color: Color) -> bool {
+    style.fg == Some(link_color) && style.add_modifier.contains(Modifier::UNDERLINED)
 }
 
 /// Scan a rendered buffer area for consecutive cells with the link style,
 /// and collect them into LinkRegion structs.
-fn collect_link_regions(buf: &Buffer, area: Rect) -> Vec<LinkRegion> {
+fn collect_link_regions(buf: &Buffer, area: Rect, link_color: Color) -> Vec<LinkRegion> {
     let right_edge = area.x.saturating_add(area.width);
     let mut regions = Vec::new();
     let mut wrap_url: Option<String> = None;
@@ -163,7 +155,7 @@ fn collect_link_regions(buf: &Buffer, area: Rect) -> Vec<LinkRegion> {
                 }
             };
 
-            if !is_link_style(&cell.style()) {
+            if !is_link_style(&cell.style(), link_color) {
                 x += 1;
                 continue;
             }
@@ -174,7 +166,7 @@ fn collect_link_regions(buf: &Buffer, area: Rect) -> Vec<LinkRegion> {
 
             while x < right_edge {
                 match buf.cell(Position::new(x, y)) {
-                    Some(c) if is_link_style(&c.style()) => {
+                    Some(c) if is_link_style(&c.style(), link_color) => {
                         let sym = c.symbol();
                         if !sym.is_empty() {
                             text.push_str(sym);
@@ -239,12 +231,13 @@ fn styled_uri_spans(
     body: &str,
     mention_ranges: &[(usize, usize)],
     style_ranges: &[(usize, usize, StyleType)],
+    theme: &Theme,
 ) -> (Vec<Span<'static>>, Option<String>) {
     let link_style = Style::default()
-        .fg(Color::Blue)
+        .fg(theme.link)
         .add_modifier(Modifier::UNDERLINED);
     let mention_style = Style::default()
-        .fg(Color::Cyan)
+        .fg(theme.mention)
         .add_modifier(Modifier::BOLD);
 
     // Attachment/image patterns: extract bracket text as display, URI as hidden metadata
@@ -385,7 +378,7 @@ fn styled_uri_spans(
         if is_spoiler {
             // Replace each character with a block character
             let block_text: String = segment_text.chars().map(|_| '\u{2588}').collect();
-            let spoiler_style = style.fg(Color::DarkGray);
+            let spoiler_style = style.fg(theme.fg_muted);
             spans.push(Span::styled(block_text, spoiler_style));
         } else {
             // Apply text style modifiers
@@ -395,7 +388,7 @@ fn styled_uri_spans(
                         StyleType::Bold => style = style.add_modifier(Modifier::BOLD),
                         StyleType::Italic => style = style.add_modifier(Modifier::ITALIC),
                         StyleType::Strikethrough => style = style.add_modifier(Modifier::CROSSED_OUT),
-                        StyleType::Monospace => style = style.fg(Color::DarkGray),
+                        StyleType::Monospace => style = style.fg(theme.fg_muted),
                         StyleType::Spoiler => {} // handled above
                     }
                 }
@@ -471,7 +464,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     // Help overlay (overlays everything)
     if app.show_help {
-        draw_help(frame, size);
+        draw_help(frame, app, size);
     }
 
     // Contacts overlay (overlays everything)
@@ -514,9 +507,14 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_delete_confirm(frame, app, size);
     }
 
+    // Theme picker overlay
+    if app.show_theme_picker {
+        draw_theme_picker(frame, app, size);
+    }
+
     // Collect link regions from the rendered buffer for OSC 8 injection
     let area = frame.area();
-    app.link_regions = collect_link_regions(frame.buffer_mut(), area);
+    app.link_regions = collect_link_regions(frame.buffer_mut(), area, app.theme.link);
 
     // Resolve hidden URLs for attachment links (display text has no URI scheme)
     for link in &mut app.link_regions {
@@ -529,6 +527,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 }
 
 fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = &app.theme;
     let max_name_width = (area.width as usize).saturating_sub(5); // "• # " + margin
 
     let items: Vec<ListItem> = app
@@ -551,7 +550,7 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
             if is_active {
                 spans.push(Span::styled(
                     "▸ ",
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
                 ));
             } else {
                 spans.push(Span::raw("  "));
@@ -559,9 +558,9 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
 
             // Unread / message request marker
             if !conv.accepted {
-                spans.push(Span::styled("? ", Style::default().fg(Color::Magenta)));
+                spans.push(Span::styled("? ", Style::default().fg(theme.mention)));
             } else if has_unread && !is_active {
-                spans.push(Span::styled("• ", Style::default().fg(Color::Yellow)));
+                spans.push(Span::styled("• ", Style::default().fg(theme.warning)));
             } else {
                 spans.push(Span::raw("  "));
             }
@@ -570,7 +569,7 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
             if conv.is_group {
                 spans.push(Span::styled(
                     "#",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_muted),
                 ));
             }
 
@@ -578,22 +577,22 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
             let is_muted = app.muted_conversations.contains(id);
             let name_style = if is_active {
                 Style::default()
-                    .fg(Color::White)
+                    .fg(theme.fg)
                     .add_modifier(Modifier::BOLD)
             } else if has_unread {
-                Style::default().fg(Color::Yellow)
+                Style::default().fg(theme.warning)
             } else if is_muted {
-                Style::default().fg(Color::DarkGray)
+                Style::default().fg(theme.fg_muted)
             } else {
-                Style::default().fg(Color::Gray)
+                Style::default().fg(theme.fg_secondary)
             };
             spans.push(Span::styled(name, name_style));
 
             if is_muted {
-                spans.push(Span::styled(" ~", Style::default().fg(Color::DarkGray)));
+                spans.push(Span::styled(" ~", Style::default().fg(theme.fg_muted)));
             }
             if app.blocked_conversations.contains(id) {
-                spans.push(Span::styled(" x", Style::default().fg(Color::Red)));
+                spans.push(Span::styled(" x", Style::default().fg(theme.error)));
             }
 
             ListItem::new(Line::from(spans))
@@ -604,7 +603,7 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
         .borders(Borders::RIGHT)
         .border_type(BorderType::Rounded)
         .title(" Chats ")
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+        .title_style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD));
     app.mouse_sidebar_inner = Some(block.inner(area));
 
     let sidebar = List::new(items).block(block);
@@ -630,6 +629,7 @@ fn draw_chat_area(frame: &mut Frame, app: &mut App, area: Rect) -> Rect {
 }
 
 fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = &app.theme;
     let (title_spans, title_right) = match &app.active_conversation {
         Some(id) => {
             let conv = &app.conversations[id];
@@ -637,7 +637,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             let mut spans = vec![
                 Span::styled(
                     format!("{prefix}{} ", conv.name),
-                    Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
                 ),
             ];
 
@@ -646,7 +646,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 let timer_label = format_compact_duration(conv.expiration_timer);
                 spans.push(Span::styled(
                     format!("\u{23F1} {timer_label} "),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_muted),
                 ));
             }
 
@@ -660,7 +660,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         }
         None => (vec![Span::styled(
             " signal-tui ".to_string(),
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
         )], String::new()),
     };
 
@@ -672,7 +672,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     if !title_right.is_empty() {
         block = block
             .title_bottom(Line::from(title_right).alignment(Alignment::Right))
-            .title_style(Style::default().fg(Color::Cyan));
+            .title_style(Style::default().fg(theme.accent));
     }
 
     let inner = block.inner(area);
@@ -732,7 +732,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         if prev_date.as_ref() != Some(&date_str) {
             if prev_date.is_some() {
                 let label = format!(" {} ", date_str);
-                lines.push(build_separator(&label, inner_width, Style::default().fg(Color::DarkGray)));
+                lines.push(build_separator(&label, inner_width, Style::default().fg(theme.fg_muted)));
                 line_msg_idx.push(None);
             }
             prev_date = Some(date_str);
@@ -743,7 +743,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             lines.push(build_separator(
                 " new messages ",
                 inner_width,
-                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.error).add_modifier(Modifier::BOLD),
             ));
             line_msg_idx.push(None);
         }
@@ -751,7 +751,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         if msg.is_system {
             lines.push(Line::from(Span::styled(
                 format!("  {}", msg.body),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.system_msg),
             )));
             line_msg_idx.push(Some(msg_index));
         } else {
@@ -759,16 +759,16 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             if let Some(ref quote) = msg.quote {
                 let quote_body = truncate(&quote.body, 50);
                 lines.push(Line::from(vec![
-                    Span::styled("  \u{2502} ", Style::default().fg(Color::DarkGray)),
+                    Span::styled("  \u{2502} ", Style::default().fg(theme.quote)),
                     Span::styled(
                         format!("<{}>", quote.author),
                         Style::default()
-                            .fg(sender_color(&quote.author))
+                            .fg(sender_color(&quote.author, theme))
                             .add_modifier(Modifier::BOLD),
                     ),
                     Span::styled(
                         format!(" {quote_body}"),
-                        Style::default().fg(Color::DarkGray),
+                        Style::default().fg(theme.quote),
                     ),
                 ]));
                 line_msg_idx.push(Some(msg_index));
@@ -780,7 +780,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             // Status symbol for outgoing messages (before timestamp)
             if app.show_receipts {
                 if let Some(status) = msg.status {
-                    let (sym, color) = status_symbol(status, app.nerd_fonts, app.color_receipts);
+                    let (sym, color) = status_symbol(status, app.nerd_fonts, app.color_receipts, theme);
                     spans.push(Span::styled(
                         format!("{sym} "),
                         Style::default().fg(color),
@@ -791,18 +791,18 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             if msg.expires_in_seconds > 0 {
                 spans.push(Span::styled(
                     format!("\u{23F1}[{}] ", time),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_muted),
                 ));
             } else {
                 spans.push(Span::styled(
                     format!("[{}] ", time),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_muted),
                 ));
             }
             spans.push(Span::styled(
                 format!("<{}>", msg.sender),
                 Style::default()
-                    .fg(sender_color(&msg.sender))
+                    .fg(sender_color(&msg.sender, theme))
                     .add_modifier(Modifier::BOLD),
             ));
 
@@ -810,7 +810,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             if msg.is_edited {
                 spans.push(Span::styled(
                     " (edited)",
-                    Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                    Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
                 ));
             }
 
@@ -818,11 +818,11 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 // Deleted message body
                 spans.push(Span::styled(
                     " [deleted]",
-                    Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+                    Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
                 ));
             } else {
                 // Style URIs and @mentions
-                let (body_spans, hidden_url) = styled_uri_spans(&msg.body, &msg.mention_ranges, &msg.style_ranges);
+                let (body_spans, hidden_url) = styled_uri_spans(&msg.body, &msg.mention_ranges, &msg.style_ranges, theme);
                 if let Some(url) = hidden_url {
                     // Collect display text for link_url_map lookup
                     let display_text: String = body_spans.iter().map(|s| s.content.as_ref()).collect();
@@ -855,7 +855,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
 
             // Render reaction summary line (skip for deleted)
             if !msg.is_deleted && !msg.reactions.is_empty() {
-                lines.push(build_reaction_summary(&msg.reactions, app.reaction_verbose));
+                lines.push(build_reaction_summary(&msg.reactions, app.reaction_verbose, theme));
                 line_msg_idx.push(Some(msg_index));
             }
         }
@@ -893,7 +893,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             lines.push(Line::from(Span::styled(
                 text,
                 Style::default()
-                    .fg(Color::DarkGray)
+                    .fg(theme.fg_muted)
                     .add_modifier(Modifier::ITALIC),
             )));
             line_msg_idx.push(None);
@@ -1011,7 +1011,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         for (i, line) in lines.iter_mut().enumerate() {
             if line_msg_idx.get(i) == Some(&Some(focused_idx)) {
                 let patched: Vec<Span> = line.spans.drain(..).map(|mut s| {
-                    s.style = s.style.bg(Color::Indexed(236));
+                    s.style = s.style.bg(theme.msg_selected_bg);
                     s
                 }).collect();
                 *line = Line::from(patched);
@@ -1041,7 +1041,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 /// Build a reaction summary line like "    👍 2  ❤️ 1  😂 1"
-fn build_reaction_summary(reactions: &[Reaction], verbose: bool) -> Line<'static> {
+fn build_reaction_summary(reactions: &[Reaction], verbose: bool, theme: &Theme) -> Line<'static> {
     if verbose {
         // Verbose: group by emoji, show sender names
         let mut grouped: std::collections::BTreeMap<String, Vec<String>> = std::collections::BTreeMap::new();
@@ -1053,7 +1053,7 @@ fn build_reaction_summary(reactions: &[Reaction], verbose: bool) -> Line<'static
             spans.push(Span::raw(format!("{emoji} ")));
             spans.push(Span::styled(
                 senders.join(", "),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             ));
             spans.push(Span::raw("  ".to_string()));
         }
@@ -1069,7 +1069,7 @@ fn build_reaction_summary(reactions: &[Reaction], verbose: bool) -> Line<'static
             spans.push(Span::raw(emoji.clone()));
             spans.push(Span::styled(
                 format!(" {count}  "),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             ));
         }
         Line::from(spans)
@@ -1077,6 +1077,7 @@ fn build_reaction_summary(reactions: &[Reaction], verbose: bool) -> Line<'static
 }
 
 fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let state = match &app.group_menu_state {
         Some(s) => s,
         None => return,
@@ -1094,7 +1095,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 .map(|c| format!(" #{} ", c.name))
                 .unwrap_or_else(|| " Group ".to_string());
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, popup_height, &title,
+                frame, area, GROUP_MENU_POPUP_WIDTH, popup_height, &title, theme,
             );
             let inner = block.inner(popup_area);
             frame.render_widget(block, popup_area);
@@ -1112,14 +1113,14 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 let pad = content_width.saturating_sub(label_part.chars().count() + hint_width + 2);
                 let padding = " ".repeat(pad);
                 let row_style = if is_selected {
-                    Style::default().bg(Color::DarkGray)
+                    Style::default().bg(theme.bg_selected)
                 } else {
                     Style::default()
                 };
                 let hint_style = if is_selected {
-                    Style::default().bg(Color::DarkGray).fg(Color::DarkGray).add_modifier(Modifier::DIM)
+                    Style::default().bg(theme.bg_selected).fg(theme.fg_muted).add_modifier(Modifier::DIM)
                 } else {
-                    Style::default().fg(Color::DarkGray)
+                    Style::default().fg(theme.fg_muted)
                 };
                 lines.push(Line::from(vec![
                     Span::styled(format!("{label_part}{padding}"), row_style),
@@ -1129,7 +1130,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  Esc to close",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             )));
             let popup = Paragraph::new(lines);
             frame.render_widget(popup, inner);
@@ -1139,7 +1140,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             let pref_height = max_visible as u16 + 5;
             let title = " Members ".to_string();
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, pref_height, &title,
+                frame, area, GROUP_MENU_POPUP_WIDTH, pref_height, &title, theme,
             );
             let inner_height = popup_area.height.saturating_sub(2) as usize;
             let footer_lines = 2;
@@ -1153,7 +1154,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             if app.group_menu_filtered.is_empty() {
                 lines.push(Line::from(Span::styled(
                     "  No members",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_muted),
                 )));
             } else {
                 let end = (scroll_offset + visible_rows).min(app.group_menu_filtered.len());
@@ -1167,14 +1168,14 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                         format!("  {}", name)
                     };
                     let name_style = if is_selected {
-                        Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+                        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
                     } else {
-                        Style::default().fg(Color::White)
+                        Style::default().fg(theme.fg)
                     };
                     let phone_style = if is_selected {
-                        Style::default().bg(Color::DarkGray).fg(Color::DarkGray)
+                        Style::default().bg(theme.bg_selected).fg(theme.fg_muted)
                     } else {
-                        Style::default().fg(Color::DarkGray)
+                        Style::default().fg(theme.fg_muted)
                     };
                     lines.push(Line::from(vec![
                         Span::styled(display, name_style),
@@ -1188,7 +1189,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  Esc to go back",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             )));
             let popup = Paragraph::new(lines).block(block);
             frame.render_widget(popup, popup_area);
@@ -1209,7 +1210,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 format!(" Remove Member [{}] ", app.group_menu_filter)
             };
             let (popup_area, block) = centered_popup(
-                frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title,
+                frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title, theme,
             );
             let inner_height = popup_area.height.saturating_sub(2) as usize;
             let footer_lines = 2;
@@ -1224,7 +1225,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 let msg = if is_add { "  No contacts to add" } else { "  No members to remove" };
                 lines.push(Line::from(Span::styled(
                     msg,
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme.fg_muted),
                 )));
             } else {
                 let end = (scroll_offset + visible_rows).min(app.group_menu_filtered.len());
@@ -1236,14 +1237,14 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                     let name_max = inner_w.saturating_sub(number_display.len() + 2);
                     let display_name = truncate(name, name_max);
                     let name_style = if is_selected {
-                        Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+                        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
                     } else {
-                        Style::default().fg(Color::White)
+                        Style::default().fg(theme.fg)
                     };
                     let number_style = if is_selected {
-                        Style::default().bg(Color::DarkGray).fg(Color::Cyan)
+                        Style::default().bg(theme.bg_selected).fg(theme.accent)
                     } else {
-                        Style::default().fg(Color::DarkGray)
+                        Style::default().fg(theme.fg_muted)
                     };
                     lines.push(Line::from(vec![
                         Span::styled(format!("  {}", display_name), name_style),
@@ -1257,7 +1258,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  Enter to select \u{00b7} Esc to cancel",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             )));
             let popup = Paragraph::new(lines).block(block);
             frame.render_widget(popup, popup_area);
@@ -1266,7 +1267,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             let is_rename = *state == GroupMenuState::Rename;
             let title = if is_rename { " Rename Group " } else { " Create Group " };
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, 6, title,
+                frame, area, GROUP_MENU_POPUP_WIDTH, 6, title, theme,
             );
             let inner = block.inner(popup_area);
             frame.render_widget(block, popup_area);
@@ -1274,12 +1275,12 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             let input_display = format!("  {}\u{2588}", app.group_menu_input);
             lines.push(Line::from(Span::styled(
                 input_display,
-                Style::default().fg(Color::White),
+                Style::default().fg(theme.fg),
             )));
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  Enter to confirm \u{00b7} Esc to cancel",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             )));
             let popup = Paragraph::new(lines);
             frame.render_widget(popup, inner);
@@ -1291,19 +1292,19 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 .unwrap_or_else(|| "this group".to_string());
             let prompt = format!("Leave #{}?", group_name);
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, 5, " Leave Group ",
+                frame, area, GROUP_MENU_POPUP_WIDTH, 5, " Leave Group ", theme,
             );
             let inner = block.inner(popup_area);
             frame.render_widget(block, popup_area);
             let mut lines: Vec<Line> = Vec::new();
             lines.push(Line::from(Span::styled(
                 format!("  {}", prompt),
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(theme.warning),
             )));
             lines.push(Line::from(""));
             lines.push(Line::from(Span::styled(
                 "  (y)es / (n)o",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme.fg_muted),
             )));
             let popup = Paragraph::new(lines);
             frame.render_widget(popup, inner);
@@ -1312,6 +1313,7 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_message_request(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let conv_id = match app.active_conversation.as_ref() {
         Some(id) => id,
         None => return,
@@ -1325,25 +1327,25 @@ fn draw_message_request(frame: &mut Frame, app: &App, area: Rect) {
     let name = &conv.name;
     let phone = &conv.id;
 
-    let (popup_area, block) = centered_popup(frame, area, 36, 9, " Message Request ");
+    let (popup_area, block) = centered_popup(frame, area, 36, 9, " Message Request ", theme);
     frame.render_widget(block, popup_area);
 
     let inner = popup_area.inner(ratatui::layout::Margin { vertical: 1, horizontal: 2 });
     let lines = vec![
-        Line::from(Span::styled(name.as_str(), Style::default().fg(Color::White).add_modifier(Modifier::BOLD))),
-        Line::from(Span::styled(phone.as_str(), Style::default().fg(Color::DarkGray))),
+        Line::from(Span::styled(name.as_str(), Style::default().fg(theme.fg).add_modifier(Modifier::BOLD))),
+        Line::from(Span::styled(phone.as_str(), Style::default().fg(theme.fg_muted))),
         Line::from(Span::styled(
             format!("{} message{}", msg_count, if msg_count == 1 { "" } else { "s" }),
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )),
         Line::from(""),
         Line::from(vec![
-            Span::styled("(a)", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
-            Span::styled("ccept / ", Style::default().fg(Color::Gray)),
-            Span::styled("(d)", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
-            Span::styled("elete", Style::default().fg(Color::Gray)),
+            Span::styled("(a)", Style::default().fg(theme.success).add_modifier(Modifier::BOLD)),
+            Span::styled("ccept / ", Style::default().fg(theme.fg_secondary)),
+            Span::styled("(d)", Style::default().fg(theme.error).add_modifier(Modifier::BOLD)),
+            Span::styled("elete", Style::default().fg(theme.fg_secondary)),
         ]),
-        Line::from(Span::styled("Esc to go back", Style::default().fg(Color::DarkGray))),
+        Line::from(Span::styled("Esc to go back", Style::default().fg(theme.fg_muted))),
     ];
 
     let text = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
@@ -1351,22 +1353,22 @@ fn draw_message_request(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let items = app.action_menu_items();
     if items.is_empty() {
         return;
     }
 
     let popup_width: u16 = 30;
-    let popup_height = items.len() as u16 + 4; // borders + hint line + padding
+    let popup_height = items.len() as u16 + 4;
 
     let (popup_area, block) = centered_popup(
-        frame, area, popup_width, popup_height, " Actions ",
+        frame, area, popup_width, popup_height, " Actions ", theme,
     );
 
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
 
-    // Content width inside the block borders
     let content_width = inner.width as usize;
 
     let mut lines: Vec<Line> = Vec::new();
@@ -1378,22 +1380,20 @@ fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {
             String::new()
         };
 
-        // Build the row: "  {icon}{label}    {hint}"
         let label_part = format!("  {icon}{}", action.label);
-        // Right-align the hint with padding
         let hint_width = action.key_hint.len();
         let pad = content_width.saturating_sub(label_part.chars().count() + hint_width + 2);
         let padding = " ".repeat(pad);
 
         let row_style = if is_selected {
-            Style::default().bg(Color::DarkGray)
+            Style::default().bg(theme.bg_selected)
         } else {
             Style::default()
         };
         let hint_style = if is_selected {
-            Style::default().bg(Color::DarkGray).fg(Color::DarkGray).add_modifier(Modifier::DIM)
+            Style::default().bg(theme.bg_selected).fg(theme.fg_muted).add_modifier(Modifier::DIM)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.fg_muted)
         };
 
         lines.push(Line::from(vec![
@@ -1402,11 +1402,10 @@ fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {
         ]));
     }
 
-    // Hint line
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  Esc to close",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_muted),
     )));
 
     let popup = Paragraph::new(lines);
@@ -1414,18 +1413,19 @@ fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_reaction_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let emoji_count = QUICK_REACTIONS.len();
     let popup_width = (emoji_count * 4 + 4) as u16;
     let popup_height = 3u16;
 
     let (popup_area, block) = centered_popup(
-        frame, area, popup_width, popup_height, " React ",
+        frame, area, popup_width, popup_height, " React ", theme,
     );
 
     let mut spans = vec![Span::raw(" ".to_string())];
     for (i, emoji) in QUICK_REACTIONS.iter().enumerate() {
         let style = if i == app.reaction_picker_index {
-            Style::default().bg(Color::DarkGray).add_modifier(Modifier::BOLD)
+            Style::default().bg(theme.bg_selected).add_modifier(Modifier::BOLD)
         } else {
             Style::default()
         };
@@ -1440,11 +1440,12 @@ fn draw_reaction_picker(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let msg = app.selected_message();
     let is_outgoing = msg.is_some_and(|m| m.sender == "you");
 
     let (popup_area, block) = centered_popup(
-        frame, area, 44, 5, " Delete Message ",
+        frame, area, 44, 5, " Delete Message ", theme,
     );
 
     let prompt = if is_outgoing {
@@ -1457,7 +1458,7 @@ fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             format!("  {prompt}"),
-            Style::default().fg(Color::White),
+            Style::default().fg(theme.fg),
         )),
     ];
     let popup = Paragraph::new(lines).block(block);
@@ -1466,102 +1467,103 @@ fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
 
 /// Render the welcome/empty-state screen when no conversation is active.
 fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let mut lines = vec![Line::from("")];
 
     if let Some(ref err) = app.connection_error {
         lines.push(Line::from(Span::styled(
             "  Connection Error",
-            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.error).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(Span::styled(
             format!("  {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme.error),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  Run with --setup to reconfigure.",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
     } else if app.loading {
         lines.push(Line::from(Span::styled(
             "  signal-tui",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  Loading...",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         )));
     } else if app.conversation_order.is_empty() {
         lines.push(Line::from(Span::styled(
             "  Welcome to signal-tui",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  No conversations yet",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  Messages you send and receive will appear here.",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  /join +1234567890  message someone by phone number",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  /contacts          browse your synced contacts",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  /help              see all commands and keybindings",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
     } else {
         lines.push(Line::from(Span::styled(
             "  Welcome to signal-tui",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  Getting started",
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(Span::styled(
             "  Tab / Shift+Tab    cycle through conversations",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  /join <contact>    open a conversation by name or number",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  Esc                switch to Normal mode (vim keys)",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  Useful commands",
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(Span::styled(
             "  /contacts          browse synced contacts",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  /settings          configure preferences",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(Span::styled(
             "  /help              all commands and keybindings",
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "  Ctrl+\u{2190}/\u{2192} to resize sidebar",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         )));
     }
 
@@ -1599,9 +1601,10 @@ fn find_focused_msg_index(
 }
 
 fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
+    let theme = &app.theme;
     let border_color = match app.mode {
-        InputMode::Insert => Color::Cyan,
-        InputMode::Normal => Color::Yellow,
+        InputMode::Insert => theme.input_insert,
+        InputMode::Normal => theme.input_normal,
     };
 
     let mut block = Block::default()
@@ -1614,12 +1617,12 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
         let label = format!(" replying: {}… ", truncate(snippet, 30));
         block = block.title(Line::from(Span::styled(
             label,
-            Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+            Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
         )));
     } else if app.editing_message.is_some() {
         block = block.title(Line::from(Span::styled(
             " editing… ",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::ITALIC),
+            Style::default().fg(theme.accent_secondary).add_modifier(Modifier::ITALIC),
         )));
     }
 
@@ -1657,7 +1660,7 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
         };
         let input = Paragraph::new(Span::styled(
             placeholder,
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         ))
         .block(block);
         frame.render_widget(input, area);
@@ -1671,11 +1674,11 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
         if let Some(ref badge_text) = badge {
             spans.push(Span::styled(
                 badge_text.clone(),
-                Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.mention).add_modifier(Modifier::BOLD),
             ));
         }
-        spans.push(Span::styled(prefix, Style::default().fg(Color::White)));
-        spans.push(Span::styled(visible.to_string(), Style::default().fg(Color::White)));
+        spans.push(Span::styled(prefix, Style::default().fg(theme.fg)));
+        spans.push(Span::styled(visible.to_string(), Style::default().fg(theme.fg)));
 
         let input = Paragraph::new(Line::from(spans)).block(block);
         frame.render_widget(input, area);
@@ -1691,6 +1694,7 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
 }
 
 fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden: bool) {
+    let theme = &app.theme;
     let mut segments: Vec<Span> = Vec::new();
 
     // Mode indicator
@@ -1698,43 +1702,43 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
         InputMode::Normal => {
             segments.push(Span::styled(
                 " [NORMAL] ",
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.accent_secondary).add_modifier(Modifier::BOLD),
             ));
         }
         InputMode::Insert => {
             segments.push(Span::styled(
                 " [INSERT] ",
-                Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.success).add_modifier(Modifier::BOLD),
             ));
         }
     }
-    segments.push(Span::styled("│ ", Style::default().fg(Color::DarkGray)));
+    segments.push(Span::styled("│ ", Style::default().fg(theme.fg_muted)));
 
     // Connection status dot
     if let Some(ref err) = app.connection_error {
-        segments.push(Span::styled(" ● ", Style::default().fg(Color::Red)));
+        segments.push(Span::styled(" ● ", Style::default().fg(theme.error)));
         let display: String = err.chars().take(60).collect();
         segments.push(Span::styled(
             format!("error: {display}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme.error),
         ));
     } else if app.connected {
-        segments.push(Span::styled(" ● ", Style::default().fg(Color::Green)));
-        segments.push(Span::styled("connected", Style::default().fg(Color::White)));
+        segments.push(Span::styled(" ● ", Style::default().fg(theme.success)));
+        segments.push(Span::styled("connected", Style::default().fg(theme.statusbar_fg)));
         if app.incognito {
-            segments.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+            segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
             segments.push(Span::styled(
                 "incognito",
-                Style::default().fg(Color::Magenta).add_modifier(Modifier::BOLD),
+                Style::default().fg(theme.mention).add_modifier(Modifier::BOLD),
             ));
         }
     } else {
-        segments.push(Span::styled(" ● ", Style::default().fg(Color::Red)));
-        segments.push(Span::styled("disconnected", Style::default().fg(Color::White)));
+        segments.push(Span::styled(" ● ", Style::default().fg(theme.error)));
+        segments.push(Span::styled("disconnected", Style::default().fg(theme.statusbar_fg)));
     }
 
     // Pipe separator
-    segments.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+    segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
 
     // Current conversation
     if let Some(ref id) = app.active_conversation {
@@ -1742,61 +1746,62 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
             let prefix = if conv.is_group { "#" } else { "" };
             segments.push(Span::styled(
                 format!("{}{}", prefix, conv.name),
-                Style::default().fg(Color::Cyan),
+                Style::default().fg(theme.accent),
             ));
         }
     } else {
         segments.push(Span::styled(
             "no conversation",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         ));
     }
 
     // Pipe separator + conversation count
     if !app.conversation_order.is_empty() {
-        segments.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+        segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
         segments.push(Span::styled(
             format!("{} chats", app.conversation_order.len()),
-            Style::default().fg(Color::Gray),
+            Style::default().fg(theme.fg_secondary),
         ));
     }
 
     // Scroll offset indicator + focused message timestamp
     if app.scroll_offset > 0 {
-        segments.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+        segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
         segments.push(Span::styled(
             format!("↑{}", app.scroll_offset),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(theme.warning),
         ));
         if let Some(ref ts) = app.focused_message_time {
             let local = ts.with_timezone(&chrono::Local);
-            segments.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+            segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
             segments.push(Span::styled(
                 local.format("%a %b %d, %Y %I:%M:%S %p").to_string(),
-                Style::default().fg(Color::White),
+                Style::default().fg(theme.statusbar_fg),
             ));
         }
     }
 
     // Auto-hidden sidebar indicator
     if sidebar_auto_hidden && app.sidebar_visible {
-        segments.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+        segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
         segments.push(Span::styled(
             "[+]",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         ));
     }
 
     // Pad the rest with background
     let status = Paragraph::new(Line::from(segments)).style(
         Style::default()
-            .fg(Color::White)
-            .bg(Color::DarkGray),
+            .fg(theme.statusbar_fg)
+            .bg(theme.statusbar_bg),
     );
     frame.render_widget(status, area);
 }
 
 fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
+    let theme = &app.theme;
     let terminal_width = frame.area().width;
     let mut lines: Vec<Line> = Vec::new();
     let mut max_content_width: usize = 0;
@@ -1819,14 +1824,14 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
                 let is_selected = i == app.autocomplete_index;
                 let style = if is_selected {
-                    Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+                    Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::Gray)
+                    Style::default().fg(theme.fg_secondary)
                 };
                 let desc_style = if is_selected {
-                    Style::default().bg(Color::DarkGray).fg(Color::Cyan)
+                    Style::default().bg(theme.bg_selected).fg(theme.accent)
                 } else {
-                    Style::default().fg(Color::DarkGray)
+                    Style::default().fg(theme.fg_muted)
                 };
 
                 lines.push(Line::from(vec![
@@ -1846,14 +1851,14 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
                 let is_selected = i == app.autocomplete_index;
                 let style = if is_selected {
-                    Style::default().bg(Color::DarkGray).fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                    Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::Cyan)
+                    Style::default().fg(theme.accent)
                 };
                 let phone_style = if is_selected {
-                    Style::default().bg(Color::DarkGray).fg(Color::DarkGray)
+                    Style::default().bg(theme.bg_selected).fg(theme.fg_muted)
                 } else {
-                    Style::default().fg(Color::DarkGray)
+                    Style::default().fg(theme.fg_muted)
                 };
 
                 lines.push(Line::from(vec![
@@ -1872,9 +1877,9 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
                 let is_selected = i == app.autocomplete_index;
                 let style = if is_selected {
-                    Style::default().bg(Color::DarkGray).fg(Color::Green).add_modifier(Modifier::BOLD)
+                    Style::default().bg(theme.bg_selected).fg(theme.success).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::Green)
+                    Style::default().fg(theme.success)
                 };
 
                 lines.push(Line::from(vec![
@@ -1902,16 +1907,18 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
-        .border_style(Style::default().fg(Color::Cyan))
-        .style(Style::default().bg(Color::Black));
+        .border_style(Style::default().fg(theme.accent))
+        .style(Style::default().bg(theme.bg));
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, area);
 }
 
 fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let height = SETTINGS_POPUP_HEIGHT + 1; // extra line for theme entry
     let (popup_area, block) = centered_popup(
-        frame, area, SETTINGS_POPUP_WIDTH, SETTINGS_POPUP_HEIGHT, " Settings ",
+        frame, area, SETTINGS_POPUP_WIDTH, height, " Settings ", theme,
     );
 
     let mut lines: Vec<Line> = Vec::new();
@@ -1920,16 +1927,16 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         let checkbox = if enabled { "[x]" } else { "[ ]" };
         let is_selected = i == app.settings_index;
         let style = if is_selected {
-            Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(Color::Gray)
+            Style::default().fg(theme.fg_secondary)
         };
         let check_style = if is_selected {
-            Style::default().bg(Color::DarkGray).fg(Color::Cyan).add_modifier(Modifier::BOLD)
+            Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
         } else if enabled {
-            Style::default().fg(Color::Green)
+            Style::default().fg(theme.success)
         } else {
-            Style::default().fg(Color::DarkGray)
+            Style::default().fg(theme.fg_muted)
         };
 
         lines.push(Line::from(vec![
@@ -1937,17 +1944,36 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
             Span::styled(def.label.to_string(), style),
         ]));
     }
+
+    // Theme selector entry (index == SETTINGS.len())
+    let is_theme_selected = app.settings_index == SETTINGS.len();
+    let theme_style = if is_theme_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.fg_secondary)
+    };
+    let theme_value_style = if is_theme_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.accent)
+    } else {
+        Style::default().fg(theme.accent)
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  Theme: ", theme_style),
+        Span::styled(app.theme.name.clone(), theme_value_style),
+    ]));
+
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  Esc to close  |  Space to toggle",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_muted),
     )));
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);
 }
 
-fn draw_help(frame: &mut Frame, area: Rect) {
+fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     // Help table entries: (key, description)
     let commands: &[(&str, &str)] = &[
         ("/join <name>", "Switch to a conversation"),
@@ -2002,13 +2028,13 @@ fn draw_help(frame: &mut Frame, area: Rect) {
         commands.len() + shortcuts.len() + vim.len() + cli.len() + 7; // headers + footer + spacing
     let pref_height = content_lines as u16 + 2;
 
-    let (popup_area, block) = centered_popup(frame, area, pref_width, pref_height, " Help ");
+    let (popup_area, block) = centered_popup(frame, area, pref_width, pref_height, " Help ", theme);
 
     let header_style = Style::default()
-        .fg(Color::Yellow)
+        .fg(theme.accent_secondary)
         .add_modifier(Modifier::BOLD);
-    let key_style = Style::default().fg(Color::Cyan);
-    let desc_style = Style::default().fg(Color::Gray);
+    let key_style = Style::default().fg(theme.accent);
+    let desc_style = Style::default().fg(theme.fg_secondary);
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -2046,7 +2072,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  Press any key to close",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_muted),
     )));
 
     let popup = Paragraph::new(lines).block(block);
@@ -2054,6 +2080,7 @@ fn draw_help(frame: &mut Frame, area: Rect) {
 }
 
 fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let max_visible = CONTACTS_MAX_VISIBLE.min(app.contacts_filtered.len());
     let pref_height = max_visible as u16 + 5; // +3 border/title +2 footer/filter
 
@@ -2064,7 +2091,7 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let (popup_area, block) = centered_popup(
-        frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title,
+        frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title, theme,
     );
 
     let inner_height = popup_area.height.saturating_sub(2) as usize; // minus borders
@@ -2083,7 +2110,7 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
     if app.contacts_filtered.is_empty() {
         lines.push(Line::from(Span::styled(
             "  No contacts found",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         )));
     } else {
         let end = (scroll_offset + visible_rows).min(app.contacts_filtered.len());
@@ -2097,7 +2124,7 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
             // Checkmark for contacts that already have a conversation
             let marker = if has_conversation { " \u{2713}" } else { "  " };
             let marker_style = if has_conversation {
-                Style::default().fg(Color::Green)
+                Style::default().fg(theme.success)
             } else {
                 Style::default()
             };
@@ -2109,21 +2136,21 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
 
             let name_style = if is_selected {
                 Style::default()
-                    .bg(Color::DarkGray)
-                    .fg(Color::White)
+                    .bg(theme.bg_selected)
+                    .fg(theme.fg)
                     .add_modifier(Modifier::BOLD)
             } else if has_conversation {
-                Style::default().fg(Color::Gray)
+                Style::default().fg(theme.fg_secondary)
             } else {
-                Style::default().fg(Color::White)
+                Style::default().fg(theme.fg)
             };
             let number_style = if is_selected {
-                Style::default().bg(Color::DarkGray).fg(Color::Cyan)
+                Style::default().bg(theme.bg_selected).fg(theme.accent)
             } else {
-                Style::default().fg(Color::DarkGray)
+                Style::default().fg(theme.fg_muted)
             };
             let marker_bg = if is_selected {
-                marker_style.bg(Color::DarkGray)
+                marker_style.bg(theme.bg_selected)
             } else {
                 marker_style
             };
@@ -2144,7 +2171,7 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  j/k navigate  |  Enter select  |  Esc close",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_muted),
     )));
 
     let popup = Paragraph::new(lines).block(block);
@@ -2152,6 +2179,7 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let max_visible = SEARCH_MAX_VISIBLE.min(app.search_results.len().max(1));
     let pref_height = max_visible as u16 + 5; // +3 border/title +2 footer
 
@@ -2162,7 +2190,7 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let (popup_area, block) = centered_popup(
-        frame, area, SEARCH_POPUP_WIDTH, pref_height, &title,
+        frame, area, SEARCH_POPUP_WIDTH, pref_height, &title, theme,
     );
 
     let inner_height = popup_area.height.saturating_sub(2) as usize; // minus borders
@@ -2187,7 +2215,7 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
         };
         lines.push(Line::from(Span::styled(
             msg,
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         )));
     } else {
         let end = (scroll_offset + visible_rows).min(app.search_results.len());
@@ -2210,19 +2238,19 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
             let body_snippet = search_snippet(&result.body, &app.search_query, body_max);
 
             let prefix_style = if is_selected {
-                Style::default().bg(Color::DarkGray).fg(Color::Cyan)
+                Style::default().bg(theme.bg_selected).fg(theme.accent)
             } else {
-                Style::default().fg(Color::Cyan)
+                Style::default().fg(theme.accent)
             };
             let body_style = if is_selected {
-                Style::default().bg(Color::DarkGray).fg(Color::White)
+                Style::default().bg(theme.bg_selected).fg(theme.fg)
             } else {
-                Style::default().fg(Color::Gray)
+                Style::default().fg(theme.fg_secondary)
             };
 
             // Build spans with highlighted match
             let mut spans = vec![Span::styled(prefix, prefix_style)];
-            spans.extend(highlight_match_spans(&body_snippet, &app.search_query, body_style, is_selected));
+            spans.extend(highlight_match_spans(&body_snippet, &app.search_query, body_style, is_selected, theme));
 
             lines.push(Line::from(spans));
         }
@@ -2242,11 +2270,11 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(vec![
         Span::styled(
             count_text,
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(theme.warning),
         ),
         Span::styled(
             "  j/k nav | Enter jump | n/N cycle | Esc close",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         ),
     ]));
 
@@ -2290,13 +2318,14 @@ fn search_snippet(body: &str, query: &str, max_len: usize) -> String {
     result
 }
 
-/// Build spans with the matching portions highlighted in Yellow.
+/// Build spans with the matching portions highlighted.
 /// Uses character-level case-insensitive matching to avoid byte-boundary issues.
 fn highlight_match_spans<'a>(
     text: &str,
     query: &str,
     base_style: Style,
     is_selected: bool,
+    theme: &Theme,
 ) -> Vec<Span<'a>> {
     if query.is_empty() {
         return vec![Span::styled(text.to_string(), base_style)];
@@ -2304,12 +2333,12 @@ fn highlight_match_spans<'a>(
 
     let match_style = if is_selected {
         Style::default()
-            .bg(Color::DarkGray)
-            .fg(Color::Yellow)
+            .bg(theme.bg_selected)
+            .fg(theme.warning)
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default()
-            .fg(Color::Yellow)
+            .fg(theme.warning)
             .add_modifier(Modifier::BOLD)
     };
 
@@ -2397,6 +2426,7 @@ fn format_file_size(bytes: u64) -> String {
 }
 
 fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
     let visible_count = FILE_BROWSER_MAX_VISIBLE.min(
         if app.file_browser_filtered.is_empty() { 1 } else { app.file_browser_filtered.len() }
     );
@@ -2409,7 +2439,7 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let (popup_area, block) = centered_popup(
-        frame, area, FILE_BROWSER_POPUP_WIDTH, pref_height, &title,
+        frame, area, FILE_BROWSER_POPUP_WIDTH, pref_height, &title, theme,
     );
 
     let inner_height = popup_area.height.saturating_sub(2) as usize;
@@ -2425,18 +2455,18 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     let dir_truncated = truncate(&dir_display, inner_w.saturating_sub(2));
     lines.push(Line::from(Span::styled(
         format!("  {dir_truncated}"),
-        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
     )));
 
     if let Some(ref err) = app.file_browser_error {
         lines.push(Line::from(Span::styled(
             format!("  {}", truncate(err, inner_w.saturating_sub(2))),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme.error),
         )));
     } else if app.file_browser_filtered.is_empty() {
         lines.push(Line::from(Span::styled(
             "  Empty directory",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme.fg_muted),
         )));
     } else {
         // Scroll the list so the selected item is always visible
@@ -2472,20 +2502,20 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
 
             let name_style = if is_selected {
                 if is_dir {
-                    Style::default().bg(Color::DarkGray).fg(Color::Cyan).add_modifier(Modifier::BOLD)
+                    Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().bg(Color::DarkGray).fg(Color::White).add_modifier(Modifier::BOLD)
+                    Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
                 }
             } else if is_dir {
-                Style::default().fg(Color::Cyan)
+                Style::default().fg(theme.accent)
             } else {
-                Style::default().fg(Color::White)
+                Style::default().fg(theme.fg)
             };
 
             let size_style = if is_selected {
-                Style::default().bg(Color::DarkGray).fg(Color::DarkGray)
+                Style::default().bg(theme.bg_selected).fg(theme.fg_muted)
             } else {
-                Style::default().fg(Color::DarkGray)
+                Style::default().fg(theme.fg_muted)
             };
 
             // Pad name to align size column
@@ -2507,7 +2537,85 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  j/k nav  Enter open/select  Backspace/- up  Esc cancel",
-        Style::default().fg(Color::DarkGray),
+        Style::default().fg(theme.fg_muted),
+    )));
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_theme_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let max_visible = 12usize.min(app.available_themes.len());
+    let pref_height = max_visible as u16 + 5; // border + title + footer
+
+    let (popup_area, block) = centered_popup(
+        frame, area, 50, pref_height, " Theme ", theme,
+    );
+
+    let inner_height = popup_area.height.saturating_sub(2) as usize;
+    let footer_lines = 2;
+    let visible_rows = inner_height.saturating_sub(footer_lines);
+
+    // Scroll the list so the selected item is always visible
+    let scroll_offset = if app.theme_index >= visible_rows {
+        app.theme_index - visible_rows + 1
+    } else {
+        0
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    let end = (scroll_offset + visible_rows).min(app.available_themes.len());
+    for (i, t) in app.available_themes[scroll_offset..end].iter().enumerate() {
+        let actual_index = scroll_offset + i;
+        let is_selected = actual_index == app.theme_index;
+        let is_active = t.name == app.theme.name;
+
+        let marker = if is_active { "[*]" } else { "[ ]" };
+        let row_style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+        let marker_style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(if is_active { theme.success } else { theme.fg_muted })
+        } else {
+            Style::default().fg(if is_active { theme.success } else { theme.fg_muted })
+        };
+
+        // Color swatches: show accent, success, error as colored blocks
+        let swatch_bg = if is_selected { theme.bg_selected } else { theme.bg };
+        let swatch_accent = Span::styled("\u{2588}\u{2588}", Style::default().fg(t.accent).bg(swatch_bg));
+        let swatch_success = Span::styled("\u{2588}\u{2588}", Style::default().fg(t.success).bg(swatch_bg));
+        let swatch_error = Span::styled("\u{2588}\u{2588}", Style::default().fg(t.error).bg(swatch_bg));
+
+        // Pad name to align swatches
+        let name_width = 28;
+        let display_name = truncate(&t.name, name_width);
+        let padded_name = format!("{display_name:width$}", width = name_width);
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {marker} "), marker_style),
+            Span::styled(padded_name, row_style),
+            Span::raw(" "),
+            swatch_accent,
+            Span::raw(" "),
+            swatch_success,
+            Span::raw(" "),
+            swatch_error,
+        ]));
+    }
+
+    // Pad to fill visible rows
+    while lines.len() < visible_rows {
+        lines.push(Line::from(""));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  j/k navigate  |  Enter apply  |  Esc cancel",
+        Style::default().fg(theme.fg_muted),
     )));
 
     let popup = Paragraph::new(lines).block(block);


### PR DESCRIPTION
## Summary
- Add a theming system with 8 built-in color themes (Default, Catppuccin Mocha/Latte, Dracula, Nord, Gruvbox Dark, mIRC Dark/Light) and custom theme support from TOML files
- Replace all ~166 hardcoded `Color::` literals in the UI with ~30 semantic theme fields for full theme coverage
- Add `/theme` command with picker overlay (j/k/Enter/Esc navigation, color swatches) and settings integration

## Changes
| File | What changed |
|------|-------------|
| `src/theme.rs` | **New** — `Theme` struct, custom Color serde (hex/named/indexed), 8 built-in themes, custom theme loading from `~/.config/signal-tui/themes/*.toml` |
| `src/config.rs` | Added `theme: String` field (default "Default") |
| `src/input.rs` | Added `/theme` command (alias `/t`) → `InputAction::Theme` |
| `src/app.rs` | Added theme state fields, `handle_theme_key()`, theme picker overlay, settings integration |
| `src/ui.rs` | Replaced all `Color::` with `app.theme.*`, added `draw_theme_picker()` |
| `src/main.rs` | Added `mod theme`, theme loading at startup, themed OSC 8 links |

## Test plan
- [x] `cargo clippy --tests -- -D warnings` — zero warnings
- [x] `cargo test` — all 229 tests pass (including 7 new theme tests)
- [ ] Manual: `/theme` → picker opens, j/k to browse, Enter to apply → colors change immediately
- [ ] Manual: each of 8 themes renders correctly (no invisible text, readable contrast)
- [ ] Manual: `/settings` → scroll to Theme entry → Enter opens picker
- [ ] Manual: theme persists after restart (check `config.toml` has `theme = "..."`)
- [ ] Manual: create custom `.toml` theme in `~/.config/signal-tui/themes/`, verify it appears in picker

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)