### PR TITLE
Fix mouse capture lost after signal-cli spawn on Windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -647,6 +647,10 @@ async fn run_app(
 
     let mut last_expiry_sweep = Instant::now();
 
+    // Re-enable mouse capture — on Windows, spawning cmd.exe subprocesses
+    // (signal-cli.bat, check_account_registered) can reset console input mode flags.
+    execute!(terminal.backend_mut(), EnableMouseCapture)?;
+
     loop {
         // Force full redraw when active conversation changes (clears native image artifacts)
         if app.native_images && app.active_conversation != app.prev_active_conversation {


### PR DESCRIPTION
## Summary
- On Windows, spawning `signal-cli.bat` (cmd.exe) resets console input mode flags, stripping `ENABLE_MOUSE_INPUT` set by crossterm's `EnableMouseCapture`
- This happens during `check_account_registered` and `SignalClient::spawn`, both before the event loop
- Demo mode was unaffected because it skips all subprocess spawning
- Fix: re-send `EnableMouseCapture` right before the event loop, after all subprocess work is done

## Test plan
- [ ] `cargo run` on Windows — verify mouse clicks and scrolling work
- [ ] `cargo run -- --debug demo` — verify mouse still works (regression check)
- [ ] Linux/macOS — verify no adverse effects (idempotent call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)