### PR TITLE
Add pinned messages support

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -119,6 +119,8 @@ pub struct DisplayMessage {
     pub is_edited: bool,
     /// Whether this message has been remotely deleted
     pub is_deleted: bool,
+    /// Whether this message is pinned
+    pub is_pinned: bool,
     /// Phone number / ID of the sender (for wire protocol; "you" for outgoing)
     pub sender_id: String,
     /// Disappearing message timer (seconds, 0 = no expiration)
@@ -453,6 +455,18 @@ pub enum SendRequest {
     Unblock {
         recipient: String,
         is_group: bool,
+    },
+    Pin {
+        recipient: String,
+        is_group: bool,
+        target_author: String,
+        target_timestamp: i64,
+    },
+    Unpin {
+        recipient: String,
+        is_group: bool,
+        target_author: String,
+        target_timestamp: i64,
     },
 }
 
@@ -1203,6 +1217,13 @@ impl App {
                 nerd_icon: "\u{f0a79}",
             });
         }
+        if !msg.is_system && !msg.is_deleted {
+            items.push(MenuAction {
+                label: if msg.is_pinned { "Unpin" } else { "Pin" },
+                key_hint: "p",
+                nerd_icon: "\u{f0403}",
+            });
+        }
         items
     }
 
@@ -1235,13 +1256,14 @@ impl App {
                     None
                 }
             }
-            KeyCode::Char(c @ ('q' | 'e' | 'r' | 'y' | 'd')) => {
+            KeyCode::Char(c @ ('q' | 'e' | 'r' | 'y' | 'd' | 'p')) => {
                 let hint = match c {
                     'q' => "q",
                     'e' => "e",
                     'r' => "r",
                     'y' => "y",
                     'd' => "d",
+                    'p' => "p",
                     _ => unreachable!(),
                 };
                 // Only execute if this action is available in the menu
@@ -1325,6 +1347,10 @@ impl App {
                     }
                 }
                 None
+            }
+            "p" => {
+                // Pin/Unpin
+                self.execute_pin_toggle()
             }
             _ => None,
         }
@@ -2108,7 +2134,7 @@ impl App {
     }
 
     /// Handle Normal mode key. Returns true if consumed.
-    pub fn handle_normal_key(&mut self, modifiers: KeyModifiers, code: KeyCode) {
+    pub fn handle_normal_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> Option<SendRequest> {
         match (modifiers, code) {
             // Scrolling (line-by-line: clear focused_msg_index so the draw
             // function re-derives it from the viewport position each frame)
@@ -2333,8 +2359,14 @@ impl App {
                 }
             }
 
+            // Pin/Unpin focused message
+            (_, KeyCode::Char('p')) => {
+                return self.execute_pin_toggle();
+            }
+
             _ => {}
         }
+        None
     }
 
     /// Handle Insert mode key.
@@ -2446,6 +2478,16 @@ impl App {
                 conv_id, sender: _, target_timestamp,
             } => {
                 self.handle_remote_delete(&conv_id, target_timestamp);
+            }
+            SignalEvent::PinReceived {
+                conv_id, sender, target_author: _, target_timestamp,
+            } => {
+                self.handle_pin_received(&conv_id, &sender, target_timestamp, true);
+            }
+            SignalEvent::UnpinReceived {
+                conv_id, sender, target_author: _, target_timestamp,
+            } => {
+                self.handle_pin_received(&conv_id, &sender, target_timestamp, false);
             }
             SignalEvent::SystemMessage { conv_id, body, timestamp, timestamp_ms } => {
                 self.handle_system_message(&conv_id, &body, timestamp, timestamp_ms);
@@ -2599,6 +2641,7 @@ impl App {
                     quote,
                     is_edited: false,
                     is_deleted: false,
+                    is_pinned: false,
                     sender_id: sender_id.clone(),
                     expires_in_seconds: msg_expires_in,
                     expiration_start_ms: msg_expiration_start,
@@ -2740,6 +2783,7 @@ impl App {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -2948,6 +2992,70 @@ impl App {
             self.db.mark_message_deleted(conv_id, target_timestamp),
             "mark_message_deleted",
         );
+    }
+
+    fn handle_pin_received(&mut self, conv_id: &str, sender: &str, target_timestamp: i64, pinned: bool) {
+        if let Some(conv) = self.conversations.get_mut(conv_id) {
+            if let Some(msg) = conv.messages.iter_mut().rev().find(|m| m.timestamp_ms == target_timestamp) {
+                msg.is_pinned = pinned;
+            }
+        }
+        db_warn(
+            self.db.set_message_pinned(conv_id, target_timestamp, pinned),
+            "set_message_pinned",
+        );
+        // Insert system message
+        let sender_name = self.contact_names.get(sender).cloned().unwrap_or_else(|| sender.to_string());
+        let action = if pinned { "pinned" } else { "unpinned" };
+        let body = format!("{sender_name} {action} a message");
+        let now = Utc::now();
+        let now_ms = now.timestamp_millis();
+        self.handle_system_message(conv_id, &body, now, now_ms);
+    }
+
+    fn execute_pin_toggle(&mut self) -> Option<SendRequest> {
+        let msg = self.selected_message()?;
+        if msg.is_system || msg.is_deleted {
+            return None;
+        }
+        let was_pinned = msg.is_pinned;
+        let target_timestamp = msg.timestamp_ms;
+        let author_phone = msg.sender_id.clone();
+        let conv_id = self.active_conversation.clone()?;
+        let is_group = self.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+
+        let target_author = if author_phone.is_empty() || author_phone == "you" {
+            self.account.clone()
+        } else {
+            author_phone
+        };
+
+        // Optimistically toggle
+        if let Some(conv) = self.conversations.get_mut(&conv_id) {
+            if let Some(m) = conv.messages.iter_mut().rev().find(|m| m.timestamp_ms == target_timestamp) {
+                m.is_pinned = !was_pinned;
+            }
+        }
+        db_warn(
+            self.db.set_message_pinned(&conv_id, target_timestamp, !was_pinned),
+            "set_message_pinned",
+        );
+
+        if was_pinned {
+            Some(SendRequest::Unpin {
+                recipient: conv_id,
+                is_group,
+                target_author,
+                target_timestamp,
+            })
+        } else {
+            Some(SendRequest::Pin {
+                recipient: conv_id,
+                is_group,
+                target_author,
+                target_timestamp,
+            })
+        }
     }
 
     fn handle_read_sync(&mut self, read_messages: Vec<(String, i64)>) {
@@ -3634,6 +3742,7 @@ impl App {
                             quote,
                             is_edited: false,
                             is_deleted: false,
+                            is_pinned: false,
                             sender_id: self.account.clone(),
                             expires_in_seconds: out_expires,
                             expiration_start_ms: out_expiry_start,
@@ -5223,6 +5332,7 @@ mod tests {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -5275,6 +5385,7 @@ mod tests {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -5318,6 +5429,7 @@ mod tests {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -5361,6 +5473,7 @@ mod tests {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -5429,6 +5542,7 @@ mod tests {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -5622,6 +5736,7 @@ mod tests {
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
+                is_pinned: false,
                 sender_id: String::new(),
                 expires_in_seconds: 0,
                 expiration_start_ms: 0,
@@ -5690,6 +5805,7 @@ mod tests {
             quote: None,
             is_edited: false,
             is_deleted: false,
+            is_pinned: false,
             sender_id: "+3".to_string(), // Charlie's phone — not in contacts
             expires_in_seconds: 0,
             expiration_start_ms: 0,
@@ -5714,6 +5830,7 @@ mod tests {
             quote: Some(Quote { author: "+10000000000".to_string(), body: "quoted".to_string(), timestamp_ms: 500, author_id: "+10000000000".to_string() }),
             is_edited: false,
             is_deleted: false,
+            is_pinned: false,
             sender_id: "+1".to_string(),
             expires_in_seconds: 0,
             expiration_start_ms: 0,
@@ -5734,6 +5851,7 @@ mod tests {
             quote: Some(Quote { author: "+3".to_string(), body: "hey".to_string(), timestamp_ms: 900, author_id: "+3".to_string() }),
             is_edited: false,
             is_deleted: false,
+            is_pinned: false,
             sender_id: "+10000000000".to_string(),
             expires_in_seconds: 0,
             expiration_start_ms: 0,

--- a/src/db.rs
+++ b/src/db.rs
@@ -184,6 +184,17 @@ impl Database {
             )?;
         }
 
+        if version < 10 {
+            self.conn.execute_batch(
+                "
+                BEGIN;
+                ALTER TABLE messages ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0;
+                UPDATE schema_version SET version = 10;
+                COMMIT;
+                ",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -238,7 +249,7 @@ impl Database {
         for (id, name, is_group, expiration_timer, accepted) in convs {
             // Load last N messages
             let mut msg_stmt = self.conn.prepare(
-                "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms FROM messages
+                "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned FROM messages
                  WHERE conversation_id = ?1
                  ORDER BY timestamp_ms DESC, rowid DESC LIMIT ?2",
             )?;
@@ -259,10 +270,11 @@ impl Database {
                     let sender_id: String = row.get(11)?;
                     let expires_in_seconds: i64 = row.get(12)?;
                     let expiration_start_ms: i64 = row.get(13)?;
-                    Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms))
+                    let is_pinned: bool = row.get::<_, i32>(14)? != 0;
+                    Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned))
                 })?
                 .filter_map(|r| r.ok())
-                .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms)| {
+                .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned)| {
                     let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
                         .ok()?
                         .with_timezone(&chrono::Utc);
@@ -290,6 +302,7 @@ impl Database {
                         quote,
                         is_edited,
                         is_deleted,
+                        is_pinned,
                         sender_id,
                         expires_in_seconds,
                         expiration_start_ms,
@@ -539,6 +552,16 @@ impl Database {
             "UPDATE messages SET is_deleted = 1, body = '[deleted]'
              WHERE conversation_id = ?1 AND timestamp_ms = ?2",
             params![conv_id, timestamp_ms],
+        )?;
+        Ok(())
+    }
+
+    /// Set the pinned state of a message.
+    pub fn set_message_pinned(&self, conv_id: &str, timestamp_ms: i64, pinned: bool) -> Result<()> {
+        self.conn.execute(
+            "UPDATE messages SET pinned = ?3
+             WHERE conversation_id = ?1 AND timestamp_ms = ?2",
+            params![conv_id, timestamp_ms, pinned as i32],
         )?;
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -598,6 +598,16 @@ async fn dispatch_send(
                 app.status_message = format!("unblock error: {e}");
             }
         }
+        SendRequest::Pin { recipient, is_group, target_author, target_timestamp } => {
+            if let Err(e) = signal_client.send_pin_message(&recipient, is_group, &target_author, target_timestamp).await {
+                app.status_message = format!("pin error: {e}");
+            }
+        }
+        SendRequest::Unpin { recipient, is_group, target_author, target_timestamp } => {
+            if let Err(e) = signal_client.send_unpin_message(&recipient, is_group, &target_author, target_timestamp).await {
+                app.status_message = format!("unpin error: {e}");
+            }
+        }
         SendRequest::MessageRequestResponse { recipient, is_group, response_type } => {
             if let Err(e) = signal_client.send_message_request_response(&recipient, is_group, &response_type).await {
                 app.status_message = format!("message request error: {e}");
@@ -681,10 +691,7 @@ async fn run_app(
                         }
                         if !overlay_handled {
                             let send_request = match app.mode {
-                                InputMode::Normal => {
-                                    app.handle_normal_key(key.modifiers, key.code);
-                                    None
-                                }
+                                InputMode::Normal => app.handle_normal_key(key.modifiers, key.code),
                                 InputMode::Insert => app.handle_insert_key(key.modifiers, key.code),
                             };
                             if let Some(req) = send_request {
@@ -820,11 +827,11 @@ async fn run_demo_app(
                     if !app.handle_global_key(key.modifiers, key.code) {
                         let (overlay_handled, _) = app.handle_overlay_key(key.code);
                         if !overlay_handled {
-                            match app.mode {
+                            let _ = match app.mode {
                                 InputMode::Normal => app.handle_normal_key(key.modifiers, key.code),
                                 // In demo mode, messages echo locally but don't send
-                                InputMode::Insert => { app.handle_insert_key(key.modifiers, key.code); }
-                            }
+                                InputMode::Insert => app.handle_insert_key(key.modifiers, key.code),
+                            };
                         }
                     }
                 }
@@ -885,6 +892,7 @@ fn populate_demo_data(app: &mut App) {
             quote: None,
             is_edited: false,
             is_deleted: false,
+            is_pinned: false,
             sender_id: String::new(),
             expires_in_seconds: 0,
             expiration_start_ms: 0,

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -338,6 +338,94 @@ impl SignalClient {
         Ok(())
     }
 
+    pub async fn send_pin_message(
+        &self,
+        recipient: &str,
+        is_group: bool,
+        target_author: &str,
+        target_timestamp: i64,
+    ) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("sendPinMessage".to_string(), Instant::now()));
+        }
+
+        let params = if is_group {
+            serde_json::json!({
+                "groupId": recipient,
+                "targetAuthor": target_author,
+                "targetTimestamp": target_timestamp,
+                "account": self.account,
+            })
+        } else {
+            serde_json::json!({
+                "recipient": [recipient],
+                "targetAuthor": target_author,
+                "targetTimestamp": target_timestamp,
+                "account": self.account,
+            })
+        };
+
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "sendPinMessage".to_string(),
+            id,
+            params: Some(params),
+        };
+
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send pin message to signal-cli stdin")?;
+        Ok(())
+    }
+
+    pub async fn send_unpin_message(
+        &self,
+        recipient: &str,
+        is_group: bool,
+        target_author: &str,
+        target_timestamp: i64,
+    ) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("sendUnpinMessage".to_string(), Instant::now()));
+        }
+
+        let params = if is_group {
+            serde_json::json!({
+                "groupId": recipient,
+                "targetAuthor": target_author,
+                "targetTimestamp": target_timestamp,
+                "account": self.account,
+            })
+        } else {
+            serde_json::json!({
+                "recipient": [recipient],
+                "targetAuthor": target_author,
+                "targetTimestamp": target_timestamp,
+                "account": self.account,
+            })
+        };
+
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "sendUnpinMessage".to_string(),
+            id,
+            params: Some(params),
+        };
+
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send unpin message to signal-cli stdin")?;
+        Ok(())
+    }
+
     pub async fn list_groups(&self) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         if let Ok(mut map) = self.pending_requests.lock() {
@@ -862,7 +950,7 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
                 .collect();
             Some(SignalEvent::GroupList(groups))
         }
-        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" | "block" | "unblock" => None, // fire-and-forget, no action needed
+        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" | "block" | "unblock" | "sendPinMessage" | "sendUnpinMessage" => None, // fire-and-forget, no action needed
         _ => None,
     }
 }
@@ -1080,6 +1168,54 @@ fn parse_data_message(
         return parse_reaction(envelope, reaction, group_id);
     }
 
+    // Check for pin message
+    if let Some(pin) = data.get("pinMessage") {
+        let target_author = pin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+        let target_timestamp = pin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let sender = envelope
+            .get("sourceNumber")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let group_id = data
+            .get("groupInfo")
+            .and_then(|g| g.get("groupId"))
+            .and_then(|v| v.as_str());
+        let conv_id = group_id
+            .map(|g| g.to_string())
+            .unwrap_or_else(|| sender.clone());
+        return Some(SignalEvent::PinReceived {
+            conv_id,
+            sender,
+            target_author,
+            target_timestamp,
+        });
+    }
+
+    // Check for unpin message
+    if let Some(unpin) = data.get("unpinMessage") {
+        let target_author = unpin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+        let target_timestamp = unpin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let sender = envelope
+            .get("sourceNumber")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let group_id = data
+            .get("groupInfo")
+            .and_then(|g| g.get("groupId"))
+            .and_then(|v| v.as_str());
+        let conv_id = group_id
+            .map(|g| g.to_string())
+            .unwrap_or_else(|| sender.clone());
+        return Some(SignalEvent::UnpinReceived {
+            conv_id,
+            sender,
+            target_author,
+            target_timestamp,
+        });
+    }
+
     // Check for remote delete
     if let Some(remote_delete) = data.get("remoteDelete") {
         let target_timestamp = remote_delete.get("timestamp").and_then(|v| v.as_i64())?;
@@ -1257,6 +1393,66 @@ fn parse_sent_sync(
     // Check for synced reaction before extracting body/attachments
     if let Some(reaction) = sent.get("reaction") {
         return parse_reaction_sync(envelope, sent, reaction);
+    }
+
+    // Check for synced pin message
+    if let Some(pin) = sent.get("pinMessage") {
+        let target_author = pin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+        let target_timestamp = pin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let sender = envelope
+            .get("sourceNumber")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let group_id = sent
+            .get("groupInfo")
+            .and_then(|g| g.get("groupId"))
+            .and_then(|v| v.as_str());
+        let conv_id = group_id
+            .map(|g| g.to_string())
+            .or_else(|| {
+                sent.get("destinationNumber")
+                    .or_else(|| sent.get("destination"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or_else(|| sender.clone());
+        return Some(SignalEvent::PinReceived {
+            conv_id,
+            sender,
+            target_author,
+            target_timestamp,
+        });
+    }
+
+    // Check for synced unpin message
+    if let Some(unpin) = sent.get("unpinMessage") {
+        let target_author = unpin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+        let target_timestamp = unpin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let sender = envelope
+            .get("sourceNumber")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let group_id = sent
+            .get("groupInfo")
+            .and_then(|g| g.get("groupId"))
+            .and_then(|v| v.as_str());
+        let conv_id = group_id
+            .map(|g| g.to_string())
+            .or_else(|| {
+                sent.get("destinationNumber")
+                    .or_else(|| sent.get("destination"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or_else(|| sender.clone());
+        return Some(SignalEvent::UnpinReceived {
+            conv_id,
+            sender,
+            target_author,
+            target_timestamp,
+        });
     }
 
     // Check for synced remote delete

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -96,6 +96,20 @@ pub enum SignalEvent {
         sender: String,
         target_timestamp: i64,
     },
+    PinReceived {
+        conv_id: String,
+        sender: String,
+        #[allow(dead_code)]
+        target_author: String,
+        target_timestamp: i64,
+    },
+    UnpinReceived {
+        conv_id: String,
+        sender: String,
+        #[allow(dead_code)]
+        target_author: String,
+        target_timestamp: i64,
+    },
     SystemMessage {
         conv_id: String,
         body: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -675,9 +675,48 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             .title_style(Style::default().fg(theme.accent));
     }
 
-    let inner = block.inner(area);
-    app.mouse_messages_area = inner;
+    let full_inner = block.inner(area);
     frame.render_widget(block, area);
+
+    let messages_ref = match &app.active_conversation {
+        Some(id) => app.conversations.get(id).map(|c| &c.messages),
+        None => None,
+    };
+
+    // Find the most recently pinned message for the banner
+    let pinned_banner: Option<(String, String)> = messages_ref.and_then(|msgs| {
+        msgs.iter()
+            .rev()
+            .find(|m| m.is_pinned && !m.is_deleted)
+            .map(|m| {
+                let sender = m.sender.clone();
+                let body: String = m.body.chars().take(80).collect();
+                (sender, body)
+            })
+    });
+
+    let (banner_area, inner) = if pinned_banner.is_some() && full_inner.height > 2 {
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(0)])
+            .split(full_inner);
+        (Some(chunks[0]), chunks[1])
+    } else {
+        (None, full_inner)
+    };
+
+    if let Some((ref pin_sender, ref pin_body)) = pinned_banner {
+        if let Some(banner) = banner_area {
+            let pin_text = format!("\u{1f4cc} {pin_sender}: {pin_body}");
+            let pin_line = Line::from(Span::styled(
+                truncate(&pin_text, banner.width as usize),
+                Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
+            ));
+            frame.render_widget(Paragraph::new(pin_line), banner);
+        }
+    }
+
+    app.mouse_messages_area = inner;
 
     let messages = match &app.active_conversation {
         Some(id) => {
@@ -811,6 +850,14 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 spans.push(Span::styled(
                     " (edited)",
                     Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
+                ));
+            }
+
+            // "(pinned)" label
+            if msg.is_pinned {
+                spans.push(Span::styled(
+                    " (pinned)",
+                    Style::default().fg(theme.warning).add_modifier(Modifier::ITALIC),
                 ));
             }
 


### PR DESCRIPTION
## Summary
- Parse `pinMessage`/`unpinMessage` from signal-cli JSON-RPC (incoming + outgoing sync)
- Send pin/unpin via `sendPinMessage`/`sendUnpinMessage` RPC methods
- `(pinned)` indicator on messages + pinned banner at top of chat
- `p` keybinding in Normal mode + Pin/Unpin entry in action menu (Enter)
- System message "X pinned/unpinned a message" on pin events
- DB migration v10: `pinned` column on messages table for persistence

Closes #65

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — all 229 tests pass
- [x] Manual: receive pinned message → "(pinned)" indicator + banner shown
- [x] Manual: press `p` on message → pin sends, indicator appears
- [x] Manual: press `p` on pinned message → unpin sends, indicator removed
- [x] Manual: action menu shows Pin/Unpin option
- [x] Manual: system message appears on pin/unpin events
- [x] Manual: pinned state persists after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)