### PR TITLE
Add pin duration picker, own-pin system messages, multi-pin banner

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -92,6 +92,14 @@ pub struct Quote {
     pub author_id: String,
 }
 
+/// Context saved when the pin duration picker is open (remembers which message is being pinned).
+pub struct PinPending {
+    pub conv_id: String,
+    pub is_group: bool,
+    pub target_author: String,
+    pub target_timestamp: i64,
+}
+
 /// A single displayed message in a conversation
 #[derive(Debug, Clone)]
 pub struct DisplayMessage {
@@ -360,6 +368,12 @@ pub struct App {
     pub theme_index: usize,
     /// All available themes (built-in + custom)
     pub available_themes: Vec<Theme>,
+    /// Pin duration picker overlay visible
+    pub show_pin_duration: bool,
+    /// Cursor position in pin duration picker
+    pub pin_duration_index: usize,
+    /// Pending pin context while duration picker is open
+    pub pin_pending: Option<PinPending>,
 }
 
 /// A search result entry.
@@ -373,6 +387,13 @@ pub struct SearchResult {
 }
 
 pub const QUICK_REACTIONS: &[&str] = &["\u{1f44d}", "\u{1f44e}", "\u{2764}\u{fe0f}", "\u{1f602}", "\u{1f62e}", "\u{1f622}", "\u{1f64f}", "\u{1f525}"];
+
+pub const PIN_DURATIONS: &[(i64, &str)] = &[
+    (-1, "Forever"),
+    (86400, "24 hours"),
+    (604800, "7 days"),
+    (2592000, "30 days"),
+];
 
 /// A request from the UI to the main loop to send something.
 pub enum SendRequest {
@@ -461,6 +482,7 @@ pub enum SendRequest {
         is_group: bool,
         target_author: String,
         target_timestamp: i64,
+        pin_duration: i64,
     },
     Unpin {
         recipient: String,
@@ -1841,6 +1863,9 @@ impl App {
             show_theme_picker: false,
             theme_index: 0,
             available_themes: theme::all_themes(),
+            show_pin_duration: false,
+            pin_duration_index: 0,
+            pin_pending: None,
         }
     }
 
@@ -2082,6 +2107,10 @@ impl App {
     /// command triggers a message send. Returns `None` otherwise.
     /// Returns `Ok(true)` if the key was consumed by an overlay.
     pub fn handle_overlay_key(&mut self, code: KeyCode) -> (bool, Option<SendRequest>) {
+        if self.show_pin_duration {
+            let send = self.handle_pin_duration_key(code);
+            return (true, send);
+        }
         if self.show_action_menu {
             let send = self.handle_action_menu_key(code);
             return (true, send);
@@ -3040,18 +3069,23 @@ impl App {
             author_phone
         };
 
-        // Optimistically toggle
-        if let Some(conv) = self.conversations.get_mut(&conv_id) {
-            if let Some(m) = conv.messages.iter_mut().rev().find(|m| m.timestamp_ms == target_timestamp) {
-                m.is_pinned = !was_pinned;
-            }
-        }
-        db_warn(
-            self.db.set_message_pinned(&conv_id, target_timestamp, !was_pinned),
-            "set_message_pinned",
-        );
-
         if was_pinned {
+            // Unpin immediately — no duration needed
+            if let Some(conv) = self.conversations.get_mut(&conv_id) {
+                if let Some(m) = conv.messages.iter_mut().rev().find(|m| m.timestamp_ms == target_timestamp) {
+                    m.is_pinned = false;
+                }
+            }
+            db_warn(
+                self.db.set_message_pinned(&conv_id, target_timestamp, false),
+                "set_message_pinned",
+            );
+            self.scroll_offset = 0;
+            self.focused_msg_index = None;
+            let body = "you unpinned a message";
+            let now = Utc::now();
+            let now_ms = now.timestamp_millis();
+            self.handle_system_message(&conv_id, body, now, now_ms);
             Some(SendRequest::Unpin {
                 recipient: conv_id,
                 is_group,
@@ -3059,12 +3093,68 @@ impl App {
                 target_timestamp,
             })
         } else {
-            Some(SendRequest::Pin {
-                recipient: conv_id,
+            // Open pin duration picker
+            self.pin_pending = Some(PinPending {
+                conv_id,
                 is_group,
                 target_author,
                 target_timestamp,
-            })
+            });
+            self.show_pin_duration = true;
+            self.pin_duration_index = 0;
+            None
+        }
+    }
+
+    /// Handle a key press while the pin duration picker overlay is open.
+    pub fn handle_pin_duration_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.pin_duration_index < PIN_DURATIONS.len() - 1 {
+                    self.pin_duration_index += 1;
+                }
+                None
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.pin_duration_index = self.pin_duration_index.saturating_sub(1);
+                None
+            }
+            KeyCode::Enter => {
+                let duration = PIN_DURATIONS[self.pin_duration_index].0;
+                self.show_pin_duration = false;
+                let pending = self.pin_pending.take()?;
+
+                // Optimistically pin
+                if let Some(conv) = self.conversations.get_mut(&pending.conv_id) {
+                    if let Some(m) = conv.messages.iter_mut().rev().find(|m| m.timestamp_ms == pending.target_timestamp) {
+                        m.is_pinned = true;
+                    }
+                }
+                db_warn(
+                    self.db.set_message_pinned(&pending.conv_id, pending.target_timestamp, true),
+                    "set_message_pinned",
+                );
+                self.scroll_offset = 0;
+                self.focused_msg_index = None;
+                let body = "you pinned a message";
+                let now = Utc::now();
+                let now_ms = now.timestamp_millis();
+                self.handle_system_message(&pending.conv_id, body, now, now_ms);
+
+                Some(SendRequest::Pin {
+                    recipient: pending.conv_id,
+                    is_group: pending.is_group,
+                    target_author: pending.target_author,
+                    target_timestamp: pending.target_timestamp,
+                    pin_duration: duration,
+                })
+            }
+            KeyCode::Esc => {
+                self.show_pin_duration = false;
+                self.pin_pending = None;
+                None
+            }
+            _ => None,
         }
     }
 
@@ -4519,6 +4609,7 @@ impl App {
             || self.group_menu_state.is_some()
             || self.show_message_request
             || self.show_theme_picker
+            || self.show_pin_duration
             || self.autocomplete_visible
     }
 
@@ -7014,6 +7105,10 @@ mod tests {
         app.autocomplete_visible = true;
         assert!(app.has_overlay());
         app.autocomplete_visible = false;
+
+        app.show_pin_duration = true;
+        assert!(app.has_overlay());
+        app.show_pin_duration = false;
 
         assert!(!app.has_overlay());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -598,8 +598,8 @@ async fn dispatch_send(
                 app.status_message = format!("unblock error: {e}");
             }
         }
-        SendRequest::Pin { recipient, is_group, target_author, target_timestamp } => {
-            if let Err(e) = signal_client.send_pin_message(&recipient, is_group, &target_author, target_timestamp).await {
+        SendRequest::Pin { recipient, is_group, target_author, target_timestamp, pin_duration } => {
+            if let Err(e) = signal_client.send_pin_message(&recipient, is_group, &target_author, target_timestamp, pin_duration).await {
                 app.status_message = format!("pin error: {e}");
             }
         }

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -345,6 +345,7 @@ impl SignalClient {
         is_group: bool,
         target_author: &str,
         target_timestamp: i64,
+        pin_duration: i64,
     ) -> Result<()> {
         let id = Uuid::new_v4().to_string();
 
@@ -357,6 +358,7 @@ impl SignalClient {
                 "groupId": recipient,
                 "targetAuthor": target_author,
                 "targetTimestamp": target_timestamp,
+                "pinDuration": pin_duration,
                 "account": self.account,
             })
         } else {
@@ -364,6 +366,7 @@ impl SignalClient {
                 "recipient": [recipient],
                 "targetAuthor": target_author,
                 "targetTimestamp": target_timestamp,
+                "pinDuration": pin_duration,
                 "account": self.account,
             })
         };
@@ -401,6 +404,7 @@ impl SignalClient {
                 "groupId": recipient,
                 "targetAuthor": target_author,
                 "targetTimestamp": target_timestamp,
+                "pinDuration": -1,
                 "account": self.account,
             })
         } else {
@@ -408,6 +412,7 @@ impl SignalClient {
                 "recipient": [recipient],
                 "targetAuthor": target_author,
                 "targetTimestamp": target_timestamp,
+                "pinDuration": -1,
                 "account": self.account,
             })
         };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, VisibleImage, QUICK_REACTIONS, SETTINGS};
+use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, VisibleImage, PIN_DURATIONS, QUICK_REACTIONS, SETTINGS};
 use crate::signal::types::{MessageStatus, Reaction, StyleType};
 use crate::image_render::ImageProtocol;
 use crate::input::{COMMANDS, format_compact_duration};
@@ -512,6 +512,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_theme_picker(frame, app, size);
     }
 
+    // Pin duration picker overlay
+    if app.show_pin_duration {
+        draw_pin_duration_picker(frame, app, size);
+    }
+
     // Collect link regions from the rendered buffer for OSC 8 injection
     let area = frame.area();
     app.link_regions = collect_link_regions(frame.buffer_mut(), area, app.theme.link);
@@ -683,19 +688,21 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         None => None,
     };
 
-    // Find the most recently pinned message for the banner
-    let pinned_banner: Option<(String, String)> = messages_ref.and_then(|msgs| {
-        msgs.iter()
-            .rev()
-            .find(|m| m.is_pinned && !m.is_deleted)
-            .map(|m| {
-                let sender = m.sender.clone();
+    // Build pinned message banner text
+    let pinned_banner_text: Option<String> = messages_ref.and_then(|msgs| {
+        let pinned: Vec<_> = msgs.iter().filter(|m| m.is_pinned && !m.is_deleted).collect();
+        match pinned.len() {
+            0 => None,
+            1 => {
+                let m = pinned[0];
                 let body: String = m.body.chars().take(80).collect();
-                (sender, body)
-            })
+                Some(format!("\u{1f4cc} {}: {body}", m.sender))
+            }
+            n => Some(format!("\u{1f4cc} {n} pinned messages")),
+        }
     });
 
-    let (banner_area, inner) = if pinned_banner.is_some() && full_inner.height > 2 {
+    let (banner_area, inner) = if pinned_banner_text.is_some() && full_inner.height > 2 {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([Constraint::Length(1), Constraint::Min(0)])
@@ -705,11 +712,10 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         (None, full_inner)
     };
 
-    if let Some((ref pin_sender, ref pin_body)) = pinned_banner {
+    if let Some(ref pin_text) = pinned_banner_text {
         if let Some(banner) = banner_area {
-            let pin_text = format!("\u{1f4cc} {pin_sender}: {pin_body}");
             let pin_line = Line::from(Span::styled(
-                truncate(&pin_text, banner.width as usize),
+                truncate(pin_text, banner.width as usize),
                 Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
             ));
             frame.render_widget(Paragraph::new(pin_line), banner);
@@ -2662,6 +2668,40 @@ fn draw_theme_picker(frame: &mut Frame, app: &App, area: Rect) {
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "  j/k navigate  |  Enter apply  |  Esc cancel",
+        Style::default().fg(theme.fg_muted),
+    )));
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_pin_duration_picker(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let item_count = PIN_DURATIONS.len();
+    let popup_height = item_count as u16 + 4; // borders + footer
+
+    let (popup_area, block) = centered_popup(
+        frame, area, 24, popup_height, " Pin Duration ", theme,
+    );
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    for (i, (_seconds, label)) in PIN_DURATIONS.iter().enumerate() {
+        let style = if i == app.pin_duration_index {
+            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+        let marker = if i == app.pin_duration_index { ">" } else { " " };
+        lines.push(Line::from(Span::styled(
+            format!(" {marker} {label}"),
+            style,
+        )));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        " j/k  Enter  Esc",
         Style::default().fg(theme.fg_muted),
     )));
 


### PR DESCRIPTION
## Summary
- Show "you pinned/unpinned a message" system message when toggling pins locally (previously only appeared for incoming pin notifications from other devices)
- Pin banner now shows "📌 N pinned messages" when 2+ messages are pinned, instead of only showing the most recent one
- Pressing `p` on an unpinned message opens a duration picker overlay (Forever, 24h, 7d, 30d) instead of hardcoding forever; pressing `p` on a pinned message still unpins immediately
- Pass `pinDuration` through `SendRequest::Pin` to signal-cli RPC, and add field to unpin RPC for signal-cli compatibility

## Test plan
- [ ] Press `p` on unpinned message → duration picker appears with 4 options (Forever, 24h, 7d, 30d)
- [ ] Select "Forever" → message pins, "you pinned a message" system message appears
- [ ] Press `p` on pinned message → unpins immediately, "you unpinned a message" system message appears
- [ ] Pin 2+ messages → banner shows "📌 2 pinned messages"
- [ ] Pin 1 message → banner shows "📌 sender: body" as before
- [ ] Esc in duration picker → closes without pinning
- [ ] j/k navigate the picker, Enter selects
- [ ] Receive pin from phone → system message shows display name (existing behavior preserved)
- [ ] `cargo clippy --tests -- -D warnings` passes
- [ ] `cargo test` — all 229 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)