### PR TITLE
Add link preview display for URLs in messages

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::image_render;
 use crate::image_render::ImageProtocol;
 use crate::input::{self, InputAction, COMMANDS};
 use crate::theme::{self, Theme};
-use crate::signal::types::{Contact, Group, Mention, MessageStatus, PollData, PollOption, PollVote, Reaction, SignalEvent, SignalMessage, StyleType, TextStyle};
+use crate::signal::types::{Contact, Group, LinkPreview, Mention, MessageStatus, PollData, PollOption, PollVote, Reaction, SignalEvent, SignalMessage, StyleType, TextStyle};
 
 /// Log a database error via debug_log (no-op when --debug is off).
 fn db_warn<T>(result: Result<T, impl std::fmt::Display>, context: &str) {
@@ -159,6 +159,12 @@ pub struct DisplayMessage {
     pub poll_data: Option<PollData>,
     /// Votes received for this poll
     pub poll_votes: Vec<PollVote>,
+    /// Link preview metadata
+    pub preview: Option<LinkPreview>,
+    /// Pre-rendered halfblock image lines for link preview thumbnail
+    pub preview_image_lines: Option<Vec<Line<'static>>>,
+    /// Local filesystem path for native protocol link preview thumbnail
+    pub preview_image_path: Option<String>,
 }
 
 impl DisplayMessage {
@@ -276,6 +282,8 @@ pub struct App {
     pub contacts_filtered: Vec<(String, String)>,
     /// Show inline halfblock image previews in chat
     pub inline_images: bool,
+    /// Show link previews (title, description, thumbnail) for URLs
+    pub show_link_previews: bool,
     /// Link regions detected in the last rendered frame (for OSC 8 injection)
     pub link_regions: Vec<crate::ui::LinkRegion>,
     /// Maps display text → hidden URL for attachment links (cleared each frame)
@@ -608,6 +616,13 @@ pub const SETTINGS: &[SettingDef] = &[
         on_toggle: Some(|a| a.refresh_image_previews()),
     },
     SettingDef {
+        label: "Link previews",
+        get: |a| a.show_link_previews,
+        set: |a, v| a.show_link_previews = v,
+        save: Some(|c, v| c.show_link_previews = v),
+        on_toggle: Some(|a| a.refresh_link_preview_images()),
+    },
+    SettingDef {
         label: "Native images (experimental)",
         get: |a| a.native_images,
         set: |a, v| a.native_images = v,
@@ -697,12 +712,40 @@ impl App {
             for msg in &mut conv.messages {
                 if msg.body.starts_with("[image:") {
                     if self.inline_images {
-                        // Re-render from stored path
                         if let Some(ref p) = msg.image_path {
                             msg.image_lines = image_render::render_image(Path::new(p), 40);
                         }
                     } else {
                         msg.image_lines = None;
+                    }
+                }
+                // Also refresh link preview thumbnails
+                if let Some(ref preview) = msg.preview {
+                    if self.inline_images && self.show_link_previews {
+                        if let Some(ref p) = preview.image_path {
+                            msg.preview_image_lines = image_render::render_image(Path::new(p), 30);
+                            msg.preview_image_path = Some(p.clone());
+                        }
+                    } else {
+                        msg.preview_image_lines = None;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Re-render or clear link preview thumbnails (after toggling show_link_previews).
+    fn refresh_link_preview_images(&mut self) {
+        for conv in self.conversations.values_mut() {
+            for msg in &mut conv.messages {
+                if let Some(ref preview) = msg.preview {
+                    if self.show_link_previews && self.inline_images {
+                        if let Some(ref p) = preview.image_path {
+                            msg.preview_image_lines = image_render::render_image(Path::new(p), 30);
+                            msg.preview_image_path = Some(p.clone());
+                        }
+                    } else {
+                        msg.preview_image_lines = None;
                     }
                 }
             }
@@ -1944,6 +1987,7 @@ impl App {
             contacts_filter: String::new(),
             contacts_filtered: Vec::new(),
             inline_images: true,
+            show_link_previews: true,
             link_regions: Vec::new(),
             link_url_map: HashMap::new(),
             image_protocol: image_render::detect_protocol(),
@@ -2056,6 +2100,19 @@ impl App {
                             msg.image_path = Some(p.clone());
                             if self.inline_images {
                                 msg.image_lines = image_render::render_image(path, 40);
+                            }
+                        }
+                    }
+                }
+
+                // Re-render link preview thumbnails from stored paths
+                if let Some(ref preview) = msg.preview {
+                    if self.show_link_previews && self.inline_images {
+                        if let Some(ref p) = preview.image_path {
+                            let path = Path::new(p);
+                            if path.exists() {
+                                msg.preview_image_lines = image_render::render_image(path, 30);
+                                msg.preview_image_path = Some(p.clone());
                             }
                         }
                     }
@@ -2859,6 +2916,9 @@ impl App {
                     expiration_start_ms: msg_expiration_start,
                     poll_data: deferred_poll,
                     poll_votes: Vec::new(),
+                    preview: None,
+                    preview_image_lines: None,
+                    preview_image_path: None,
                 });
                 // Bump last_read_index if we inserted before the read marker
                 if let Some(read_idx) = self.last_read_index.get_mut(&conv_id) {
@@ -2922,6 +2982,29 @@ impl App {
             } else {
                 push_msg(format!("[attachment: {label}]{path_info}"), None, None, Vec::new(), Vec::new(), None);
             }
+        }
+
+        // Attach first link preview to the body message (not attachment messages)
+        if let Some(preview) = msg.previews.into_iter().next() {
+            if let Some(conv) = self.conversations.get_mut(&conv_id) {
+                if let Some(dm) = conv.messages.iter_mut().rev()
+                    .find(|m| m.timestamp_ms == msg_ts_ms && !m.body.starts_with('['))
+                {
+                    let (img_lines, img_path) = if self.show_link_previews && self.inline_images {
+                        if let Some(ref p) = preview.image_path {
+                            (image_render::render_image(Path::new(p), 30), Some(p.clone()))
+                        } else {
+                            (None, None)
+                        }
+                    } else {
+                        (None, None)
+                    };
+                    dm.preview = Some(preview.clone());
+                    dm.preview_image_lines = img_lines;
+                    dm.preview_image_path = img_path;
+                }
+            }
+            db_warn(self.db.upsert_link_preview(&conv_id, msg_ts_ms, &preview), "upsert_link_preview");
         }
 
         let is_active = self
@@ -3006,6 +3089,9 @@ impl App {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
             // Bump last_read_index if we inserted before the read marker
             if let Some(read_idx) = self.last_read_index.get_mut(conv_id) {
@@ -4167,6 +4253,9 @@ impl App {
                             expiration_start_ms: out_expiry_start,
                             poll_data: None,
                             poll_votes: Vec::new(),
+                            preview: None,
+                            preview_image_lines: None,
+                            preview_image_path: None,
                         });
                         if out_expires > 0 {
                             self.expiring_msg_count += 1;
@@ -4407,6 +4496,9 @@ impl App {
                             expiration_start_ms: 0,
                             poll_data: Some(poll_data),
                             poll_votes: Vec::new(),
+                            preview: None,
+                            preview_image_lines: None,
+                            preview_image_path: None,
                         });
                     }
                     self.db_warn_visible(self.db.insert_message_full(
@@ -5199,6 +5291,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         assert_eq!(app.conversations["+15551234567"].name, "+15551234567");
@@ -5229,6 +5322,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         assert_eq!(app.conversations["+1"].name, "Alice");
@@ -5267,6 +5361,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
 
@@ -5299,6 +5394,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
 
@@ -5332,6 +5428,7 @@ mod tests {
                 text_styles: vec![],
                 quote: None,
                 expires_in_seconds: 0,
+                previews: Vec::new(),
             };
             app.handle_signal_event(SignalEvent::MessageReceived(msg));
         }
@@ -5774,6 +5871,9 @@ mod tests {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
         }
 
@@ -5828,6 +5928,9 @@ mod tests {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
         }
 
@@ -5873,6 +5976,9 @@ mod tests {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
         }
 
@@ -5918,6 +6024,9 @@ mod tests {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
         }
 
@@ -5950,6 +6059,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
 
@@ -5987,6 +6097,9 @@ mod tests {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
         }
 
@@ -6039,6 +6152,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let ts_ms = app.conversations["+1"].messages[0].timestamp_ms;
@@ -6078,6 +6192,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let ts_ms = app.conversations["+1"].messages[0].timestamp_ms;
@@ -6125,6 +6240,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let ts_ms = app.conversations["+1"].messages[0].timestamp_ms;
@@ -6183,6 +6299,9 @@ mod tests {
                 expiration_start_ms: 0,
                 poll_data: None,
                 poll_votes: Vec::new(),
+                preview: None,
+                preview_image_lines: None,
+                preview_image_path: None,
             });
         }
 
@@ -6254,6 +6373,9 @@ mod tests {
             expiration_start_ms: 0,
             poll_data: None,
             poll_votes: Vec::new(),
+            preview: None,
+            preview_image_lines: None,
+            preview_image_path: None,
         });
         conv.messages.push(DisplayMessage {
             sender: "Alice".to_string(),
@@ -6281,6 +6403,9 @@ mod tests {
             expiration_start_ms: 0,
             poll_data: None,
             poll_votes: Vec::new(),
+            preview: None,
+            preview_image_lines: None,
+            preview_image_path: None,
         });
         // A message with a quote from a non-contact
         conv.messages.push(DisplayMessage {
@@ -6304,6 +6429,9 @@ mod tests {
             expiration_start_ms: 0,
             poll_data: None,
             poll_votes: Vec::new(),
+            preview: None,
+            preview_image_lines: None,
+            preview_image_path: None,
         });
 
         // Contact list arrives — only +2 is a formal contact
@@ -6501,6 +6629,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
 
@@ -6664,6 +6793,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg1));
 
@@ -6690,6 +6820,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg2));
 
@@ -6718,6 +6849,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg("one", 1000)));
         app.handle_signal_event(SignalEvent::MessageReceived(msg("two", 2000)));
@@ -6754,6 +6886,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg("one", 1000)));
         app.handle_signal_event(SignalEvent::MessageReceived(msg("two", 2000)));
@@ -7023,6 +7156,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         }
     }
 
@@ -7055,6 +7189,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         assert!(app.conversations["+1"].accepted);
@@ -7414,6 +7549,7 @@ mod tests {
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
+            previews: Vec::new(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,10 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub inline_images: bool,
 
+    /// Show link previews (title, description, thumbnail) for URLs in messages
+    #[serde(default = "default_true")]
+    pub show_link_previews: bool,
+
     /// Experimental: use native terminal image protocols (Kitty/iTerm2) over halfblock
     #[serde(default)]
     pub native_images: bool,
@@ -93,6 +97,7 @@ impl Default for Config {
             notify_group: true,
             desktop_notifications: false,
             inline_images: true,
+            show_link_previews: true,
             native_images: false,
             show_receipts: true,
             color_receipts: true,

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use rusqlite::{params, Connection};
 
 use crate::app::{Conversation, DisplayMessage};
-use crate::signal::types::{MessageStatus, PollData, PollVote, Reaction};
+use crate::signal::types::{LinkPreview, MessageStatus, PollData, PollVote, Reaction};
 
 /// (sender, body, timestamp_ms, conversation_id, conversation_name)
 pub type SearchRow = (String, String, i64, String, String);
@@ -216,6 +216,17 @@ impl Database {
             )?;
         }
 
+        if version < 12 {
+            self.conn.execute_batch(
+                "
+                BEGIN;
+                ALTER TABLE messages ADD COLUMN link_preview TEXT;
+                UPDATE schema_version SET version = 12;
+                COMMIT;
+                ",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -270,7 +281,7 @@ impl Database {
         for (id, name, is_group, expiration_timer, accepted) in convs {
             // Load last N messages
             let mut msg_stmt = self.conn.prepare(
-                "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data FROM messages
+                "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data, link_preview FROM messages
                  WHERE conversation_id = ?1
                  ORDER BY timestamp_ms DESC, rowid DESC LIMIT ?2",
             )?;
@@ -293,10 +304,11 @@ impl Database {
                     let expiration_start_ms: i64 = row.get(13)?;
                     let is_pinned: bool = row.get::<_, i32>(14)? != 0;
                     let poll_data_json: Option<String> = row.get(15)?;
-                    Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json))
+                    let link_preview_json: Option<String> = row.get(16)?;
+                    Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json))
                 })?
                 .filter_map(|r| r.ok())
-                .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json)| {
+                .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json)| {
                     let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
                         .ok()?
                         .with_timezone(&chrono::Utc);
@@ -310,6 +322,7 @@ impl Database {
                         _ => None,
                     };
                     let poll_data = poll_data_json.and_then(|j| serde_json::from_str::<PollData>(&j).ok());
+                    let preview = link_preview_json.and_then(|j| serde_json::from_str::<LinkPreview>(&j).ok());
                     Some(DisplayMessage {
                         sender,
                         timestamp,
@@ -331,6 +344,9 @@ impl Database {
                         expiration_start_ms,
                         poll_data,
                         poll_votes: Vec::new(),
+                        preview,
+                        preview_image_lines: None,
+                        preview_image_path: None,
                     })
                 })
                 .collect();
@@ -751,6 +767,16 @@ impl Database {
         let json = serde_json::to_string(poll_data)?;
         self.conn.execute(
             "UPDATE messages SET poll_data = ?3
+             WHERE conversation_id = ?1 AND timestamp_ms = ?2",
+            params![conv_id, timestamp_ms, json],
+        )?;
+        Ok(())
+    }
+
+    pub fn upsert_link_preview(&self, conv_id: &str, timestamp_ms: i64, preview: &LinkPreview) -> Result<()> {
+        let json = serde_json::to_string(preview)?;
+        self.conn.execute(
+            "UPDATE messages SET link_preview = ?3
              WHERE conversation_id = ?1 AND timestamp_ms = ?2",
             params![conv_id, timestamp_ms, json],
         )?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -654,6 +654,7 @@ async fn run_app(
     app.notify_group = config.notify_group;
     app.desktop_notifications = config.desktop_notifications;
     app.inline_images = config.inline_images;
+    app.show_link_previews = config.show_link_previews;
     app.native_images = config.native_images;
     app.incognito = incognito;
     app.show_receipts = config.show_receipts;
@@ -922,6 +923,9 @@ fn populate_demo_data(app: &mut App) {
             expiration_start_ms: 0,
             poll_data: None,
             poll_votes: Vec::new(),
+            preview: None,
+            preview_image_lines: None,
+            preview_image_path: None,
         }
     };
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -1520,10 +1520,13 @@ fn parse_data_message(
         })
         .unwrap_or_default();
 
+    let mut previews = parse_link_previews(data, download_dir);
+
     // View-once messages: replace content with placeholder
     if data.get("viewOnce").and_then(|v| v.as_bool()).unwrap_or(false) {
         body = Some("[View-once message]".to_string());
         attachments = Vec::new();
+        previews = Vec::new();
     }
 
     let mentions = parse_mentions(data);
@@ -1555,6 +1558,7 @@ fn parse_data_message(
         text_styles,
         quote,
         expires_in_seconds,
+        previews,
     }))
 }
 
@@ -1877,10 +1881,13 @@ fn parse_sent_sync(
         })
         .unwrap_or_default();
 
+    let mut previews = parse_link_previews(sent, download_dir);
+
     // View-once messages: replace content with placeholder
     if sent.get("viewOnce").and_then(|v| v.as_bool()).unwrap_or(false) {
         body = Some("[View-once message]".to_string());
         attachments = Vec::new();
+        previews = Vec::new();
     }
 
     let mentions = parse_mentions(sent);
@@ -1912,6 +1919,7 @@ fn parse_sent_sync(
         text_styles,
         quote,
         expires_in_seconds,
+        previews,
     }))
 }
 
@@ -2105,6 +2113,30 @@ fn parse_attachment(
         filename: Some(effective_name),
         local_path,
     })
+}
+
+/// Parse link previews from a dataMessage / sentMessage object.
+fn parse_link_previews(
+    data: &serde_json::Value,
+    download_dir: &std::path::Path,
+) -> Vec<LinkPreview> {
+    // signal-cli uses "previews" (plural) in some versions, "preview" in others
+    let arr = data
+        .get("previews")
+        .or_else(|| data.get("preview"))
+        .and_then(|v| v.as_array());
+    let Some(arr) = arr else { return Vec::new() };
+    arr.iter()
+        .filter_map(|p| {
+            let url = p.get("url").and_then(|v| v.as_str())?.to_string();
+            let title = p.get("title").and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
+            let description = p.get("description").and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
+            let image_path = p.get("image")
+                .and_then(|img| parse_attachment(img, download_dir))
+                .and_then(|att| att.local_path);
+            Some(LinkPreview { url, title, description, image_path })
+        })
+        .collect()
 }
 
 /// Look for an attachment file in signal-cli's data directory by attachment ID.
@@ -3260,5 +3292,51 @@ mod tests {
             }
             _ => panic!("Expected PollTerminated, got {event:?}"),
         }
+    }
+
+    // --- Link preview parsing ---
+
+    #[test]
+    fn parse_link_preview_basic() {
+        let data = json!({
+            "previews": [{
+                "url": "https://example.com/article",
+                "title": "Example Article",
+                "description": "An interesting article",
+                "image": {
+                    "id": "abc123",
+                    "contentType": "image/jpeg"
+                }
+            }]
+        });
+        let previews = parse_link_previews(&data, std::path::Path::new("/tmp"));
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].url, "https://example.com/article");
+        assert_eq!(previews[0].title.as_deref(), Some("Example Article"));
+        assert_eq!(previews[0].description.as_deref(), Some("An interesting article"));
+    }
+
+    #[test]
+    fn parse_link_preview_missing() {
+        let data = json!({"body": "hello"});
+        let previews = parse_link_previews(&data, std::path::Path::new("/tmp"));
+        assert!(previews.is_empty());
+    }
+
+    #[test]
+    fn parse_link_preview_singular_key() {
+        // signal-cli may use "preview" (singular) instead of "previews"
+        let data = json!({
+            "preview": [{
+                "url": "https://example.com",
+                "title": "Test"
+            }]
+        });
+        let previews = parse_link_previews(&data, std::path::Path::new("/tmp"));
+        assert_eq!(previews.len(), 1);
+        assert_eq!(previews[0].url, "https://example.com");
+        assert_eq!(previews[0].title.as_deref(), Some("Test"));
+        assert!(previews[0].description.is_none());
+        assert!(previews[0].image_path.is_none());
     }
 }

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -196,6 +196,17 @@ pub struct SignalMessage {
     pub quote: Option<(i64, String, String)>,
     /// Disappearing message timer (seconds, 0 = no expiration)
     pub expires_in_seconds: i64,
+    /// Link previews attached to this message
+    pub previews: Vec<LinkPreview>,
+}
+
+/// Link preview metadata attached to a message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LinkPreview {
+    pub url: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub image_path: Option<String>,
 }
 
 /// An attachment on a message

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,7 +23,7 @@ const MSG_WINDOW_MULTIPLIER: usize = 10;
 
 // Popup dimensions
 const SETTINGS_POPUP_WIDTH: u16 = 42;
-const SETTINGS_POPUP_HEIGHT: u16 = 16;
+const SETTINGS_POPUP_HEIGHT: u16 = 17;
 const CONTACTS_POPUP_WIDTH: u16 = 50;
 const CONTACTS_MAX_VISIBLE: usize = 20;
 const FILE_BROWSER_POPUP_WIDTH: u16 = 60;
@@ -906,6 +906,55 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                     if use_native {
                         if let Some(ref path) = msg.image_path {
                             image_records.push((first_idx, count, path.clone()));
+                        }
+                    }
+                }
+            }
+
+            // Render link preview block
+            if !msg.is_deleted && app.show_link_previews {
+                if let Some(ref preview) = msg.preview {
+                    if let Some(ref title) = preview.title {
+                        lines.push(Line::from(vec![
+                            Span::styled("  \u{258E} ", Style::default().fg(theme.link)),
+                            Span::styled(
+                                truncate(title, 60),
+                                Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+                            ),
+                        ]));
+                        line_msg_idx.push(Some(msg_index));
+                    }
+                    if let Some(ref desc) = preview.description {
+                        lines.push(Line::from(vec![
+                            Span::styled("  \u{258E} ", Style::default().fg(theme.link)),
+                            Span::styled(
+                                truncate(desc, 60),
+                                Style::default().fg(theme.fg_muted),
+                            ),
+                        ]));
+                        line_msg_idx.push(Some(msg_index));
+                    }
+                    lines.push(Line::from(vec![
+                        Span::styled("  \u{258E} ", Style::default().fg(theme.link)),
+                        Span::styled(
+                            truncate(&preview.url, 60),
+                            Style::default().fg(theme.link).add_modifier(Modifier::UNDERLINED),
+                        ),
+                    ]));
+                    line_msg_idx.push(Some(msg_index));
+
+                    // Render link preview thumbnail
+                    if let Some(ref img_lines) = msg.preview_image_lines {
+                        let first_idx = lines.len();
+                        let count = img_lines.len();
+                        for line in img_lines {
+                            lines.push(line.clone());
+                            line_msg_idx.push(Some(msg_index));
+                        }
+                        if use_native {
+                            if let Some(ref path) = msg.preview_image_path {
+                                image_records.push((first_idx, count, path.clone()));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Parse link previews from signal-cli's `dataMessage.previews` / `preview` JSON array (title, description, thumbnail image)
- Persist link previews to SQLite via new `link_preview` TEXT column (schema v12)
- Render styled preview block below message body: `▎` bar in link color, bold title, muted description, underlined URL, optional thumbnail
- Add "Link previews" toggle in `/settings` that persists to config — respects existing "Inline image previews" for thumbnails
- Add `parse_link_preview_basic`, `parse_link_preview_missing`, and `parse_link_preview_singular_key` tests

Closes #63

## Test plan
- [ ] `cargo clippy --tests -- -D warnings` passes
- [ ] `cargo test` passes (296 tests including 3 new link preview parser tests)
- [ ] Receive a message with a URL from another Signal user — preview block appears below message
- [ ] Toggle "Link previews" off in `/settings` — preview blocks disappear immediately
- [ ] Toggle "Inline image previews" off — preview thumbnails disappear but text preview stays
- [ ] Restart app — previews persist from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)