### PR TITLE
Fix poll vote counting inflated by voteCount multiplier

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2784,14 +2784,12 @@ pub(crate) fn build_poll_display(
 
     let option_count = poll.options.len();
     let mut counts = vec![0usize; option_count];
-    let mut total_votes = 0usize;
     let mut own_selections: Vec<bool> = vec![false; option_count];
 
     for vote in votes {
         for &idx in &vote.option_indexes {
             if (idx as usize) < option_count {
-                counts[idx as usize] += vote.vote_count as usize;
-                total_votes += vote.vote_count as usize;
+                counts[idx as usize] += 1;
             }
         }
         if vote.voter == own_account {
@@ -2802,6 +2800,7 @@ pub(crate) fn build_poll_display(
             }
         }
     }
+    let total_votes: usize = counts.iter().sum();
 
     let bar_width = 10;
 


### PR DESCRIPTION
## Summary
- signal-cli's `voteCount` field is a cumulative counter that increments each time a voter changes their selection, not a weight of 1
- `build_poll_display` was using `vote.vote_count` as a multiplier (`+= vote.vote_count`), causing inflated counts (e.g. 1 person voting showed as 4 votes)
- Fix: count each voter's selection as `+= 1` and derive `total_votes` from `counts.iter().sum()`

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] All 296 tests pass
- [ ] Manual: create poll, vote, change vote — counts stay accurate

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)