### PR TITLE
Add identity key verification with /verify overlay (closes #70)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::image_render;
 use crate::image_render::ImageProtocol;
 use crate::input::{self, InputAction, COMMANDS};
 use crate::theme::{self, Theme};
-use crate::signal::types::{Contact, Group, LinkPreview, Mention, MessageStatus, PollData, PollOption, PollVote, Reaction, SignalEvent, SignalMessage, StyleType, TextStyle};
+use crate::signal::types::{Contact, Group, IdentityInfo, LinkPreview, Mention, MessageStatus, PollData, PollOption, PollVote, Reaction, SignalEvent, SignalMessage, StyleType, TextStyle, TrustLevel};
 
 /// Log a database error via debug_log (no-op when --debug is off).
 fn db_warn<T>(result: Result<T, impl std::fmt::Display>, context: &str) {
@@ -280,6 +280,14 @@ pub struct App {
     pub contacts_filter: String,
     /// Filtered list of (phone_number, display_name) for contacts overlay
     pub contacts_filtered: Vec<(String, String)>,
+    /// Verify identity overlay visible
+    pub show_verify: bool,
+    /// Cursor position in verify overlay (for group member list)
+    pub verify_index: usize,
+    /// Identity info entries filtered for the current overlay
+    pub verify_identities: Vec<IdentityInfo>,
+    /// Cached trust levels keyed by phone number
+    pub identity_trust: HashMap<String, TrustLevel>,
     /// Show inline halfblock image previews in chat
     pub inline_images: bool,
     /// Show link previews (title, description, thumbnail) for URLs
@@ -567,6 +575,10 @@ pub enum SendRequest {
         recipient: String,
         is_group: bool,
         poll_timestamp: i64,
+    },
+    ListIdentities,
+    TrustIdentity {
+        recipient: String,
     },
 }
 
@@ -1567,6 +1579,37 @@ impl App {
     }
 
     /// Handle a key press while the contacts overlay is open.
+    pub fn handle_verify_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.verify_identities.is_empty()
+                    && self.verify_index < self.verify_identities.len() - 1
+                {
+                    self.verify_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.verify_index > 0 {
+                    self.verify_index -= 1;
+                }
+            }
+            KeyCode::Char('v') | KeyCode::Enter => {
+                // Trust the selected identity
+                if let Some(id) = self.verify_identities.get(self.verify_index) {
+                    if let Some(ref number) = id.number {
+                        let recipient = number.clone();
+                        return Some(SendRequest::TrustIdentity { recipient });
+                    }
+                }
+            }
+            KeyCode::Esc => {
+                self.show_verify = false;
+            }
+            _ => {}
+        }
+        None
+    }
+
     pub fn handle_contacts_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
@@ -1986,6 +2029,10 @@ impl App {
             contacts_index: 0,
             contacts_filter: String::new(),
             contacts_filtered: Vec::new(),
+            show_verify: false,
+            verify_index: 0,
+            verify_identities: Vec::new(),
+            identity_trust: HashMap::new(),
             inline_images: true,
             show_link_previews: true,
             link_regions: Vec::new(),
@@ -2350,6 +2397,10 @@ impl App {
         if self.show_help {
             self.show_help = false;
             return (true, None);
+        }
+        if self.show_verify {
+            let send = self.handle_verify_key(code);
+            return (true, send);
         }
         if self.show_contacts {
             self.handle_contacts_key(code);
@@ -2776,6 +2827,7 @@ impl App {
             }
             SignalEvent::ContactList(contacts) => self.handle_contact_list(contacts),
             SignalEvent::GroupList(groups) => self.handle_group_list(groups),
+            SignalEvent::IdentityList(identities) => self.handle_identity_list(identities),
             SignalEvent::Error(ref err) => {
                 crate::debug_log::logf(format_args!("signal event error: {err}"));
                 self.status_message = format!("error: {err}");
@@ -3697,6 +3749,41 @@ impl App {
         self.resolve_stored_names();
     }
 
+    fn handle_identity_list(&mut self, identities: Vec<IdentityInfo>) {
+        // Populate the trust level cache
+        self.identity_trust.clear();
+        for id in &identities {
+            if let Some(ref number) = id.number {
+                self.identity_trust.insert(number.clone(), id.trust_level);
+            }
+        }
+        // If verify overlay is open, refresh the displayed identities
+        if self.show_verify {
+            if let Some(ref conv_id) = self.active_conversation {
+                let conv_id = conv_id.clone();
+                let is_group = self.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                if is_group {
+                    if let Some(group) = self.groups.get(&conv_id) {
+                        let members: HashSet<&str> = group.members.iter().map(|s| s.as_str()).collect();
+                        self.verify_identities = identities.iter()
+                            .filter(|id| id.number.as_ref().is_some_and(|n| members.contains(n.as_str())))
+                            .cloned()
+                            .collect();
+                    }
+                } else {
+                    self.verify_identities = identities.iter()
+                        .filter(|id| id.number.as_deref() == Some(conv_id.as_str()))
+                        .cloned()
+                        .collect();
+                }
+                // Clamp index
+                if !self.verify_identities.is_empty() && self.verify_index >= self.verify_identities.len() {
+                    self.verify_index = self.verify_identities.len() - 1;
+                }
+            }
+        }
+    }
+
     /// Re-resolve reaction senders and quote authors across all conversations.
     /// Uses contact_names first, then falls back to sender_id→sender mappings
     /// from the messages themselves (covers people not in formal contacts but
@@ -4425,6 +4512,54 @@ impl App {
                 self.group_menu_index = 0;
                 self.group_menu_filter.clear();
                 self.group_menu_input.clear();
+            }
+            InputAction::Verify => {
+                if let Some(ref conv_id) = self.active_conversation {
+                    let conv_id = conv_id.clone();
+                    let conv = &self.conversations[&conv_id];
+                    // Filter identities for this conversation
+                    if conv.is_group {
+                        // For groups, show identities for all members
+                        if let Some(group) = self.groups.get(&conv_id) {
+                            let members: HashSet<&str> = group.members.iter().map(|s| s.as_str()).collect();
+                            self.verify_identities = self.identity_trust.keys()
+                                .filter(|num| members.contains(num.as_str()))
+                                .filter_map(|num| {
+                                    // Find matching identity info from cached data
+                                    // We rebuild from identity_trust + contact_names
+                                    Some(IdentityInfo {
+                                        number: Some(num.clone()),
+                                        uuid: None,
+                                        fingerprint: String::new(),
+                                        safety_number: String::new(),
+                                        trust_level: *self.identity_trust.get(num)?,
+                                        added_timestamp: 0,
+                                    })
+                                })
+                                .collect();
+                        } else {
+                            self.verify_identities.clear();
+                        }
+                    } else {
+                        // 1:1 — show single identity
+                        self.verify_identities = self.identity_trust.get(&conv_id)
+                            .map(|tl| vec![IdentityInfo {
+                                number: Some(conv_id.clone()),
+                                uuid: None,
+                                fingerprint: String::new(),
+                                safety_number: String::new(),
+                                trust_level: *tl,
+                                added_timestamp: 0,
+                            }])
+                            .unwrap_or_default();
+                    }
+                    self.show_verify = true;
+                    self.verify_index = 0;
+                    // Request fresh identity data
+                    return Some(SendRequest::ListIdentities);
+                } else {
+                    self.status_message = "no active conversation".to_string();
+                }
             }
             InputAction::Help => {
                 self.show_help = true;

--- a/src/input.rs
+++ b/src/input.rs
@@ -22,6 +22,7 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo { name: "/group",    alias: "/g",  args: "",        description: "Group management" },
     CommandInfo { name: "/theme",    alias: "/t",  args: "",        description: "Change color theme" },
     CommandInfo { name: "/poll",     alias: "",    args: "\"question\" \"opt1\" \"opt2\" [--single]", description: "Create a poll" },
+    CommandInfo { name: "/verify",   alias: "/v",  args: "",        description: "Verify contact identity" },
     CommandInfo { name: "/help",     alias: "/h",  args: "",        description: "Show help" },
     CommandInfo { name: "/quit",     alias: "/q",  args: "",        description: "Exit signal-tui" },
 ];
@@ -65,6 +66,8 @@ pub enum InputAction {
     Theme,
     /// Create a poll
     Poll { question: String, options: Vec<String>, allow_multiple: bool },
+    /// Show identity verification overlay
+    Verify,
     /// Unknown command
     Unknown(String),
 }
@@ -132,6 +135,7 @@ pub fn parse_input(input: &str) -> InputAction {
                 _ => InputAction::Unknown("Usage: /poll \"question\" \"option1\" \"option2\" [--single]".into()),
             }
         }
+        "/verify" | "/v" => InputAction::Verify,
         "/help" | "/h" => InputAction::Help,
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }
@@ -261,6 +265,8 @@ mod tests {
     #[case("/unblock", InputAction::Unblock)]
     #[case("/group", InputAction::Group)]
     #[case("/g", InputAction::Group)]
+    #[case("/verify", InputAction::Verify)]
+    #[case("/v", InputAction::Verify)]
     #[case("/bell", InputAction::ToggleBell(None))]
     fn command_returns_expected_action(#[case] input: &str, #[case] expected: InputAction) {
         assert_eq!(parse_input(input), expected);

--- a/src/main.rs
+++ b/src/main.rs
@@ -639,6 +639,18 @@ async fn dispatch_send(
                 };
             }
         }
+        SendRequest::ListIdentities => {
+            let _ = signal_client.list_identities().await;
+        }
+        SendRequest::TrustIdentity { recipient } => {
+            if let Err(e) = signal_client.trust_identity(&recipient).await {
+                app.status_message = format!("trust error: {e}");
+            } else {
+                app.status_message = format!("Trusted {}", app.contact_names.get(&recipient).unwrap_or(&recipient));
+                // Re-fetch identities to update trust levels
+                let _ = signal_client.list_identities().await;
+            }
+        }
     }
 }
 
@@ -679,6 +691,7 @@ async fn run_app(
     let _ = signal_client.send_sync_request().await;
     let _ = signal_client.list_contacts().await;
     let _ = signal_client.list_groups().await;
+    let _ = signal_client.list_identities().await;
 
     let mut last_expiry_sweep = Instant::now();
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -462,6 +462,42 @@ impl SignalClient {
         Ok(())
     }
 
+    pub async fn list_identities(&self) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("listIdentities".to_string(), Instant::now()));
+        }
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "listIdentities".to_string(),
+            id,
+            params: Some(serde_json::json!({ "account": self.account })),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send")?;
+        Ok(())
+    }
+
+    pub async fn trust_identity(&self, recipient: &str) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("trust".to_string(), Instant::now()));
+        }
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "trust".to_string(),
+            id,
+            params: Some(serde_json::json!({
+                "recipient": [recipient],
+                "trustAllKnownKeys": true,
+                "account": self.account,
+            })),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send")?;
+        Ok(())
+    }
+
     pub async fn send_sync_request(&self) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         let request = JsonRpcRequest {
@@ -1106,6 +1142,31 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
                 .collect();
             Some(SignalEvent::GroupList(groups))
         }
+        "listIdentities" => {
+            let arr = result.as_array()?;
+            let identities: Vec<IdentityInfo> = arr
+                .iter()
+                .map(|obj| {
+                    let number = obj.get("number").and_then(|v| v.as_str()).map(|s| s.to_string());
+                    let uuid = obj.get("uuid").and_then(|v| v.as_str()).map(|s| s.to_string());
+                    let fingerprint = obj.get("fingerprint").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let safety_number = obj.get("safetyNumber").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                    let trust_level = obj.get("trustLevel").and_then(|v| v.as_str())
+                        .map(TrustLevel::from_str)
+                        .unwrap_or(TrustLevel::TrustedUnverified);
+                    let added_timestamp = obj.get("addedTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+                    IdentityInfo {
+                        number,
+                        uuid,
+                        fingerprint,
+                        safety_number,
+                        trust_level,
+                        added_timestamp,
+                    }
+                })
+                .collect();
+            Some(SignalEvent::IdentityList(identities))
+        }
         "sendPollCreate" => {
             let id = rpc_id?.to_string();
             let server_ts = result.get("timestamp").and_then(|v| v.as_i64())
@@ -1113,7 +1174,7 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
                 .unwrap_or(0);
             Some(SignalEvent::SendTimestamp { rpc_id: id, server_ts })
         }
-        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" | "block" | "unblock" | "sendPinMessage" | "sendUnpinMessage" | "sendPollVote" | "sendPollTerminate" => None, // fire-and-forget, no action needed
+        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" | "block" | "unblock" | "sendPinMessage" | "sendUnpinMessage" | "sendPollVote" | "sendPollTerminate" | "trust" => None, // fire-and-forget, no action needed
         _ => None,
     }
 }
@@ -3338,5 +3399,46 @@ mod tests {
         assert_eq!(previews[0].title.as_deref(), Some("Test"));
         assert!(previews[0].description.is_none());
         assert!(previews[0].image_path.is_none());
+    }
+
+    #[test]
+    fn parse_identity_list() {
+        let result = json!([
+            {
+                "number": "+15551234567",
+                "uuid": "uuid-alice",
+                "fingerprint": "05ab12cd",
+                "safetyNumber": "123456789012345678901234567890123456789012345678901234567890",
+                "trustLevel": "TRUSTED_VERIFIED",
+                "addedTimestamp": 1700000000000_i64
+            },
+            {
+                "number": "+15559876543",
+                "uuid": "uuid-bob",
+                "fingerprint": "05ef34ab",
+                "safetyNumber": "098765432109876543210987654321098765432109876543210987654321",
+                "trustLevel": "UNTRUSTED",
+                "addedTimestamp": 1700000001000_i64
+            },
+            {
+                "number": "+15550001111",
+                "trustLevel": "TRUSTED_UNVERIFIED"
+            }
+        ]);
+        let event = parse_rpc_result("listIdentities", &result, None).unwrap();
+        match event {
+            SignalEvent::IdentityList(identities) => {
+                assert_eq!(identities.len(), 3);
+                assert_eq!(identities[0].number.as_deref(), Some("+15551234567"));
+                assert_eq!(identities[0].uuid.as_deref(), Some("uuid-alice"));
+                assert_eq!(identities[0].trust_level, TrustLevel::TrustedVerified);
+                assert_eq!(identities[0].fingerprint, "05ab12cd");
+                assert_eq!(identities[1].trust_level, TrustLevel::Untrusted);
+                assert_eq!(identities[2].trust_level, TrustLevel::TrustedUnverified);
+                assert_eq!(identities[2].fingerprint, "");
+                assert_eq!(identities[2].safety_number, "");
+            }
+            _ => panic!("Expected IdentityList"),
+        }
     }
 }

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -40,6 +40,36 @@ impl MessageStatus {
     }
 }
 
+/// Trust level for a contact's identity key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustLevel {
+    Untrusted,
+    TrustedUnverified,
+    TrustedVerified,
+}
+
+impl TrustLevel {
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "UNTRUSTED" => TrustLevel::Untrusted,
+            "TRUSTED_VERIFIED" => TrustLevel::TrustedVerified,
+            _ => TrustLevel::TrustedUnverified,
+        }
+    }
+}
+
+/// Identity key information for a contact.
+#[derive(Debug, Clone)]
+pub struct IdentityInfo {
+    pub number: Option<String>,
+    pub uuid: Option<String>,
+    pub fingerprint: String,
+    pub safety_number: String,
+    pub trust_level: TrustLevel,
+    #[allow(dead_code)]
+    pub added_timestamp: i64,
+}
+
 /// A single emoji reaction on a message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Reaction {
@@ -172,6 +202,7 @@ pub enum SignalEvent {
     },
     ContactList(Vec<Contact>),
     GroupList(Vec<Group>),
+    IdentityList(Vec<IdentityInfo>),
     Error(String),
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -11,7 +11,7 @@ use ratatui::{
 };
 
 use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, VisibleImage, PIN_DURATIONS, QUICK_REACTIONS, SETTINGS};
-use crate::signal::types::{MessageStatus, PollData, PollVote, Reaction, StyleType};
+use crate::signal::types::{MessageStatus, PollData, PollVote, Reaction, StyleType, TrustLevel};
 use crate::image_render::ImageProtocol;
 use crate::input::{COMMANDS, format_compact_duration};
 use crate::theme::Theme;
@@ -472,6 +472,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_contacts(frame, app, size);
     }
 
+    // Verify identity overlay
+    if app.show_verify {
+        draw_verify(frame, app, size);
+    }
+
     // Search overlay
     if app.show_search {
         draw_search(frame, app, size);
@@ -658,6 +663,27 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                     format!("\u{23F1} {timer_label} "),
                     Style::default().fg(theme.fg_muted),
                 ));
+            }
+
+            // Trust level indicator (1:1 only)
+            if !conv.is_group {
+                if let Some(trust) = app.identity_trust.get(id) {
+                    match trust {
+                        TrustLevel::TrustedVerified => {
+                            spans.push(Span::styled(
+                                "\u{2713} verified ",
+                                Style::default().fg(theme.accent),
+                            ));
+                        }
+                        TrustLevel::Untrusted => {
+                            spans.push(Span::styled(
+                                "\u{26A0} untrusted ",
+                                Style::default().fg(theme.warning),
+                            ));
+                        }
+                        TrustLevel::TrustedUnverified => {} // normal state, no indicator
+                    }
+                }
             }
 
             // Scroll indicator in title
@@ -2294,6 +2320,153 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);
+}
+
+fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let is_group = app.active_conversation.as_ref()
+        .and_then(|id| app.conversations.get(id))
+        .map(|c| c.is_group)
+        .unwrap_or(false);
+
+    let pref_height: u16 = if is_group { 18 } else { 14 };
+    let pref_width: u16 = 50;
+    let (popup_area, block) = centered_popup(
+        frame, area, pref_width, pref_height, " Verify Identity ", theme,
+    );
+    let inner = popup_area.inner(ratatui::layout::Margin { horizontal: 1, vertical: 1 });
+    let mut lines: Vec<Line> = Vec::new();
+
+    if app.verify_identities.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  No identity information available",
+            Style::default().fg(theme.fg_muted),
+        )));
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  Esc: close",
+            Style::default().fg(theme.fg_muted),
+        )));
+    } else if is_group {
+        // Group view: scrollable member list with trust badges
+        let member_rows = inner.height.saturating_sub(7) as usize; // reserve for safety number + footer
+        let scroll_offset = if app.verify_index >= member_rows {
+            app.verify_index - member_rows + 1
+        } else {
+            0
+        };
+        let end = (scroll_offset + member_rows).min(app.verify_identities.len());
+
+        for (i, identity) in app.verify_identities[scroll_offset..end].iter().enumerate() {
+            let actual_idx = scroll_offset + i;
+            let is_selected = actual_idx == app.verify_index;
+            let number = identity.number.as_deref().unwrap_or("unknown");
+            let name = app.contact_names.get(number).cloned().unwrap_or_else(|| number.to_string());
+            let (badge, badge_color) = match identity.trust_level {
+                TrustLevel::TrustedVerified => ("\u{2713}", theme.accent),
+                TrustLevel::Untrusted => ("\u{26A0}", theme.warning),
+                TrustLevel::TrustedUnverified => ("\u{2500}", theme.fg_muted),
+            };
+            let prefix = if is_selected { "> " } else { "  " };
+            let style = if is_selected {
+                Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme.fg)
+            };
+            let badge_style = if is_selected {
+                Style::default().bg(theme.bg_selected).fg(badge_color)
+            } else {
+                Style::default().fg(badge_color)
+            };
+            lines.push(Line::from(vec![
+                Span::styled(prefix.to_string(), style),
+                Span::styled(format!("{badge} "), badge_style),
+                Span::styled(name, style),
+            ]));
+        }
+
+        lines.push(Line::from(""));
+
+        // Show selected member's safety number
+        if let Some(identity) = app.verify_identities.get(app.verify_index) {
+            if !identity.safety_number.is_empty() {
+                lines.push(Line::from(Span::styled("  Safety Number:", Style::default().fg(theme.fg_secondary))));
+                let sn = &identity.safety_number;
+                let formatted = format_safety_number(sn);
+                for row in formatted {
+                    lines.push(Line::from(Span::styled(format!("  {row}"), Style::default().fg(theme.fg))));
+                }
+            } else {
+                lines.push(Line::from(Span::styled("  Safety number not available", Style::default().fg(theme.fg_muted))));
+            }
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "  j/k: navigate  v: verify  Esc: close",
+            Style::default().fg(theme.fg_muted),
+        )));
+    } else {
+        // 1:1 view: single identity with full details
+        let identity = &app.verify_identities[0];
+        let number = identity.number.as_deref().unwrap_or("unknown");
+        let name = app.contact_names.get(number).cloned().unwrap_or_else(|| number.to_string());
+
+        lines.push(Line::from(Span::styled(
+            format!("  {} ({})", name, number),
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+        )));
+
+        let (trust_label, trust_color) = match identity.trust_level {
+            TrustLevel::TrustedVerified => ("\u{2713} Verified", theme.accent),
+            TrustLevel::Untrusted => ("\u{26A0} Untrusted", theme.warning),
+            TrustLevel::TrustedUnverified => ("\u{2500} Unverified", theme.fg_muted),
+        };
+        lines.push(Line::from(Span::styled(
+            format!("  Trust: {trust_label}"),
+            Style::default().fg(trust_color),
+        )));
+        lines.push(Line::from(""));
+
+        if !identity.safety_number.is_empty() {
+            lines.push(Line::from(Span::styled("  Safety Number:", Style::default().fg(theme.fg_secondary))));
+            let formatted = format_safety_number(&identity.safety_number);
+            for row in formatted {
+                lines.push(Line::from(Span::styled(format!("  {row}"), Style::default().fg(theme.fg))));
+            }
+        } else {
+            lines.push(Line::from(Span::styled("  Safety number not available", Style::default().fg(theme.fg_muted))));
+        }
+
+        lines.push(Line::from(""));
+        if !identity.fingerprint.is_empty() {
+            lines.push(Line::from(Span::styled(
+                format!("  Fingerprint: {}", identity.fingerprint),
+                Style::default().fg(theme.fg_muted),
+            )));
+            lines.push(Line::from(""));
+        }
+
+        lines.push(Line::from(Span::styled(
+            "  v: verify key  Esc: close",
+            Style::default().fg(theme.fg_muted),
+        )));
+    }
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+/// Format a safety number string as groups of 5 digits, 6 per line.
+fn format_safety_number(sn: &str) -> Vec<String> {
+    let digits: String = sn.chars().filter(|c| c.is_ascii_digit()).collect();
+    let chunks: Vec<&str> = digits.as_bytes()
+        .chunks(5)
+        .map(|chunk| std::str::from_utf8(chunk).unwrap_or(""))
+        .collect();
+    chunks.chunks(6)
+        .map(|row| row.join(" "))
+        .collect()
 }
 
 fn draw_search(frame: &mut Frame, app: &App, area: Rect) {


### PR DESCRIPTION
## Summary
- Add `/verify` (`/v`) command to view safety numbers, trust levels, and verify contact identity keys
- Display trust indicator in 1:1 conversation headers: `✓ verified` (green) or `⚠ untrusted` (warning)
- Scrollable group member list with trust badges (`✓`/`⚠`/`─`) and per-member safety number display
- Trust/verify keys via signal-cli's `trust` RPC with `v` or Enter key
- Fetch identities on startup and refresh on demand

## Changes
- **types.rs**: `TrustLevel` enum, `IdentityInfo` struct, `SignalEvent::IdentityList`
- **client.rs**: `list_identities()` / `trust_identity()` RPC methods, `listIdentities` result parsing, new test
- **input.rs**: `/verify` (`/v`) command + test cases
- **app.rs**: Verify overlay state, `handle_verify_key()`, `handle_identity_list()`, `SendRequest::ListIdentities` / `TrustIdentity`
- **ui.rs**: `draw_verify()` overlay (1:1 + group views), header trust indicator, `format_safety_number()` helper
- **main.rs**: Startup `list_identities()` call, `dispatch_send` routing

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` — all 299 tests pass including new `parse_identity_list` test
- [ ] Manual: `/verify` in 1:1 chat shows safety number and trust level
- [ ] Manual: `/verify` in group shows member list with trust badges
- [ ] Manual: Press `v` on a contact to verify — trust level updates
- [ ] Manual: Header shows `✓ verified` / `⚠ untrusted` indicators
- [ ] Manual: Restart app — trust levels re-queried on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)