### PR TITLE
Fix mouse selection, right-click paste, and slow Ctrl+V

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -412,6 +412,8 @@ pub struct App {
     pub mouse_input_prefix_len: u16,
     /// Enable mouse support (click sidebar, scroll messages, click links)
     pub mouse_enabled: bool,
+    /// Pending mouse capture toggle — set by settings on_toggle, drained by main loop
+    pub pending_mouse_toggle: Option<bool>,
     /// Active color theme
     pub theme: Theme,
     /// Theme picker overlay visible
@@ -681,7 +683,7 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.mouse_enabled,
         set: |a, v| a.mouse_enabled = v,
         save: Some(|c, v| c.mouse_enabled = v),
-        on_toggle: None,
+        on_toggle: Some(|a| { a.pending_mouse_toggle = Some(a.mouse_enabled); }),
     },
 ];
 
@@ -2095,6 +2097,7 @@ impl App {
             mouse_input_area: Rect::default(),
             mouse_input_prefix_len: 0,
             mouse_enabled: true,
+            pending_mouse_toggle: None,
             theme: theme::default_theme(),
             show_theme_picker: false,
             theme_index: 0,
@@ -4938,6 +4941,29 @@ impl App {
             }
             _ => false,
         }
+    }
+
+    /// Handle a bracketed paste event (Ctrl+V or terminal paste).
+    /// Inserts the entire pasted string at once, avoiding per-character overhead.
+    pub fn handle_paste(&mut self, text: String) -> Option<SendRequest> {
+        if self.mode != InputMode::Insert || self.has_overlay() {
+            return None;
+        }
+        // Insert pasted text at cursor position
+        self.input_buffer.insert_str(self.input_cursor, &text);
+        self.input_cursor += text.len();
+        // Single autocomplete + typing indicator update
+        self.update_autocomplete();
+        self.typing_last_keypress = Some(Instant::now());
+        if !self.typing_sent
+            && !self.input_buffer.is_empty()
+            && !self.input_buffer.starts_with('/')
+            && self.active_conversation.as_ref().is_some_and(|id| !self.blocked_conversations.contains(id))
+        {
+            self.typing_sent = true;
+            return self.build_typing_request(false);
+        }
+        None
     }
 
     /// Accept the currently selected autocomplete candidate.

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use crossterm::{
     cursor::{MoveTo, RestorePosition, SavePosition},
-    event::{self, EnableMouseCapture, DisableMouseCapture, Event, KeyEventKind},
+    event::{self, EnableBracketedPaste, DisableBracketedPaste, EnableMouseCapture, DisableMouseCapture, Event, KeyEventKind},
     execute, queue,
     style::{Print, ResetColor, SetForegroundColor},
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
@@ -132,7 +132,11 @@ async fn main() -> Result<()> {
     // Set up terminal BEFORE anything else so all errors render in the TUI
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    if config.mouse_enabled {
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste)?;
+    } else {
+        execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+    }
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -141,7 +145,7 @@ async fn main() -> Result<()> {
 
     // Restore terminal
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture)?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste)?;
     terminal.show_cursor()?;
 
     if let Err(e) = result {
@@ -695,9 +699,13 @@ async fn run_app(
 
     let mut last_expiry_sweep = Instant::now();
 
-    // Re-enable mouse capture — on Windows, spawning cmd.exe subprocesses
+    // Re-enable terminal modes — on Windows, spawning cmd.exe subprocesses
     // (signal-cli.bat, check_account_registered) can reset console input mode flags.
-    execute!(terminal.backend_mut(), EnableMouseCapture)?;
+    if config.mouse_enabled {
+        execute!(terminal.backend_mut(), EnableMouseCapture, EnableBracketedPaste)?;
+    } else {
+        execute!(terminal.backend_mut(), EnableBracketedPaste)?;
+    }
 
     loop {
         // Force full redraw when active conversation changes (clears native image artifacts)
@@ -740,6 +748,11 @@ async fn run_app(
                 }
                 Event::Mouse(mouse) => {
                     if let Some(req) = app.handle_mouse_event(mouse) {
+                        dispatch_send(signal_client, &mut app, req).await;
+                    }
+                }
+                Event::Paste(text) => {
+                    if let Some(req) = app.handle_paste(text) {
                         dispatch_send(signal_client, &mut app, req).await;
                     }
                 }
@@ -809,6 +822,15 @@ async fn run_app(
             execute!(terminal.backend_mut(), crossterm::style::Print("\x07"))?;
         }
 
+        // Dynamic mouse capture toggle from settings
+        if let Some(enabled) = app.pending_mouse_toggle.take() {
+            if enabled {
+                execute!(terminal.backend_mut(), EnableMouseCapture)?;
+            } else {
+                execute!(terminal.backend_mut(), DisableMouseCapture)?;
+            }
+        }
+
         // Update terminal title with unread count
         let unread = app.total_unread();
         let title = if unread > 0 {
@@ -875,6 +897,9 @@ async fn run_demo_app(
                 }
                 Event::Mouse(mouse) => {
                     app.handle_mouse_event(mouse);
+                }
+                Event::Paste(text) => {
+                    app.handle_paste(text);
                 }
                 _ => {}
             }


### PR DESCRIPTION
## Summary
- **Dynamic mouse capture toggle**: toggling mouse off in `/settings` now sends `DisableMouseCapture` to the terminal so native text selection and right-click paste work; toggling back on re-sends `EnableMouseCapture`
- **Conditional startup**: only enable mouse capture if `config.mouse_enabled` is true, so users who disabled mouse keep native selection on launch
- **Bracketed paste**: enable `EnableBracketedPaste` so pasted text arrives as a single `Event::Paste(String)` instead of individual key events, eliminating per-character autocomplete/typing-indicator overhead
- **`App::handle_paste()`**: inserts full pasted string at cursor position in one shot with a single autocomplete + typing indicator update

## Test plan
- [ ] Toggle mouse off in `/settings` → click-drag to select text works, right-click paste works
- [ ] Toggle mouse back on → sidebar clicks and scroll work again
- [ ] Ctrl+V a large block of text → appears instantly (not character-by-character)
- [ ] Paste positions cursor correctly after inserted text
- [ ] `cargo clippy --tests -- -D warnings` passes
- [ ] `cargo test` passes (299 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)