### PR TITLE
Add sidebar position setting (left/right toggle)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -232,6 +232,8 @@ pub struct App {
     pub account: String,
     /// Resizable sidebar width (min 14, max 40)
     pub sidebar_width: u16,
+    /// Display sidebar on the right side instead of left
+    pub sidebar_on_right: bool,
     /// Per-conversation typing indicators with expiry timestamp
     pub typing_indicators: HashMap<String, Instant>,
     /// Last-read message index per conversation (for unread marker)
@@ -684,6 +686,13 @@ pub const SETTINGS: &[SettingDef] = &[
         set: |a, v| a.mouse_enabled = v,
         save: Some(|c, v| c.mouse_enabled = v),
         on_toggle: Some(|a| { a.pending_mouse_toggle = Some(a.mouse_enabled); }),
+    },
+    SettingDef {
+        label: "Sidebar on right",
+        get: |a| a.sidebar_on_right,
+        set: |a, v| a.sidebar_on_right = v,
+        save: Some(|c, v| c.sidebar_on_right = v),
+        on_toggle: None,
     },
 ];
 
@@ -2007,6 +2016,7 @@ impl App {
             should_quit: false,
             account,
             sidebar_width: 22,
+            sidebar_on_right: false,
             typing_indicators: HashMap::new(),
             last_read_index: HashMap::new(),
             connected: false,

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,10 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub mouse_enabled: bool,
 
+    /// Display sidebar on the right side instead of left
+    #[serde(default)]
+    pub sidebar_on_right: bool,
+
     /// Color theme name (matches a built-in or custom theme)
     #[serde(default = "default_theme")]
     pub theme: String,
@@ -105,6 +109,7 @@ impl Default for Config {
             reaction_verbose: false,
             send_read_receipts: true,
             mouse_enabled: true,
+            sidebar_on_right: false,
             theme: default_theme(),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -679,6 +679,7 @@ async fn run_app(
     app.reaction_verbose = config.reaction_verbose;
     app.send_read_receipts = config.send_read_receipts;
     app.mouse_enabled = config.mouse_enabled;
+    app.sidebar_on_right = config.sidebar_on_right;
     app.available_themes = theme::all_themes();
     app.theme = theme::find_theme(&config.theme);
     app.load_from_db()?;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -428,16 +428,18 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     let show_sidebar = app.sidebar_visible && !sidebar_auto_hidden;
 
     let input_area = if show_sidebar {
+        let (sidebar_idx, chat_idx, constraints) = if app.sidebar_on_right {
+            (1, 0, [Constraint::Min(MIN_CHAT_WIDTH), Constraint::Length(app.sidebar_width)])
+        } else {
+            (0, 1, [Constraint::Length(app.sidebar_width), Constraint::Min(MIN_CHAT_WIDTH)])
+        };
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Length(app.sidebar_width),
-                Constraint::Min(MIN_CHAT_WIDTH),
-            ])
+            .constraints(constraints)
             .split(body_area);
 
-        draw_sidebar(frame, app, horizontal[0]);
-        draw_chat_area(frame, app, horizontal[1])
+        draw_sidebar(frame, app, horizontal[sidebar_idx]);
+        draw_chat_area(frame, app, horizontal[chat_idx])
     } else {
         app.mouse_sidebar_inner = None;
         draw_chat_area(frame, app, body_area)
@@ -614,8 +616,9 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
+    let border_side = if app.sidebar_on_right { Borders::LEFT } else { Borders::RIGHT };
     let block = Block::default()
-        .borders(Borders::RIGHT)
+        .borders(border_side)
         .border_type(BorderType::Rounded)
         .title(" Chats ")
         .title_style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD));


### PR DESCRIPTION
## Summary
- Adds `sidebar_on_right` bool to config, app state, and `/settings` overlay
- Swaps layout constraints and sidebar border direction when toggled
- Mouse clicks work on either side (no changes needed — `mouse_sidebar_inner` stores the actual `Rect`)

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — 299 tests pass
- [ ] Manual: toggle in `/settings`, sidebar moves sides with correct border
- [ ] Manual: setting persists across restart
- [ ] Manual: mouse clicks/scroll work on both sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)