### PR TITLE
Add /profile editor and /about overlay

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -443,6 +443,18 @@ pub struct App {
     pub pending_polls: HashMap<(String, i64), PollData>,
     /// Number of in-memory messages with expiration > 0 (skip sweeps when zero)
     pub expiring_msg_count: usize,
+    /// About overlay visible
+    pub show_about: bool,
+    /// Profile editor overlay visible
+    pub show_profile: bool,
+    /// Cursor position in profile editor (0-3 = fields, 4 = Save)
+    pub profile_index: usize,
+    /// Whether currently editing a profile field
+    pub profile_editing: bool,
+    /// Profile fields: [given_name, family_name, about, about_emoji]
+    pub profile_fields: [String; 4],
+    /// Temp buffer while editing a profile field
+    pub profile_edit_buffer: String,
 }
 
 /// A search result entry.
@@ -583,6 +595,12 @@ pub enum SendRequest {
     ListIdentities,
     TrustIdentity {
         recipient: String,
+    },
+    UpdateProfile {
+        given_name: String,
+        family_name: String,
+        about: String,
+        about_emoji: String,
     },
 }
 
@@ -2121,6 +2139,12 @@ impl App {
             poll_vote_pending: None,
             pending_polls: HashMap::new(),
             expiring_msg_count: 0,
+            show_about: false,
+            show_profile: false,
+            profile_index: 0,
+            profile_editing: false,
+            profile_fields: [String::new(), String::new(), String::new(), String::new()],
+            profile_edit_buffer: String::new(),
         }
     }
 
@@ -2405,6 +2429,14 @@ impl App {
         }
         if self.group_menu_state.is_some() {
             let send = self.handle_group_menu_key(code);
+            return (true, send);
+        }
+        if self.show_about {
+            self.show_about = false;
+            return (true, None);
+        }
+        if self.show_profile {
+            let send = self.handle_profile_key(code);
             return (true, send);
         }
         if self.show_help {
@@ -3561,6 +3593,75 @@ impl App {
         }
     }
 
+    /// Handle keys in the profile editor overlay.
+    pub fn handle_profile_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        const FIELD_COUNT: usize = 4;
+        const SAVE_INDEX: usize = FIELD_COUNT;
+
+        if self.profile_editing {
+            // Editing a field
+            match code {
+                KeyCode::Esc => {
+                    // Cancel edit, discard buffer
+                    self.profile_editing = false;
+                }
+                KeyCode::Enter => {
+                    // Confirm edit, write buffer back to field
+                    self.profile_fields[self.profile_index] = self.profile_edit_buffer.clone();
+                    self.profile_editing = false;
+                }
+                KeyCode::Backspace => {
+                    self.profile_edit_buffer.pop();
+                }
+                KeyCode::Char(c) => {
+                    self.profile_edit_buffer.push(c);
+                }
+                _ => {}
+            }
+            return None;
+        }
+
+        // Navigation mode
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.profile_index < SAVE_INDEX {
+                    self.profile_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                if self.profile_index > 0 {
+                    self.profile_index -= 1;
+                }
+            }
+            KeyCode::Enter => {
+                if self.profile_index < FIELD_COUNT {
+                    // Start editing the selected field
+                    self.profile_editing = true;
+                    self.profile_edit_buffer = self.profile_fields[self.profile_index].clone();
+                } else {
+                    // Save button
+                    let [given_name, family_name, about, about_emoji] = self.profile_fields.clone();
+                    if given_name.trim().is_empty() {
+                        self.status_message = "Given name is required".to_string();
+                        return None;
+                    }
+                    self.show_profile = false;
+                    return Some(SendRequest::UpdateProfile {
+                        given_name,
+                        family_name,
+                        about,
+                        about_emoji,
+                    });
+                }
+            }
+            KeyCode::Esc => {
+                self.show_profile = false;
+            }
+            _ => {}
+        }
+        None
+    }
+
     pub fn handle_poll_vote_key(&mut self, code: KeyCode) -> Option<SendRequest> {
         let pending = self.poll_vote_pending.as_ref()?;
         let option_count = pending.options.len();
@@ -4574,6 +4675,14 @@ impl App {
                     self.status_message = "no active conversation".to_string();
                 }
             }
+            InputAction::Profile => {
+                self.show_profile = true;
+                self.profile_index = 0;
+                self.profile_editing = false;
+            }
+            InputAction::About => {
+                self.show_about = true;
+            }
             InputAction::Help => {
                 self.show_help = true;
             }
@@ -5261,6 +5370,8 @@ impl App {
             || self.show_theme_picker
             || self.show_pin_duration
             || self.show_poll_vote
+            || self.show_about
+            || self.show_profile
             || self.autocomplete_visible
     }
 
@@ -7699,6 +7810,14 @@ mod tests {
         app.show_poll_vote = true;
         assert!(app.has_overlay());
         app.show_poll_vote = false;
+
+        app.show_about = true;
+        assert!(app.has_overlay());
+        app.show_about = false;
+
+        app.show_profile = true;
+        assert!(app.has_overlay());
+        app.show_profile = false;
 
         assert!(!app.has_overlay());
     }

--- a/src/input.rs
+++ b/src/input.rs
@@ -23,6 +23,8 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo { name: "/theme",    alias: "/t",  args: "",        description: "Change color theme" },
     CommandInfo { name: "/poll",     alias: "",    args: "\"question\" \"opt1\" \"opt2\" [--single]", description: "Create a poll" },
     CommandInfo { name: "/verify",   alias: "/v",  args: "",        description: "Verify contact identity" },
+    CommandInfo { name: "/profile",  alias: "",    args: "",        description: "Edit your Signal profile" },
+    CommandInfo { name: "/about",    alias: "",    args: "",        description: "About signal-tui" },
     CommandInfo { name: "/help",     alias: "/h",  args: "",        description: "Show help" },
     CommandInfo { name: "/quit",     alias: "/q",  args: "",        description: "Exit signal-tui" },
 ];
@@ -68,6 +70,10 @@ pub enum InputAction {
     Poll { question: String, options: Vec<String>, allow_multiple: bool },
     /// Show identity verification overlay
     Verify,
+    /// Edit Signal profile
+    Profile,
+    /// Show about overlay
+    About,
     /// Unknown command
     Unknown(String),
 }
@@ -136,6 +142,8 @@ pub fn parse_input(input: &str) -> InputAction {
             }
         }
         "/verify" | "/v" => InputAction::Verify,
+        "/profile" => InputAction::Profile,
+        "/about" => InputAction::About,
         "/help" | "/h" => InputAction::Help,
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }
@@ -267,6 +275,8 @@ mod tests {
     #[case("/g", InputAction::Group)]
     #[case("/verify", InputAction::Verify)]
     #[case("/v", InputAction::Verify)]
+    #[case("/profile", InputAction::Profile)]
+    #[case("/about", InputAction::About)]
     #[case("/bell", InputAction::ToggleBell(None))]
     fn command_returns_expected_action(#[case] input: &str, #[case] expected: InputAction) {
         assert_eq!(parse_input(input), expected);

--- a/src/main.rs
+++ b/src/main.rs
@@ -655,6 +655,13 @@ async fn dispatch_send(
                 let _ = signal_client.list_identities().await;
             }
         }
+        SendRequest::UpdateProfile { given_name, family_name, about, about_emoji } => {
+            if let Err(e) = signal_client.update_profile(&given_name, &family_name, &about, &about_emoji).await {
+                app.status_message = format!("profile error: {e}");
+            } else {
+                app.status_message = "Profile updated".to_string();
+            }
+        }
     }
 }
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -794,6 +794,36 @@ impl SignalClient {
         Ok(())
     }
 
+    /// Update the user's Signal profile.
+    pub async fn update_profile(
+        &self,
+        given_name: &str,
+        family_name: &str,
+        about: &str,
+        about_emoji: &str,
+    ) -> Result<()> {
+        let id = Uuid::new_v4().to_string();
+        if let Ok(mut map) = self.pending_requests.lock() {
+            map.insert(id.clone(), ("updateProfile".to_string(), Instant::now()));
+        }
+        let params = serde_json::json!({
+            "account": self.account,
+            "givenName": given_name,
+            "familyName": family_name,
+            "about": about,
+            "aboutEmoji": about_emoji,
+        });
+        let request = JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            method: "updateProfile".to_string(),
+            id,
+            params: Some(params),
+        };
+        let json = serde_json::to_string(&request)?;
+        self.stdin_tx.send(json).await.context("Failed to send updateProfile to signal-cli stdin")?;
+        Ok(())
+    }
+
     /// Block a contact or group.
     pub async fn block_contact(&self, recipient: &str, is_group: bool) -> Result<()> {
         let id = Uuid::new_v4().to_string();

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -32,6 +32,8 @@ const SEARCH_POPUP_WIDTH: u16 = 60;
 const SEARCH_MAX_VISIBLE: usize = 15;
 const GROUP_MENU_POPUP_WIDTH: u16 = 40;
 const GROUP_MEMBER_MAX_VISIBLE: usize = 15;
+const ABOUT_POPUP_WIDTH: u16 = 50;
+const PROFILE_POPUP_WIDTH: u16 = 50;
 
 /// Map a MessageStatus to its display symbol and color.
 pub(crate) fn status_symbol(status: MessageStatus, nerd_fonts: bool, color: bool, theme: &Theme) -> (&'static str, Color) {
@@ -527,6 +529,16 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // Poll vote overlay
     if app.show_poll_vote {
         draw_poll_vote_overlay(frame, app, size);
+    }
+
+    // About overlay
+    if app.show_about {
+        draw_about(frame, app, size);
+    }
+
+    // Profile editor overlay
+    if app.show_profile {
+        draw_profile(frame, app, size);
     }
 
     // Collect link regions from the rendered buffer for OSC 8 injection
@@ -3064,6 +3076,128 @@ fn draw_poll_vote_overlay(frame: &mut Frame, app: &App, area: Rect) {
         format!(" {mode_hint}  Enter: submit  Esc"),
         Style::default().fg(theme.fg_muted),
     )));
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_about(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let version = env!("CARGO_PKG_VERSION");
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  signal-tui v{version}"),
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  A terminal Signal messenger client",
+            Style::default().fg(theme.fg),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Created by John Sideserf",
+            Style::default().fg(theme.fg_secondary),
+        )),
+        Line::from(Span::styled(
+            "  License: GPL-3.0",
+            Style::default().fg(theme.fg_secondary),
+        )),
+        Line::from(Span::styled(
+            "  github.com/johnsideserf/signal-tui",
+            Style::default().fg(theme.link),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Press any key to close",
+            Style::default().fg(theme.fg_muted),
+        )),
+    ];
+
+    let pref_height = lines.len() as u16 + 2; // +2 for borders
+    let (popup_area, block) = centered_popup(
+        frame, area, ABOUT_POPUP_WIDTH, pref_height, " About ", theme,
+    );
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_profile(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let labels = ["Given name", "Family name", "About", "About emoji"];
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    for (i, label) in labels.iter().enumerate() {
+        let is_selected = i == app.profile_index;
+        let is_editing = is_selected && app.profile_editing;
+
+        let label_style = if is_selected {
+            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+
+        let value = if is_editing {
+            format!("{}\u{2588}", app.profile_edit_buffer) // block cursor
+        } else {
+            let v = &app.profile_fields[i];
+            if v.is_empty() { "(empty)".to_string() } else { v.clone() }
+        };
+
+        let value_style = if is_editing || is_selected {
+            Style::default().bg(theme.bg_selected).fg(theme.fg)
+        } else if app.profile_fields[i].is_empty() {
+            Style::default().fg(theme.fg_muted)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+
+        let row_style = if is_selected {
+            Style::default().bg(theme.bg_selected)
+        } else {
+            Style::default()
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {:<14} ", label), label_style),
+            Span::styled(value, value_style),
+            // Pad remaining width with bg color for selected row
+            Span::styled("", row_style),
+        ]));
+    }
+
+    // Blank line before Save
+    lines.push(Line::from(""));
+
+    // Save button
+    let save_selected = app.profile_index == 4;
+    let save_style = if save_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.fg_secondary)
+    };
+    lines.push(Line::from(Span::styled("  [ Save ]", save_style)));
+
+    // Footer
+    lines.push(Line::from(""));
+    let footer = if app.profile_editing {
+        "  Type to edit | Enter confirm | Esc cancel"
+    } else {
+        "  j/k navigate | Enter edit | Esc close"
+    };
+    lines.push(Line::from(Span::styled(
+        footer,
+        Style::default().fg(theme.fg_muted),
+    )));
+
+    let pref_height = lines.len() as u16 + 2; // +2 for borders
+    let (popup_area, block) = centered_popup(
+        frame, area, PROFILE_POPUP_WIDTH, pref_height, " Edit Profile ", theme,
+    );
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);


### PR DESCRIPTION
## Summary
- Adds `/about` command: read-only overlay showing app version, author, license, and repo link (closes on any key like `/help`)
- Adds `/profile` command: editable overlay for Signal profile fields (given name, family name, about text, about emoji) with j/k navigation, Enter to inline-edit, and Save button that sends `updateProfile` RPC to signal-cli (closes #69)
- New `updateProfile` method in `SignalClient` following the existing `rename_group` RPC pattern

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (301 tests)
- [ ] Manual: `/about` shows overlay with version, author, license, repo — closes on any key
- [ ] Manual: `/profile` shows 4 editable fields + Save, j/k navigates, Enter edits, Esc cancels/closes
- [ ] Manual: Saving profile sends `updateProfile` RPC, changes reflected on other Signal clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)