### PR TITLE
Fix OSC 8 escape injection and attachment path traversal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -385,11 +385,13 @@ fn emit_osc8_links(
             let ct_bg = ratatui_color_to_crossterm(bg);
             queue!(backend, SetBackgroundColor(ct_bg))?;
         }
+        // Sanitize URL: strip control characters to prevent terminal escape injection
+        let safe_url: String = link.url.chars().filter(|c| !c.is_control()).collect();
         queue!(
             backend,
             Print(format!(
                 "\x1b]8;;{}\x07{}\x1b]8;;\x07",
-                link.url, link.text
+                safe_url, link.text
             ))
         )?;
         queue!(backend, ResetColor)?;

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -2173,6 +2173,16 @@ fn parse_attachment(
         }
     }
 
+    // Sanitize filename: strip path separators and traversal sequences
+    // to prevent writes outside the download directory.
+    effective_name = effective_name
+        .replace(['/', '\\'], "_")
+        .replace("..", "_");
+    if effective_name.is_empty() {
+        let short_id = if id.len() > 8 { &id[id.len() - 8..] } else { &id };
+        effective_name = format!("{short_id}.bin");
+    }
+
     let dest = download_dir.join(&effective_name);
 
     // Try to find the source file: explicit "file" field, or signal-cli's attachment dir


### PR DESCRIPTION
## Summary
- **OSC 8 terminal escape injection**: Strip control characters from URLs before embedding in `\x1b]8;;{url}\x07` sequences. A crafted message URL containing terminal escape codes could manipulate terminal state (change title, clear screen, redefine colors).
- **Attachment path traversal**: Sanitize attachment filenames by replacing `/`, `\`, and `..` with `_`. A malicious attachment with a name like `../../../.config/siggy/config.toml` could write files outside the download directory.

## Test plan
- [ ] Verify URLs with control characters are stripped in OSC 8 output
- [ ] Verify attachment filenames with `../` are sanitized to safe names
- [ ] `cargo clippy --tests -- -D warnings && cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)