### PR TITLE
Add v1.0.0 and v1.0.1 changelog, update roadmap

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## v1.0.1
+
+### Security
+
+- **OSC 8 escape injection fix** -- URLs in messages are now sanitized before
+  being embedded in terminal hyperlink escape sequences, preventing crafted
+  URLs from manipulating terminal state (title, colors, screen)
+- **Attachment path traversal fix** -- attachment filenames from signal-cli are
+  now sanitized by replacing path separators and `..` traversal sequences,
+  preventing writes outside the configured download directory
+
+---
+
+## v1.0.0
+
+### Rename to siggy
+
+- **Renamed from signal-tui to siggy** -- the binary, package, config paths,
+  data paths, and database filename are all now "siggy" (#127)
+- **Automatic migration** -- existing config directories, data directories,
+  and database files are seamlessly migrated from the old "signal-tui" paths
+  on first launch. No manual action required
+- **Published to crates.io** -- install with `cargo install siggy` (closes #11)
+
+### Docsite
+
+- **Brand theme** -- docsite color palette updated from gray mIRC to siggy's
+  navy-blue brand colors in both light and dark modes (#128)
+- **Logo integration** -- siggy logo and favicon added to the docsite intro
+  page and menu bar
+
+### Repo hygiene
+
+- **Cargo.lock tracked** -- binary crate now correctly tracks its lockfile
+- **.gitignore cleanup** -- added IDE directories and platform artifacts
+
+---
+
 ## v0.9.0
 
 ### Pinned messages

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -59,17 +59,18 @@
 - [x] Profile editor (`/profile` overlay for Signal profile fields)
 - [x] About overlay (`/about` command showing app info)
 - [x] Sidebar position setting (left or right placement)
+- [x] Publish to crates.io (`cargo install siggy`)
+- [x] Rename to siggy (auto-migration from signal-tui paths)
 
 ## Future
 
 ### Medium priority
 
-- [ ] Publish to crates.io (#11)
 - [ ] Multi-line message input (Shift+Enter for newlines)
+- [ ] Forward messages
 
 ### Low priority
 
 - [ ] Message history pagination (scroll-up to load older messages)
 - [ ] Scroll position memory per conversation
 - [ ] Configurable keybindings
-- [ ] Forward messages


### PR DESCRIPTION
## Summary
- Add changelog entries for v1.0.0 (rename to siggy, crates.io, brand theme, repo hygiene) and v1.0.1 (security fixes)
- Move "Publish to crates.io" and "Rename to siggy" to Completed in roadmap
- Reorder Future roadmap items (forward messages bumped to medium priority)

Also closed #11 (crates.io) and created issues for all remaining roadmap items:
- #135 Multi-line message input
- #136 Message history pagination
- #137 Scroll position memory
- #138 Configurable keybindings
- #139 Forward messages

## Test plan
- [ ] Verify changelog reads well and covers all changes
- [ ] Verify roadmap Completed/Future sections are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)