### PR TITLE
Fix UTF-8 panic, filter non-HTTP URLs, harden path sanitization

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5460,6 +5460,11 @@ impl App {
     }
 
     fn open_url(&mut self, url: &str) {
+        // Only allow http/https URLs to prevent local file access via file:// etc.
+        if !url.starts_with("http://") && !url.starts_with("https://") {
+            self.status_message = "Only http/https URLs can be opened".to_string();
+            return;
+        }
         if let Err(e) = open::that(url) {
             self.status_message = format!("Failed to open URL: {e}");
         }
@@ -5476,9 +5481,10 @@ fn is_in_rect(col: u16, row: u16, rect: Rect) -> bool {
 
 /// Shorten a phone number for display: +15551234567 -> +1***4567
 fn short_name(number: &str) -> String {
-    if number.len() > 6 {
-        let last4 = &number[number.len() - 4..];
-        let prefix = &number[..2];
+    let chars: Vec<char> = number.chars().collect();
+    if chars.len() > 6 {
+        let prefix: String = chars[..2].iter().collect();
+        let last4: String = chars[chars.len() - 4..].iter().collect();
         format!("{prefix}***{last4}")
     } else {
         number.to_string()

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -2185,6 +2185,13 @@ fn parse_attachment(
 
     let dest = download_dir.join(&effective_name);
 
+    // Defense-in-depth: verify resolved path stays within download directory.
+    let canon_dir = download_dir.canonicalize().unwrap_or_else(|_| download_dir.to_path_buf());
+    let canon_dest = dest.canonicalize().unwrap_or_else(|_| canon_dir.join(&effective_name));
+    if !canon_dest.starts_with(&canon_dir) {
+        return None;
+    }
+
     // Try to find the source file: explicit "file" field, or signal-cli's attachment dir
     let local_path = if dest.exists() {
         // Already copied previously


### PR DESCRIPTION
## Summary
Three quick security fixes from audit #143:

- **#146** — `short_name()` now uses char-based slicing instead of byte indexing, preventing a panic on multi-byte UTF-8 phone numbers
- **#145** — `open_url()` now only allows `http://` and `https://` schemes, blocking `file:///` URLs that could trigger local file access
- **#147** — Attachment path sanitization now includes a canonicalization check as defense-in-depth on top of the existing string replacement

## Test plan
- [ ] `cargo clippy --tests -- -D warnings && cargo test` passes
- [ ] Verify `open_url` rejects `file:///etc/passwd` with status message
- [ ] Verify `short_name` handles edge cases without panic

Closes #145, closes #146, closes #147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)