### PR TITLE
Set restrictive file permissions on sensitive files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -155,13 +155,35 @@ impl Config {
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("Failed to create config directory {}", parent.display()))?;
+            Self::set_dir_permissions(parent);
         }
         let contents = toml::to_string_pretty(self)
             .context("Failed to serialize config")?;
         std::fs::write(&config_path, contents)
             .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
+        Self::set_file_permissions(&config_path);
         Ok(())
     }
+
+    /// Set restrictive permissions (0600) on a sensitive file (Unix only).
+    #[cfg(unix)]
+    fn set_file_permissions(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+    }
+
+    #[cfg(not(unix))]
+    fn set_file_permissions(_path: &std::path::Path) {}
+
+    /// Set restrictive permissions (0700) on a sensitive directory (Unix only).
+    #[cfg(unix)]
+    fn set_dir_permissions(path: &std::path::Path) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+    }
+
+    #[cfg(not(unix))]
+    fn set_dir_permissions(_path: &std::path::Path) {}
 
     /// Returns true if the account is empty and setup is needed.
     pub fn needs_setup(&self) -> bool {

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -10,11 +10,18 @@ static FILE: Mutex<Option<File>> = Mutex::new(None);
 
 pub fn enable() {
     ENABLED.store(true, Ordering::Relaxed);
+    let path = "siggy-debug.log";
     if let Ok(f) = OpenOptions::new()
         .create(true)
         .append(true)
-        .open("siggy-debug.log")
+        .open(path)
     {
+        // Restrict log file to owner-only access (contains message content)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        }
         if let Ok(mut guard) = FILE.lock() {
             *guard = Some(f);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,26 @@ use signal::client::SignalClient;
 /// Keyboard polling interval for the main event loop.
 const POLL_TIMEOUT: Duration = Duration::from_millis(50);
 
+/// Set restrictive permissions (0600) on a sensitive file (Unix only).
+#[cfg(unix)]
+fn set_file_permissions(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_file_permissions(_path: &std::path::Path) {}
+
+/// Set restrictive permissions (0700) on a sensitive directory (Unix only).
+#[cfg(unix)]
+fn set_dir_permissions(path: &std::path::Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
+}
+
+#[cfg(not(unix))]
+fn set_dir_permissions(_path: &std::path::Path) {}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Disable the default Windows Ctrl+C handler — crossterm captures it as a
@@ -186,6 +206,7 @@ async fn run_main_flow(
     // Create download directory
     if !config.download_dir.exists() {
         std::fs::create_dir_all(&config.download_dir)?;
+        set_dir_permissions(&config.download_dir);
     }
 
     // Open database (in-memory for incognito mode)
@@ -207,6 +228,7 @@ async fn run_main_flow(
         }
 
         std::fs::create_dir_all(&db_dir)?;
+        set_dir_permissions(&db_dir);
         let db_path = db_dir.join("siggy.db");
 
         // Auto-migrate old database filename
@@ -216,6 +238,7 @@ async fn run_main_flow(
                 let _ = std::fs::rename(&old_db_path, &db_path);
             }
         }
+        set_file_permissions(&db_path);
         db::Database::open(&db_path)?
     };
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -2206,6 +2206,11 @@ fn parse_attachment(
 
         if let Some(src) = src.filter(|p| p.exists()) {
             let _ = std::fs::create_dir_all(download_dir);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(download_dir, std::fs::Permissions::from_mode(0o700));
+            }
             match std::fs::copy(&src, &dest) {
                 Ok(_) => Some(dest.to_string_lossy().to_string()),
                 Err(_) => Some(src.to_string_lossy().to_string()),


### PR DESCRIPTION
## Summary
Sets restrictive Unix file permissions on all sensitive files and directories:

| Path | Permission | Contents |
|---|---|---|
| Data directory | 0700 | Database files |
| `siggy.db` | 0600 | Message history, contacts, groups |
| Config directory | 0700 | Config file |
| `config.toml` | 0600 | Phone number, settings |
| Download directory | 0700 | Received attachments |
| `siggy-debug.log` | 0600 | Full message content (when --debug) |

Uses `#[cfg(unix)]` / `#[cfg(not(unix))]` — no-op on Windows where permissions use ACLs.

## Files changed
- `src/main.rs` — helper functions + permissions on db dir, download dir, db file
- `src/config.rs` — permissions on config dir and config file after save
- `src/debug_log.rs` — permissions on log file after creation
- `src/signal/client.rs` — permissions on download dir when created for attachments

## Test plan
- [ ] `cargo clippy --tests -- -D warnings && cargo test` passes
- [ ] On Linux/macOS: verify `ls -la` shows 0600 on files, 0700 on directories
- [ ] On Windows: verify no errors (no-op)

Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)