### PR TITLE
Fix tree-style connectors for quotes and link previews

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -850,7 +850,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             if let Some(ref quote) = msg.quote {
                 let quote_body = truncate(&quote.body, 50);
                 lines.push(Line::from(vec![
-                    Span::styled("  \u{2570} ", Style::default().fg(theme.quote)),
+                    Span::styled("  \u{256D} ", Style::default().fg(theme.quote)),
                     Span::styled(
                         format!("<{}>", quote.author),
                         Style::default()
@@ -957,7 +957,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 if let Some(ref preview) = msg.preview {
                     if let Some(ref title) = preview.title {
                         lines.push(Line::from(vec![
-                            Span::styled("  \u{2502} ", Style::default().fg(theme.link)),
+                            Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
                             Span::styled(
                                 truncate(title, 60),
                                 Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
@@ -966,8 +966,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                         line_msg_idx.push(Some(msg_index));
                     }
                     if let Some(ref desc) = preview.description {
+                        // Description is a middle line; URL always follows
                         lines.push(Line::from(vec![
-                            Span::styled("  \u{2502} ", Style::default().fg(theme.link)),
+                            Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
                             Span::styled(
                                 truncate(desc, 60),
                                 Style::default().fg(theme.fg_muted),


### PR DESCRIPTION
## Summary
- Quotes now use `╭` (top corner) so the branch visually points down to the reply message below
- Link previews use `├` (tee) for title/description lines and `╰` (bottom corner) for the URL

Visual result:

**Quotes:**
```
  ╭ <Alice> original message text
  [12:00] <Bob> this is the reply
```

**Link previews:**
```
  [12:00] <Bob> check this out
  ├ Article Title
  ├ Description text
  ╰ https://example.com
```

Closes #141

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` — all 301 tests pass
- [ ] Visual verification with `cargo run -- --demo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)