### PR TITLE
Fix trustAllKnownKeys bypass in identity verification

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -290,6 +290,8 @@ pub struct App {
     pub verify_identities: Vec<IdentityInfo>,
     /// Cached trust levels keyed by phone number
     pub identity_trust: HashMap<String, TrustLevel>,
+    /// Confirmation pending for verify action (user must press v twice)
+    pub verify_confirming: bool,
     /// Show inline halfblock image previews in chat
     pub inline_images: bool,
     /// Show link previews (title, description, thumbnail) for URLs
@@ -595,6 +597,7 @@ pub enum SendRequest {
     ListIdentities,
     TrustIdentity {
         recipient: String,
+        safety_number: String,
     },
     UpdateProfile {
         given_name: String,
@@ -1611,6 +1614,7 @@ impl App {
     pub fn handle_verify_key(&mut self, code: KeyCode) -> Option<SendRequest> {
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
+                self.verify_confirming = false;
                 if !self.verify_identities.is_empty()
                     && self.verify_index < self.verify_identities.len() - 1
                 {
@@ -1618,23 +1622,38 @@ impl App {
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
+                self.verify_confirming = false;
                 if self.verify_index > 0 {
                     self.verify_index -= 1;
                 }
             }
             KeyCode::Char('v') | KeyCode::Enter => {
-                // Trust the selected identity
                 if let Some(id) = self.verify_identities.get(self.verify_index) {
-                    if let Some(ref number) = id.number {
-                        let recipient = number.clone();
-                        return Some(SendRequest::TrustIdentity { recipient });
+                    if id.safety_number.is_empty() {
+                        self.status_message = "Safety number not available — cannot verify".to_string();
+                        return None;
+                    }
+                    if self.verify_confirming {
+                        // Second press: actually trust with the specific safety number
+                        if let Some(ref number) = id.number {
+                            let recipient = number.clone();
+                            let safety_number = id.safety_number.clone();
+                            self.verify_confirming = false;
+                            return Some(SendRequest::TrustIdentity { recipient, safety_number });
+                        }
+                    } else {
+                        // First press: ask for confirmation
+                        self.verify_confirming = true;
                     }
                 }
             }
             KeyCode::Esc => {
+                self.verify_confirming = false;
                 self.show_verify = false;
             }
-            _ => {}
+            _ => {
+                self.verify_confirming = false;
+            }
         }
         None
     }
@@ -2063,6 +2082,7 @@ impl App {
             verify_index: 0,
             verify_identities: Vec::new(),
             identity_trust: HashMap::new(),
+            verify_confirming: false,
             inline_images: true,
             show_link_previews: true,
             link_regions: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -690,11 +690,11 @@ async fn dispatch_send(
         SendRequest::ListIdentities => {
             let _ = signal_client.list_identities().await;
         }
-        SendRequest::TrustIdentity { recipient } => {
-            if let Err(e) = signal_client.trust_identity(&recipient).await {
+        SendRequest::TrustIdentity { recipient, safety_number } => {
+            if let Err(e) = signal_client.trust_identity(&recipient, &safety_number).await {
                 app.status_message = format!("trust error: {e}");
             } else {
-                app.status_message = format!("Trusted {}", app.contact_names.get(&recipient).unwrap_or(&recipient));
+                app.status_message = format!("Verified {}", app.contact_names.get(&recipient).unwrap_or(&recipient));
                 // Re-fetch identities to update trust levels
                 let _ = signal_client.list_identities().await;
             }

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -478,7 +478,7 @@ impl SignalClient {
         Ok(())
     }
 
-    pub async fn trust_identity(&self, recipient: &str) -> Result<()> {
+    pub async fn trust_identity(&self, recipient: &str, safety_number: &str) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         if let Ok(mut map) = self.pending_requests.lock() {
             map.insert(id.clone(), ("trust".to_string(), Instant::now()));
@@ -489,7 +489,7 @@ impl SignalClient {
             id,
             params: Some(serde_json::json!({
                 "recipient": [recipient],
-                "trustAllKnownKeys": true,
+                "verifiedSafetyNumber": safety_number,
                 "account": self.account,
             })),
         };

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2418,10 +2418,17 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
         }
 
         lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "  j/k: navigate  v: verify  Esc: close",
-            Style::default().fg(theme.fg_muted),
-        )));
+        if app.verify_confirming {
+            lines.push(Line::from(Span::styled(
+                "  Compare safety numbers, then press v to confirm",
+                Style::default().fg(theme.warning),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "  j/k: navigate  v: verify  Esc: close",
+                Style::default().fg(theme.fg_muted),
+            )));
+        }
     } else {
         // 1:1 view: single identity with full details
         let identity = &app.verify_identities[0];
@@ -2463,10 +2470,17 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
             lines.push(Line::from(""));
         }
 
-        lines.push(Line::from(Span::styled(
-            "  v: verify key  Esc: close",
-            Style::default().fg(theme.fg_muted),
-        )));
+        if app.verify_confirming {
+            lines.push(Line::from(Span::styled(
+                "  Compare safety numbers, then press v to confirm",
+                Style::default().fg(theme.warning),
+            )));
+        } else {
+            lines.push(Line::from(Span::styled(
+                "  v: verify key  Esc: close",
+                Style::default().fg(theme.fg_muted),
+            )));
+        }
     }
 
     let popup = Paragraph::new(lines).block(block);


### PR DESCRIPTION
## Summary
- Replace `trustAllKnownKeys: true` with `verifiedSafetyNumber` in the trust RPC call, so only the specific identity key the user is viewing gets trusted
- Add two-step confirmation: first `v` press shows "Compare safety numbers, then press v to confirm" prompt; second `v` press sends the trust command
- Navigation (j/k) or any other key cancels the pending confirmation
- Block verification when safety number is unavailable (shows status error)

Closes #144

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` — all 301 tests pass
- [ ] Manual: `/verify` in 1:1 chat — first `v` shows confirmation prompt, second `v` trusts with safety number
- [ ] Manual: `/verify` in group — same two-step flow per member
- [ ] Manual: pressing Esc or j/k after first `v` cancels confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)