### PR TITLE
Add clipboard auto-clear, notification preview levels, secure debug log

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,16 +31,33 @@ impl App {
 }
 
 /// Fire an OS-level desktop notification (runs on a blocking thread to avoid stalling async).
-fn show_desktop_notification(sender: &str, body: &str, is_group: bool, group_name: Option<&str>) {
-    let title = if is_group {
-        match group_name {
-            Some(gn) => format!("{} — {}", gn, sender),
-            None => sender.to_string(),
+fn show_desktop_notification(sender: &str, body: &str, is_group: bool, group_name: Option<&str>, preview_level: &str) {
+    let (title, preview) = match preview_level {
+        "minimal" => ("New message".to_string(), String::new()),
+        "sender" => {
+            let t = if is_group {
+                match group_name {
+                    Some(gn) => format!("{} — {}", gn, sender),
+                    None => sender.to_string(),
+                }
+            } else {
+                sender.to_string()
+            };
+            (t, "New message".to_string())
         }
-    } else {
-        sender.to_string()
+        _ => {
+            // "full" or any unknown value — current behavior
+            let t = if is_group {
+                match group_name {
+                    Some(gn) => format!("{} — {}", gn, sender),
+                    None => sender.to_string(),
+                }
+            } else {
+                sender.to_string()
+            };
+            (t, body.chars().take(100).collect())
+        }
     };
-    let preview: String = body.chars().take(100).collect();
 
     tokio::task::spawn_blocking(move || {
         let _ = notify_rust::Notification::new()
@@ -260,6 +277,12 @@ pub struct App {
     pub notify_group: bool,
     /// OS-level desktop notifications for incoming messages
     pub desktop_notifications: bool,
+    /// Notification preview level: "full", "sender", or "minimal"
+    pub notification_preview: String,
+    /// Seconds before clipboard is auto-cleared after copying (0 = disabled)
+    pub clipboard_clear_seconds: u64,
+    /// Timestamp when clipboard was last set (for auto-clear)
+    pub clipboard_set_at: Option<std::time::Instant>,
     /// Conversations muted from notifications
     pub muted_conversations: HashSet<String>,
     /// Conversations blocked via signal-cli
@@ -2070,6 +2093,9 @@ impl App {
             notify_direct: true,
             notify_group: true,
             desktop_notifications: false,
+            notification_preview: "full".to_string(),
+            clipboard_clear_seconds: 30,
+            clipboard_set_at: None,
             muted_conversations: HashSet::new(),
             blocked_conversations: HashSet::new(),
             autocomplete_visible: false,
@@ -3158,6 +3184,7 @@ impl App {
                     notif_body,
                     is_group,
                     notif_group.as_deref(),
+                    &self.notification_preview,
                 );
             }
         }
@@ -5382,6 +5409,9 @@ impl App {
             Ok(mut clipboard) => match clipboard.set_text(&text) {
                 Ok(()) => {
                     self.status_message = "Copied to clipboard".to_string();
+                    if self.clipboard_clear_seconds > 0 {
+                        self.clipboard_set_at = Some(std::time::Instant::now());
+                    }
                 }
                 Err(e) => {
                     self.status_message = format!("Clipboard error: {e}");
@@ -5389,6 +5419,18 @@ impl App {
             },
             Err(e) => {
                 self.status_message = format!("Clipboard error: {e}");
+            }
+        }
+    }
+
+    /// Clear the clipboard if auto-clear timer has expired.
+    pub fn check_clipboard_clear(&mut self) {
+        if let Some(set_at) = self.clipboard_set_at {
+            if set_at.elapsed().as_secs() >= self.clipboard_clear_seconds {
+                self.clipboard_set_at = None;
+                if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                    let _ = clipboard.set_text("");
+                }
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,14 @@ pub struct Config {
     #[serde(default)]
     pub desktop_notifications: bool,
 
+    /// Notification preview level: "full", "sender", or "minimal"
+    #[serde(default = "default_notification_preview")]
+    pub notification_preview: String,
+
+    /// Seconds before clipboard is auto-cleared after copying (0 = disabled)
+    #[serde(default = "default_clipboard_clear_seconds")]
+    pub clipboard_clear_seconds: u64,
+
     /// Show inline halfblock image previews in chat
     #[serde(default = "default_true")]
     pub inline_images: bool,
@@ -81,6 +89,14 @@ fn default_theme() -> String {
     "Default".to_string()
 }
 
+fn default_notification_preview() -> String {
+    "full".to_string()
+}
+
+fn default_clipboard_clear_seconds() -> u64 {
+    30
+}
+
 fn default_signal_cli_path() -> String {
     "signal-cli".to_string()
 }
@@ -100,6 +116,8 @@ impl Default for Config {
             notify_direct: true,
             notify_group: true,
             desktop_notifications: false,
+            notification_preview: default_notification_preview(),
+            clipboard_clear_seconds: default_clipboard_clear_seconds(),
             inline_images: true,
             show_link_previews: true,
             native_images: false,

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -1,4 +1,5 @@
-//! Optional debug logger — writes to siggy-debug.log when --debug is passed.
+//! Optional debug logger — writes to ~/.cache/siggy/debug.log when --debug is passed.
+//! Rotates log file when it exceeds MAX_LOG_SIZE bytes.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -7,25 +8,55 @@ use std::sync::Mutex;
 
 static ENABLED: AtomicBool = AtomicBool::new(false);
 static FILE: Mutex<Option<File>> = Mutex::new(None);
+static PATH: Mutex<Option<std::path::PathBuf>> = Mutex::new(None);
+
+const MAX_LOG_SIZE: u64 = 10 * 1024 * 1024; // 10 MB
+
+fn log_path() -> std::path::PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from(".cache"))
+        .join("siggy")
+        .join("debug.log")
+}
 
 pub fn enable() {
     ENABLED.store(true, Ordering::Relaxed);
-    let path = "siggy-debug.log";
-    if let Ok(f) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)
-    {
-        // Restrict log file to owner-only access (contains message content)
+    let path = log_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+            let _ = std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+    // Rotate if existing log exceeds size limit
+    if path.exists() {
+        if let Ok(meta) = std::fs::metadata(&path) {
+            if meta.len() > MAX_LOG_SIZE {
+                let backup = path.with_extension("log.old");
+                let _ = std::fs::rename(&path, &backup);
+            }
+        }
+    }
+    if let Ok(f) = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
         }
         if let Ok(mut guard) = FILE.lock() {
             *guard = Some(f);
         }
+        if let Ok(mut guard) = PATH.lock() {
+            *guard = Some(path.clone());
+        }
     }
+    eprintln!("Debug logging enabled: {}", path.display());
 }
 
 pub fn log(msg: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -720,6 +720,8 @@ async fn run_app(
     app.notify_direct = config.notify_direct;
     app.notify_group = config.notify_group;
     app.desktop_notifications = config.desktop_notifications;
+    app.notification_preview = config.notification_preview.clone();
+    app.clipboard_clear_seconds = config.clipboard_clear_seconds;
     app.inline_images = config.inline_images;
     app.show_link_previews = config.show_link_previews;
     app.native_images = config.native_images;
@@ -873,6 +875,9 @@ async fn run_app(
             app.pending_bell = false;
             execute!(terminal.backend_mut(), crossterm::style::Print("\x07"))?;
         }
+
+        // Auto-clear clipboard after timeout
+        app.check_clipboard_clear();
 
         // Dynamic mouse capture toggle from settings
         if let Some(enabled) = app.pending_mouse_toggle.take() {


### PR DESCRIPTION
## Summary
Three privacy hardening features:

**#131 — Auto-clear clipboard**
- Clipboard is cleared 30 seconds after copying a message with `y`/`Y`
- Configurable via `clipboard_clear_seconds` in config (default: 30, set to 0 to disable)

**#132 — Notification preview levels**
- New `notification_preview` config option with three levels:
  - `"full"` (default) — sender name + message preview (existing behavior)
  - `"sender"` — sender name only, body shows "New message"
  - `"minimal"` — just "New message" with no sender info

**#134 — Secure debug log location**
- Debug log moved from CWD (`siggy-debug.log`) to `~/.cache/siggy/debug.log`
- 10MB size-based rotation (keeps one `.log.old` backup)
- Prints warning to stderr on startup when debug mode is enabled
- Directory created with 0700, file with 0600 permissions (Unix)

Closes #131, closes #132, closes #134

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` — all 301 tests pass
- [ ] Manual: copy message, verify clipboard clears after 30s
- [ ] Manual: set `notification_preview = "sender"` in config, verify notifications hide body
- [ ] Manual: run with `--debug`, verify log appears in `~/.cache/siggy/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)