### PR TITLE
Add message history pagination

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -337,6 +337,10 @@ pub struct App {
     pub prev_active_conversation: Option<String>,
     /// Incognito mode — in-memory DB, no local persistence
     pub incognito: bool,
+    /// Conversations that have more messages in the database to load
+    pub has_more_messages: HashSet<String>,
+    /// Set by the renderer when the active conversation is scrolled to the top and has more
+    pub at_scroll_top: bool,
     /// Show delivery/read receipt status symbols on outgoing messages
     pub show_receipts: bool,
     /// Use colored status symbols (vs monochrome DarkGray)
@@ -2229,6 +2233,8 @@ impl App {
             native_image_cache: HashMap::new(),
             prev_active_conversation: None,
             incognito: false,
+            has_more_messages: HashSet::new(),
+            at_scroll_top: false,
             show_receipts: true,
             color_receipts: true,
             nerd_fonts: false,
@@ -2310,8 +2316,11 @@ impl App {
     }
 
     /// Load conversations and messages from the database on startup
+    /// Number of messages loaded per page (initial load + pagination batches).
+    const PAGE_SIZE: usize = 100;
+
     pub fn load_from_db(&mut self) -> anyhow::Result<()> {
-        let conv_data = self.db.load_conversations(500)?;
+        let conv_data = self.db.load_conversations(Self::PAGE_SIZE)?;
         let order = self.db.load_conversation_order()?;
 
         for mut conv in conv_data {
@@ -2364,6 +2373,10 @@ impl App {
                 }
             }
 
+            // Mark conversations that may have more messages in DB
+            if msg_count >= Self::PAGE_SIZE {
+                self.has_more_messages.insert(id.clone());
+            }
             self.conversations.insert(id.clone(), conv);
             // Derive last_read_index from unread count
             if msg_count > 0 {
@@ -2392,6 +2405,87 @@ impl App {
         }
 
         Ok(())
+    }
+
+    /// Load older messages for the active conversation when scrolled to the top.
+    pub fn load_more_messages(&mut self) {
+        self.at_scroll_top = false;
+        let conv_id = match self.active_conversation.as_ref() {
+            Some(id) if self.has_more_messages.contains(id) => id.clone(),
+            _ => return,
+        };
+
+        let already_loaded = self.conversations.get(&conv_id)
+            .map(|c| c.messages.len()).unwrap_or(0);
+
+        let new_msgs = match self.db.load_messages_page(&conv_id, Self::PAGE_SIZE, already_loaded) {
+            Ok(msgs) => msgs,
+            Err(_) => return,
+        };
+
+        if new_msgs.len() < Self::PAGE_SIZE {
+            self.has_more_messages.remove(&conv_id);
+        }
+
+        if new_msgs.is_empty() {
+            return;
+        }
+
+        let prepend_count = new_msgs.len();
+
+        // Post-process: promote stale Sending → Sent, re-render images
+        let mut processed: Vec<DisplayMessage> = new_msgs.into_iter().map(|mut msg| {
+            if msg.status == Some(MessageStatus::Sending) {
+                msg.status = Some(MessageStatus::Sent);
+            }
+            if msg.body.starts_with("[image:") {
+                let path_str = if let Some(uri_pos) = msg.body.find("file:///") {
+                    let uri_slice = msg.body[uri_pos..].trim_end_matches(')');
+                    Some(file_uri_to_path(uri_slice))
+                } else if let Some(arrow_pos) = msg.body.find(" -> ") {
+                    Some(msg.body[arrow_pos + 4..].trim_end_matches(']').to_string())
+                } else {
+                    None
+                };
+                if let Some(p) = path_str {
+                    let path = Path::new(&p);
+                    if path.exists() {
+                        msg.image_path = Some(p.clone());
+                        if self.inline_images {
+                            msg.image_lines = image_render::render_image(path, 40);
+                        }
+                    }
+                }
+            }
+            if let Some(ref preview) = msg.preview {
+                if self.show_link_previews && self.inline_images {
+                    if let Some(ref p) = preview.image_path {
+                        let path = Path::new(p);
+                        if path.exists() {
+                            msg.preview_image_lines = image_render::render_image(path, 30);
+                            msg.preview_image_path = Some(p.clone());
+                        }
+                    }
+                }
+            }
+            msg
+        }).collect();
+
+        // Prepend to conversation
+        if let Some(conv) = self.conversations.get_mut(&conv_id) {
+            processed.append(&mut conv.messages);
+            conv.messages = processed;
+        }
+
+        // Shift message indexes that reference this conversation
+        if let Some(read_idx) = self.last_read_index.get_mut(&conv_id) {
+            *read_idx += prepend_count;
+        }
+        if self.active_conversation.as_ref() == Some(&conv_id) {
+            if let Some(ref mut fi) = self.focused_msg_index {
+                *fi += prepend_count;
+            }
+        }
     }
 
     /// Resize sidebar by delta, clamped between 14..=40
@@ -6527,6 +6621,78 @@ mod tests {
         app.mode = InputMode::Insert;
         app.handle_paste("hello\r\nworld\rfoo".to_string());
         assert_eq!(app.input_buffer, "hello\nworld\nfoo");
+    }
+
+    // --- Pagination tests ---
+
+    #[rstest]
+    fn load_from_db_marks_has_more(mut app: App) {
+        // Insert exactly PAGE_SIZE messages
+        let conv_id = "+pagination";
+        app.db.upsert_conversation(conv_id, "PagTest", false).unwrap();
+        for i in 0..App::PAGE_SIZE {
+            app.db.insert_message(
+                conv_id, "Alice",
+                &format!("2025-01-01T00:{:02}:{:02}Z", i / 60, i % 60),
+                &format!("msg{i}"),
+                false, None, i as i64 * 1000,
+            ).unwrap();
+        }
+        app.load_from_db().unwrap();
+        assert!(app.has_more_messages.contains(conv_id));
+    }
+
+    #[rstest]
+    fn load_from_db_no_more_when_under_page_size(mut app: App) {
+        let conv_id = "+small";
+        app.db.upsert_conversation(conv_id, "Small", false).unwrap();
+        app.db.insert_message(conv_id, "Alice", "2025-01-01T00:00:00Z", "only one", false, None, 0).unwrap();
+        app.load_from_db().unwrap();
+        assert!(!app.has_more_messages.contains(conv_id));
+    }
+
+    #[rstest]
+    fn load_more_messages_prepends(mut app: App) {
+        let conv_id = "+paginate";
+        app.db.upsert_conversation(conv_id, "Test", false).unwrap();
+        // Insert 150 messages (more than PAGE_SIZE=100)
+        for i in 0..150 {
+            app.db.insert_message(
+                conv_id, "Alice",
+                &format!("2025-01-01T{:02}:{:02}:00Z", i / 60, i % 60),
+                &format!("msg{i}"),
+                false, None, i as i64 * 1000,
+            ).unwrap();
+        }
+        app.load_from_db().unwrap();
+        app.active_conversation = Some(conv_id.to_string());
+
+        // Should have 100 messages loaded, has_more set
+        assert_eq!(app.conversations[conv_id].messages.len(), 100);
+        assert!(app.has_more_messages.contains(conv_id));
+
+        // The loaded messages should be the 100 most recent (msg50..msg149)
+        assert_eq!(app.conversations[conv_id].messages[0].body, "msg50");
+        assert_eq!(app.conversations[conv_id].messages[99].body, "msg149");
+
+        // Set last_read_index and focused_msg_index to verify they shift
+        app.last_read_index.insert(conv_id.to_string(), 90);
+        app.focused_msg_index = Some(95);
+
+        // Trigger load_more
+        app.load_more_messages();
+
+        // Should now have 150 messages, oldest first
+        assert_eq!(app.conversations[conv_id].messages.len(), 150);
+        assert_eq!(app.conversations[conv_id].messages[0].body, "msg0");
+        assert_eq!(app.conversations[conv_id].messages[149].body, "msg149");
+
+        // Indexes should have shifted by 50 (the prepend count)
+        assert_eq!(app.last_read_index[conv_id], 140);
+        assert_eq!(app.focused_msg_index, Some(145));
+
+        // No more messages to load
+        assert!(!app.has_more_messages.contains(conv_id));
     }
 
     // --- Receipt handling tests ---

--- a/src/db.rs
+++ b/src/db.rs
@@ -258,6 +258,117 @@ impl Database {
         Ok(())
     }
 
+    /// Load a page of messages for a conversation, ordered chronologically (oldest first).
+    /// `offset` skips the N most recent messages (for pagination).
+    pub fn load_messages_page(&self, conv_id: &str, limit: usize, offset: usize) -> Result<Vec<DisplayMessage>> {
+        let mut msg_stmt = self.conn.prepare(
+            "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data, link_preview FROM messages
+             WHERE conversation_id = ?1
+             ORDER BY timestamp_ms DESC, rowid DESC LIMIT ?2 OFFSET ?3",
+        )?;
+
+        let mut messages: Vec<DisplayMessage> = msg_stmt
+            .query_map(params![conv_id, limit as i64, offset as i64], |row| {
+                let sender: String = row.get(0)?;
+                let ts_str: String = row.get(1)?;
+                let body: String = row.get(2)?;
+                let is_system: bool = row.get::<_, i32>(3)? != 0;
+                let status_i32: i32 = row.get(4)?;
+                let timestamp_ms: i64 = row.get(5)?;
+                let is_edited: bool = row.get::<_, i32>(6)? != 0;
+                let is_deleted: bool = row.get::<_, i32>(7)? != 0;
+                let quote_author: Option<String> = row.get(8)?;
+                let quote_body: Option<String> = row.get(9)?;
+                let quote_ts_ms: Option<i64> = row.get(10)?;
+                let sender_id: String = row.get(11)?;
+                let expires_in_seconds: i64 = row.get(12)?;
+                let expiration_start_ms: i64 = row.get(13)?;
+                let is_pinned: bool = row.get::<_, i32>(14)? != 0;
+                let poll_data_json: Option<String> = row.get(15)?;
+                let link_preview_json: Option<String> = row.get(16)?;
+                Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json)| {
+                let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
+                    .ok()?
+                    .with_timezone(&chrono::Utc);
+                let quote = match (quote_author, quote_body, quote_ts_ms) {
+                    (Some(author), Some(body), Some(ts)) => Some(crate::app::Quote {
+                        author_id: author.clone(),
+                        author,
+                        body: body.replace('\u{FFFC}', ""),
+                        timestamp_ms: ts,
+                    }),
+                    _ => None,
+                };
+                let poll_data = poll_data_json.and_then(|j| serde_json::from_str::<PollData>(&j).ok());
+                let preview = link_preview_json.and_then(|j| serde_json::from_str::<LinkPreview>(&j).ok());
+                Some(DisplayMessage {
+                    sender,
+                    timestamp,
+                    body,
+                    is_system,
+                    image_lines: None,
+                    image_path: None,
+                    status: MessageStatus::from_i32(status_i32),
+                    timestamp_ms,
+                    reactions: Vec::new(),
+                    mention_ranges: Vec::new(),
+                    style_ranges: Vec::new(),
+                    quote,
+                    is_edited,
+                    is_deleted,
+                    is_pinned,
+                    sender_id,
+                    expires_in_seconds,
+                    expiration_start_ms,
+                    poll_data,
+                    poll_votes: Vec::new(),
+                    preview,
+                    preview_image_lines: None,
+                    preview_image_path: None,
+                })
+            })
+            .collect();
+
+        // Reverse so oldest first
+        messages.reverse();
+
+        // Attach reactions
+        let mut ts_to_idx: HashMap<i64, Vec<usize>> = HashMap::new();
+        for (i, m) in messages.iter().enumerate() {
+            ts_to_idx.entry(m.timestamp_ms).or_default().push(i);
+        }
+        if let Ok(reactions) = self.load_reactions(conv_id) {
+            for (target_ts, target_author, emoji, sender) in reactions {
+                let idx = ts_to_idx.get(&target_ts).and_then(|idxs| {
+                    idxs.iter().find(|&&i| {
+                        messages[i].sender == target_author || messages[i].sender == "you"
+                    }).or_else(|| idxs.first()).copied()
+                });
+                if let Some(msg) = idx.and_then(|i| messages.get_mut(i)) {
+                    if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == sender) {
+                        existing.emoji = emoji;
+                    } else {
+                        msg.reactions.push(Reaction { emoji, sender });
+                    }
+                }
+            }
+        }
+
+        // Attach poll votes
+        for msg in &mut messages {
+            if msg.poll_data.is_some() {
+                if let Ok(votes) = self.load_poll_votes(conv_id, msg.timestamp_ms) {
+                    msg.poll_votes = votes;
+                }
+            }
+        }
+
+        Ok(messages)
+    }
+
     /// Load all conversations with their most recent messages (up to `msg_limit`).
     pub fn load_conversations(&self, msg_limit: usize) -> Result<Vec<Conversation>> {
         let mut stmt = self
@@ -279,115 +390,7 @@ impl Database {
         let mut result = Vec::with_capacity(convs.len());
 
         for (id, name, is_group, expiration_timer, accepted) in convs {
-            // Load last N messages
-            let mut msg_stmt = self.conn.prepare(
-                "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data, link_preview FROM messages
-                 WHERE conversation_id = ?1
-                 ORDER BY timestamp_ms DESC, rowid DESC LIMIT ?2",
-            )?;
-
-            let mut messages: Vec<DisplayMessage> = msg_stmt
-                .query_map(params![id, msg_limit as i64], |row| {
-                    let sender: String = row.get(0)?;
-                    let ts_str: String = row.get(1)?;
-                    let body: String = row.get(2)?;
-                    let is_system: bool = row.get::<_, i32>(3)? != 0;
-                    let status_i32: i32 = row.get(4)?;
-                    let timestamp_ms: i64 = row.get(5)?;
-                    let is_edited: bool = row.get::<_, i32>(6)? != 0;
-                    let is_deleted: bool = row.get::<_, i32>(7)? != 0;
-                    let quote_author: Option<String> = row.get(8)?;
-                    let quote_body: Option<String> = row.get(9)?;
-                    let quote_ts_ms: Option<i64> = row.get(10)?;
-                    let sender_id: String = row.get(11)?;
-                    let expires_in_seconds: i64 = row.get(12)?;
-                    let expiration_start_ms: i64 = row.get(13)?;
-                    let is_pinned: bool = row.get::<_, i32>(14)? != 0;
-                    let poll_data_json: Option<String> = row.get(15)?;
-                    let link_preview_json: Option<String> = row.get(16)?;
-                    Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json))
-                })?
-                .filter_map(|r| r.ok())
-                .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json)| {
-                    let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
-                        .ok()?
-                        .with_timezone(&chrono::Utc);
-                    let quote = match (quote_author, quote_body, quote_ts_ms) {
-                        (Some(author), Some(body), Some(ts)) => Some(crate::app::Quote {
-                            author_id: author.clone(),
-                            author,
-                            body: body.replace('\u{FFFC}', ""),
-                            timestamp_ms: ts,
-                        }),
-                        _ => None,
-                    };
-                    let poll_data = poll_data_json.and_then(|j| serde_json::from_str::<PollData>(&j).ok());
-                    let preview = link_preview_json.and_then(|j| serde_json::from_str::<LinkPreview>(&j).ok());
-                    Some(DisplayMessage {
-                        sender,
-                        timestamp,
-                        body,
-                        is_system,
-                        image_lines: None,
-                        image_path: None,
-                        status: MessageStatus::from_i32(status_i32),
-                        timestamp_ms,
-                        reactions: Vec::new(),
-                        mention_ranges: Vec::new(),
-                        style_ranges: Vec::new(),
-                        quote,
-                        is_edited,
-                        is_deleted,
-                        is_pinned,
-                        sender_id,
-                        expires_in_seconds,
-                        expiration_start_ms,
-                        poll_data,
-                        poll_votes: Vec::new(),
-                        preview,
-                        preview_image_lines: None,
-                        preview_image_path: None,
-                    })
-                })
-                .collect();
-
-            // Reverse so oldest first
-            messages.reverse();
-
-            // Build timestamp → index map for O(1) reaction attachment.
-            // Multiple messages can share a timestamp, so we store all matching
-            // indexes and prefer the one whose sender matches the target_author.
-            let mut ts_to_idx: HashMap<i64, Vec<usize>> = HashMap::new();
-            for (i, m) in messages.iter().enumerate() {
-                ts_to_idx.entry(m.timestamp_ms).or_default().push(i);
-            }
-            if let Ok(reactions) = self.load_reactions(&id) {
-                for (target_ts, target_author, emoji, sender) in reactions {
-                    let idx = ts_to_idx.get(&target_ts).and_then(|idxs| {
-                        // Prefer author+timestamp match, fall back to first timestamp match
-                        idxs.iter().find(|&&i| {
-                            messages[i].sender == target_author || messages[i].sender == "you"
-                        }).or_else(|| idxs.first()).copied()
-                    });
-                    if let Some(msg) = idx.and_then(|i| messages.get_mut(i)) {
-                        if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == sender) {
-                            existing.emoji = emoji;
-                        } else {
-                            msg.reactions.push(Reaction { emoji, sender });
-                        }
-                    }
-                }
-            }
-
-            // Attach poll votes from DB to matching poll messages
-            for msg in &mut messages {
-                if msg.poll_data.is_some() {
-                    if let Ok(votes) = self.load_poll_votes(&id, msg.timestamp_ms) {
-                        msg.poll_votes = votes;
-                    }
-                }
-            }
-
+            let messages = self.load_messages_page(&id, msg_limit, 0)?;
             let unread = self.unread_count(&id).unwrap_or(0);
 
             result.push(Conversation {
@@ -993,6 +996,35 @@ mod tests {
 
         // Timestamp between second and third
         assert_eq!(db.max_rowid_up_to_timestamp("+1", 2500).unwrap(), Some(r2));
+    }
+
+    #[rstest]
+    fn load_messages_page_pagination(db: Database) {
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        for i in 0..5 {
+            db.insert_message(
+                "+1", "Alice",
+                &format!("2025-01-01T00:0{i}:00Z"),
+                &format!("msg{i}"),
+                false, None, i * 1000,
+            ).unwrap();
+        }
+
+        // Load first page (most recent 3)
+        let page1 = db.load_messages_page("+1", 3, 0).unwrap();
+        assert_eq!(page1.len(), 3);
+        assert_eq!(page1[0].body, "msg2"); // oldest of the 3 most recent
+        assert_eq!(page1[2].body, "msg4"); // newest
+
+        // Load second page (next 2 older)
+        let page2 = db.load_messages_page("+1", 3, 3).unwrap();
+        assert_eq!(page2.len(), 2);
+        assert_eq!(page2[0].body, "msg0"); // oldest overall
+        assert_eq!(page2[1].body, "msg1");
+
+        // Load third page (nothing left)
+        let page3 = db.load_messages_page("+1", 3, 5).unwrap();
+        assert!(page3.is_empty());
     }
 
     #[rstest]

--- a/src/main.rs
+++ b/src/main.rs
@@ -791,6 +791,11 @@ async fn run_app(
             emit_native_images(terminal.backend_mut(), &mut app)?;
         }
 
+        // Load older messages when scrolled to the top
+        if app.at_scroll_top {
+            app.load_more_messages();
+        }
+
         // Poll for events with a short timeout so we stay responsive to signal events
         let has_terminal_event = event::poll(POLL_TIMEOUT)?;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1078,6 +1078,12 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     app.scroll_offset = app.scroll_offset.min(base_scroll);
     let mut scroll_y = base_scroll - app.scroll_offset;
 
+    // Signal when user has scrolled to the top of loaded content
+    app.at_scroll_top = app.scroll_offset >= base_scroll
+        && base_scroll > 0
+        && app.active_conversation.as_ref()
+            .is_some_and(|id| app.has_more_messages.contains(id));
+
     // Determine the focused message for highlight and full-timestamp display in Normal mode.
     // Check focused_msg_index too so J/K navigation works even when content fits the viewport
     // (base_scroll == 0 clamps scroll_offset to 0, but J/K focus should persist).


### PR DESCRIPTION
## Summary
- Reduces initial message load from 500 to **100 per conversation** for faster startup
- Extracts `load_messages_page()` in db.rs — reusable paginated query with `LIMIT`/`OFFSET`
- Automatically **loads older messages from SQLite** when the user scrolls to the top of loaded content
- Correctly shifts `last_read_index` and `focused_msg_index` after prepending older messages
- `has_more_messages` flag tracks which conversations have unloaded history; cleared when DB is exhausted

Closes #136

## Test plan
- [x] 4 new tests: DB pagination, has_more detection, prepend + index shifting
- [x] All 320 tests pass
- [x] Clippy clean
- [ ] Manual: open a conversation with >100 messages, scroll to top, verify older messages load seamlessly
- [ ] Manual: verify `g` (go to top) loads more messages progressively
- [ ] Manual: verify unread markers and focused message highlight remain correct after loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)