### PR TITLE
Add PRAGMA secure_delete = ON (#161)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -19,6 +19,7 @@ impl Database {
         let conn = Connection::open(path)?;
         conn.execute_batch("PRAGMA journal_mode=WAL;")?;
         conn.execute_batch("PRAGMA foreign_keys=ON;")?;
+        conn.execute_batch("PRAGMA secure_delete=ON;")?;
         let db = Self { conn };
         db.migrate()?;
         Ok(db)


### PR DESCRIPTION
## Summary
- Adds `PRAGMA secure_delete=ON;` to the on-disk SQLite setup in `db.rs`
- Zeroes out deleted content in database free pages rather than leaving it recoverable
- One-line change, minimal performance impact, no new dependencies

Closes #161

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — all 347 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)