### PR TITLE
Expose notification preview level in /settings UI (#162)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -818,6 +818,7 @@ impl App {
         config.account = self.account.clone();
         config.theme = self.theme.name.clone();
         config.keybinding_profile = self.keybindings.profile_name.clone();
+        config.notification_preview = self.notification_preview.clone();
         for def in SETTINGS {
             if let Some(save_fn) = def.save {
                 save_fn(&mut config, (def.get)(self));
@@ -880,8 +881,9 @@ impl App {
     /// Handle a key press while the settings overlay is open.
     /// After toggles: Theme at SETTINGS.len(), Keybindings at SETTINGS.len()+1.
     pub fn handle_settings_key(&mut self, code: KeyCode) {
-        let theme_index = SETTINGS.len();
-        let kb_index = SETTINGS.len() + 1;
+        let preview_index = SETTINGS.len();
+        let theme_index = SETTINGS.len() + 1;
+        let kb_index = SETTINGS.len() + 2;
         let max_index = kb_index;
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
@@ -893,7 +895,13 @@ impl App {
                 self.settings_index = self.settings_index.saturating_sub(1);
             }
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
-                if self.settings_index == theme_index {
+                if self.settings_index == preview_index {
+                    self.notification_preview = match self.notification_preview.as_str() {
+                        "full" => "sender".to_string(),
+                        "sender" => "minimal".to_string(),
+                        _ => "full".to_string(),
+                    };
+                } else if self.settings_index == theme_index {
                     self.show_settings = false;
                     self.save_settings();
                     self.show_theme_picker = true;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2147,7 +2147,7 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
 fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
-    let height = SETTINGS_POPUP_HEIGHT + 2; // extra lines for theme + keybindings entries
+    let height = SETTINGS_POPUP_HEIGHT + 3; // extra lines for preview + theme + keybindings entries
     let (popup_area, block) = centered_popup(
         frame, area, SETTINGS_POPUP_WIDTH, height, " Settings ", theme,
     );
@@ -2176,8 +2176,26 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         ]));
     }
 
-    // Theme selector entry (index == SETTINGS.len())
-    let is_theme_selected = app.settings_index == SETTINGS.len();
+    // Notification preview cycle entry (index == SETTINGS.len())
+    let preview_index = SETTINGS.len();
+    let is_preview_selected = app.settings_index == preview_index;
+    let preview_style = if is_preview_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.fg_secondary)
+    };
+    let preview_value_style = if is_preview_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.accent)
+    } else {
+        Style::default().fg(theme.accent)
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  Notification preview: ", preview_style),
+        Span::styled(app.notification_preview.clone(), preview_value_style),
+    ]));
+
+    // Theme selector entry (index == SETTINGS.len() + 1)
+    let is_theme_selected = app.settings_index == SETTINGS.len() + 1;
     let theme_style = if is_theme_selected {
         Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
     } else {
@@ -2193,8 +2211,8 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(app.theme.name.clone(), theme_value_style),
     ]));
 
-    // Keybindings selector entry (index == SETTINGS.len() + 1)
-    let is_kb_selected = app.settings_index == SETTINGS.len() + 1;
+    // Keybindings selector entry (index == SETTINGS.len() + 2)
+    let is_kb_selected = app.settings_index == SETTINGS.len() + 2;
     let kb_style = if is_kb_selected {
         Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
     } else {


### PR DESCRIPTION
## Summary
- Adds a "Notification preview" cycle toggle in the `/settings` overlay
- Cycles through "full" → "sender" → "minimal" on Space/Enter
- Persisted to `config.toml` on close
- Renders between the boolean toggles and the Theme selector row

The `notification_preview` config field already existed but was only configurable by editing `config.toml` manually.

Closes #162

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — all 347 tests pass
- [ ] Manual: open `/settings`, navigate to "Notification preview", cycle through values
- [ ] Manual: close settings, reopen — value persists
- [ ] Manual: verify desktop notifications respect the selected level

🤖 Generated with [Claude Code](https://claude.com/claude-code)