### PR TITLE
Redact PII in --debug logs, add --debug-full (#163)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4311,7 +4311,8 @@ impl App {
             }
             if !found {
                 crate::debug_log::logf(format_args!(
-                    "read_sync: no conversation found for sender={sender} ts={timestamp}"
+                    "read_sync: no conversation found for sender={} ts={timestamp}",
+                    crate::debug_log::mask_phone(sender)
                 ));
             }
         }
@@ -4714,7 +4715,8 @@ impl App {
     fn handle_send_timestamp(&mut self, rpc_id: &str, server_ts: i64) {
         if let Some((conv_id, local_ts)) = self.pending_sends.remove(rpc_id) {
             crate::debug_log::logf(format_args!(
-                "send confirmed: conv={conv_id} local_ts={local_ts} server_ts={server_ts}"
+                "send confirmed: conv={} local_ts={local_ts} server_ts={server_ts}",
+                crate::debug_log::mask_phone(&conv_id)
             ));
             let effective_ts = if server_ts != 0 { server_ts } else { local_ts };
             let mut found = false;
@@ -4827,7 +4829,8 @@ impl App {
         // that assigns the server timestamp. Buffer it for replay.
         if !matched_any && !timestamps.is_empty() {
             crate::debug_log::logf(format_args!(
-                "receipt: buffering {receipt_type} from {sender} (no matching ts)"
+                "receipt: buffering {receipt_type} from {} (no matching ts)",
+                crate::debug_log::mask_phone(sender)
             ));
             self.pending_receipts.push((
                 sender.to_string(),
@@ -4836,7 +4839,8 @@ impl App {
             ));
         } else if matched_any {
             crate::debug_log::logf(format_args!(
-                "receipt: {receipt_type} from {sender} -> {new_status:?}"
+                "receipt: {receipt_type} from {} -> {new_status:?}",
+                crate::debug_log::mask_phone(sender)
             ));
         }
     }

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -1,5 +1,8 @@
 //! Optional debug logger — writes to ~/.cache/siggy/debug.log when --debug is passed.
 //! Rotates log file when it exceeds MAX_LOG_SIZE bytes.
+//!
+//! `--debug` enables logging with PII redaction (phone numbers masked, message bodies omitted).
+//! `--debug-full` enables logging with full unredacted output.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -7,6 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 static ENABLED: AtomicBool = AtomicBool::new(false);
+static REDACT: AtomicBool = AtomicBool::new(true);
 static FILE: Mutex<Option<File>> = Mutex::new(None);
 static PATH: Mutex<Option<std::path::PathBuf>> = Mutex::new(None);
 
@@ -19,8 +23,7 @@ fn log_path() -> std::path::PathBuf {
         .join("debug.log")
 }
 
-pub fn enable() {
-    ENABLED.store(true, Ordering::Relaxed);
+fn setup_file() {
     let path = log_path();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
@@ -57,6 +60,49 @@ pub fn enable() {
         }
     }
     eprintln!("Debug logging enabled: {}", path.display());
+}
+
+/// Enable debug logging with PII redaction (--debug).
+pub fn enable() {
+    ENABLED.store(true, Ordering::Relaxed);
+    REDACT.store(true, Ordering::Relaxed);
+    setup_file();
+}
+
+/// Enable debug logging without PII redaction (--debug-full).
+pub fn enable_full() {
+    ENABLED.store(true, Ordering::Relaxed);
+    REDACT.store(false, Ordering::Relaxed);
+    setup_file();
+}
+
+/// Whether PII should be redacted in log output.
+pub fn redact() -> bool {
+    REDACT.load(Ordering::Relaxed)
+}
+
+/// Mask a phone number for redacted logging: "+15551234567" → "+1***...567"
+pub fn mask_phone(phone: &str) -> String {
+    if !redact() {
+        return phone.to_string();
+    }
+    if phone.starts_with('+') && phone.len() > 5 {
+        let suffix = &phone[phone.len() - 3..];
+        format!("+{}***...{}", &phone[1..2], suffix)
+    } else if phone.len() > 8 {
+        // Group IDs or other long identifiers
+        format!("{}...{}", &phone[..4], &phone[phone.len() - 4..])
+    } else {
+        "[redacted]".to_string()
+    }
+}
+
+/// Summarize a message body for redacted logging: "hello world" → "[msg: 11 chars]"
+pub fn mask_body(body: &str) -> String {
+    if !redact() {
+        return body.to_string();
+    }
+    format!("[msg: {} chars]", body.len())
 }
 
 pub fn log(msg: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ async fn main() -> Result<()> {
     let mut demo_mode = false;
     let mut incognito = false;
     let mut debug = false;
+    let mut debug_full = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -117,6 +118,10 @@ async fn main() -> Result<()> {
                 debug = true;
                 i += 1;
             }
+            "--debug-full" => {
+                debug_full = true;
+                i += 1;
+            }
             "--help" => {
                 eprintln!("siggy - Terminal Signal client");
                 eprintln!();
@@ -128,7 +133,8 @@ async fn main() -> Result<()> {
                 eprintln!("      --setup             Run first-time setup wizard");
                 eprintln!("      --demo              Launch with dummy data (no signal-cli needed)");
                 eprintln!("      --incognito         No local message storage (in-memory only)");
-                eprintln!("      --debug             Write debug log to siggy-debug.log");
+                eprintln!("      --debug             Write debug log (PII redacted)");
+                eprintln!("      --debug-full        Write debug log (full, unredacted)");
                 eprintln!("      --help              Show this help");
                 std::process::exit(0);
             }
@@ -139,9 +145,12 @@ async fn main() -> Result<()> {
         }
     }
 
-    if debug {
+    if debug_full {
+        debug_log::enable_full();
+        debug_log::log("=== siggy debug session started (full/unredacted) ===");
+    } else if debug {
         debug_log::enable();
-        debug_log::log("=== siggy debug session started ===");
+        debug_log::log("=== siggy debug session started (PII redacted) ===");
     }
 
     // Load config
@@ -530,7 +539,7 @@ async fn dispatch_send(
             let att_refs: Vec<&std::path::Path> = attachments.iter().map(|p| p.as_path()).collect();
             match signal_client.send_message(&recipient, &body, is_group, &mentions, &att_refs, quote.as_ref().map(|(a, t, b)| (a.as_str(), *t, b.as_str()))).await {
                 Ok(rpc_id) => {
-                    debug_log::logf(format_args!("send: to={recipient} ts={local_ts_ms}"));
+                    debug_log::logf(format_args!("send: to={} ts={local_ts_ms}", debug_log::mask_phone(&recipient)));
                     app.pending_sends
                         .insert(rpc_id, (recipient.to_string(), local_ts_ms));
                 }
@@ -556,7 +565,7 @@ async fn dispatch_send(
             };
             match signal_client.send_edit_message(&recipient, &body, is_group, edit_timestamp, &mentions, quote.as_ref().map(|(a, t, b)| (a.as_str(), *t, b.as_str()))).await {
                 Ok(rpc_id) => {
-                    debug_log::logf(format_args!("edit: to={recipient} ts={edit_timestamp}"));
+                    debug_log::logf(format_args!("edit: to={} ts={edit_timestamp}", debug_log::mask_phone(&recipient)));
                     app.pending_sends.insert(rpc_id, (recipient.to_string(), local_ts_ms));
                 }
                 Err(e) => {

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -100,7 +100,11 @@ impl SignalClient {
                         };
 
                         if let Some(ref event) = event {
-                            crate::debug_log::logf(format_args!("event: {event:?}"));
+                            if crate::debug_log::redact() {
+                                crate::debug_log::logf(format_args!("event: {}", event.redacted_summary()));
+                            } else {
+                                crate::debug_log::logf(format_args!("event: {event:?}"));
+                            }
                         }
 
                         if let Some(event) = event {

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -207,6 +207,82 @@ pub enum SignalEvent {
     Error(String),
 }
 
+impl SignalEvent {
+    /// Format this event for debug logging with PII redacted.
+    pub fn redacted_summary(&self) -> String {
+        use crate::debug_log::{mask_phone, mask_body};
+        match self {
+            Self::MessageReceived(msg) => format!(
+                "MessageReceived(from={}, body={}, attachments={}, group={})",
+                mask_phone(&msg.source),
+                msg.body.as_deref().map_or("[none]".to_string(), mask_body),
+                msg.attachments.len(),
+                msg.group_id.is_some(),
+            ),
+            Self::ReceiptReceived { sender, receipt_type, timestamps } => format!(
+                "ReceiptReceived({receipt_type} from={}, count={})",
+                mask_phone(sender), timestamps.len(),
+            ),
+            Self::SendTimestamp { rpc_id, server_ts } => format!(
+                "SendTimestamp(rpc={rpc_id}, ts={server_ts})",
+            ),
+            Self::SendFailed { rpc_id } => format!("SendFailed(rpc={rpc_id})"),
+            Self::TypingIndicator { sender, is_typing, .. } => format!(
+                "TypingIndicator(from={}, typing={is_typing})",
+                mask_phone(sender),
+            ),
+            Self::ReactionReceived { conv_id, emoji, sender, target_timestamp, is_remove, .. } => format!(
+                "ReactionReceived(conv={}, from={}, emoji={emoji}, target_ts={target_timestamp}, remove={is_remove})",
+                mask_phone(conv_id), mask_phone(sender),
+            ),
+            Self::EditReceived { conv_id, target_timestamp, new_body, .. } => format!(
+                "EditReceived(conv={}, target_ts={target_timestamp}, body={})",
+                mask_phone(conv_id), mask_body(new_body),
+            ),
+            Self::RemoteDeleteReceived { conv_id, target_timestamp, .. } => format!(
+                "RemoteDeleteReceived(conv={}, target_ts={target_timestamp})",
+                mask_phone(conv_id),
+            ),
+            Self::PinReceived { conv_id, target_timestamp, .. } => format!(
+                "PinReceived(conv={}, target_ts={target_timestamp})",
+                mask_phone(conv_id),
+            ),
+            Self::UnpinReceived { conv_id, target_timestamp, .. } => format!(
+                "UnpinReceived(conv={}, target_ts={target_timestamp})",
+                mask_phone(conv_id),
+            ),
+            Self::PollCreated { conv_id, timestamp, .. } => format!(
+                "PollCreated(conv={}, ts={timestamp})",
+                mask_phone(conv_id),
+            ),
+            Self::PollVoteReceived { conv_id, target_timestamp, voter, .. } => format!(
+                "PollVoteReceived(conv={}, target_ts={target_timestamp}, voter={})",
+                mask_phone(conv_id), mask_phone(voter),
+            ),
+            Self::PollTerminated { conv_id, target_timestamp } => format!(
+                "PollTerminated(conv={}, target_ts={target_timestamp})",
+                mask_phone(conv_id),
+            ),
+            Self::SystemMessage { conv_id, body, .. } => format!(
+                "SystemMessage(conv={}, body={})",
+                mask_phone(conv_id), mask_body(body),
+            ),
+            Self::ExpirationTimerChanged { conv_id, seconds, .. } => format!(
+                "ExpirationTimerChanged(conv={}, seconds={seconds})",
+                mask_phone(conv_id),
+            ),
+            Self::ReadSyncReceived { read_messages } => format!(
+                "ReadSyncReceived(count={})",
+                read_messages.len(),
+            ),
+            Self::ContactList(contacts) => format!("ContactList(count={})", contacts.len()),
+            Self::GroupList(groups) => format!("GroupList(count={})", groups.len()),
+            Self::IdentityList(ids) => format!("IdentityList(count={})", ids.len()),
+            Self::Error(e) => format!("Error({e})"),
+        }
+    }
+}
+
 /// A message from Signal
 #[derive(Debug, Clone)]
 pub struct SignalMessage {


### PR DESCRIPTION
## Summary
- `--debug` now redacts PII: phone numbers masked as `+1***...567`, message bodies as `[msg: 42 chars]`
- `--debug-full` preserves the old unredacted behavior for when you actually need message content
- Added `redacted_summary()` on `SignalEvent` for structured, privacy-safe event logging
- All log callsites that output phone numbers or conversation IDs now use `mask_phone()`

This means users can safely share debug logs without leaking private data.

Closes #163

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — all 347 tests pass
- [ ] Manual: run with `--debug`, check log file — phone numbers masked, no message bodies
- [ ] Manual: run with `--debug-full`, check log file — full unredacted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)