### PR TITLE
Add :q and :quit as aliases for /quit (#173)

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -89,6 +89,10 @@ pub fn parse_input(input: &str) -> InputAction {
     }
 
     if !trimmed.starts_with('/') {
+        // Handle :q and :quit as vim-style quit aliases
+        if trimmed == ":q" || trimmed == ":quit" {
+            return InputAction::Quit;
+        }
         return InputAction::SendText(trimmed.to_string());
     }
 


### PR DESCRIPTION
## Summary
- Maps `:q` and `:quit` to the existing quit action alongside `/q` and `/quit`
- One-line change in the input parser

Closes #173

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test` — all 347 tests pass
- [ ] Manual: type `:q` in insert mode — app quits

🤖 Generated with [Claude Code](https://claude.com/claude-code)