### PR TITLE
Fix image attachments not rendering after restart on Unix

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6174,13 +6174,20 @@ fn path_to_file_uri(path: &str) -> String {
     }
 }
 
-/// Extract a local file path from a file:/// URI string (which may have trailing text).
+/// Extract a local file path from a file:/// URI. On Unix the third slash is the
+/// root path separator, so it must be preserved; on Windows it's just the scheme.
 fn file_uri_to_path(uri: &str) -> String {
     let uri = uri.trim();
-    let stripped = uri.strip_prefix("file:///").unwrap_or(
-        uri.strip_prefix("file://").unwrap_or(uri),
-    );
-    stripped.to_string()
+    if let Some(rest) = uri.strip_prefix("file:///") {
+        #[cfg(windows)]
+        { rest.to_string() }
+        #[cfg(not(windows))]
+        { format!("/{rest}")}
+    } else if let Some(rest) = uri.strip_prefix("file://") {
+        rest.to_string()
+    } else {
+        uri.to_string()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
hey, much like this project! literally just discovered it earlier today and immediately started using it. so I will be glad to contribute :)

Right now there's a bug in MacOS (and most likely linux, although I didnt test) where images sent to you render, but open reloading the app, they disappear:

https://github.com/user-attachments/assets/897fb694-ffd0-4921-8b92-93c082bc6c79

This happens because `file_uri_to_path` stripped the leading / from absolute paths when removing the `file:///` prefix. This produces a relative path that never matches on disk for Unix systems.

To illustrate this, here's the roundtrip:                                                                              
1. saving an attachment at /Users/you/photo.jpg is encoded via `path_to_file_uri`: "/" prefix => `format!("file://{path}")` => `"file:///Users/you/photo.jpg"`
2. body stored in DB is: `[image: photo.jpg](file:///Users/you/photo.jpg)`
3. when loading, file_uri_to_path strips the prefix: `strip_prefix("file:///")` => `"Users/you/photo.jpg"`. the leading "/" is lost
3. `Path::new("Users/you/photo.jpg").exists()` => `false` because it's now a relative path

The file:/// URI scheme is file:// (scheme + empty authority) + /path (absolute path). strip_prefix("file:///") eats all three slashes, including the one that belongs to the path.

the fix is simple: file_uri_to_path now re-adds the leading / on Unix after stripping the file:/// prefix, so the path stays absolute.

Here's it fixed on this branch:
<img width="1129" height="1013" alt="Screenshot 2026-03-07 at 15 26 26" src="https://github.com/user-attachments/assets/3d0851ca-73a6-4055-a0f9-e4249e97ab7b" />

checks:
```
➜  siggy git:(fix/image-attachments-not-loading) cargo build && cargo test && cargo clippy
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.34s
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.07s
     Running unittests src/main.rs (target/debug/deps/siggy-23a21892af607095)
     
running 347 tests
[...]
test result: ok. 347 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.74s

    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
```
