### PR TITLE
Add proxy config passthrough to signal-cli

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -83,6 +83,10 @@ pub struct Config {
     /// Keybinding profile name (matches a built-in or custom profile)
     #[serde(default = "default_keybinding_profile")]
     pub keybinding_profile: String,
+
+    /// Signal TLS proxy URL passed through to signal-cli (e.g., "https://signal-proxy.example.com")
+    #[serde(default)]
+    pub proxy: String,
 }
 
 fn default_true() -> bool {
@@ -138,6 +142,7 @@ impl Default for Config {
             sidebar_on_right: false,
             theme: default_theme(),
             keybinding_profile: default_keybinding_profile(),
+            proxy: String::new(),
         }
     }
 }

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -33,6 +33,9 @@ impl SignalClient {
         if !config.account.is_empty() {
             cmd.arg("-a").arg(&config.account);
         }
+        if !config.proxy.is_empty() {
+            cmd.arg("--proxy").arg(&config.proxy);
+        }
         cmd.arg("jsonRpc");
         cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary
- Adds a `proxy` field to `config.toml` for Signal TLS proxy URLs
- Passed through as `--proxy <url>` when spawning signal-cli
- Empty by default, no behavior change for existing users

Users in censored regions can now add to their config:
```toml
proxy = "https://signal-proxy.example.com"
```

Closes #165.

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (347 tests)
- [x] Existing configs without `proxy` field load correctly (serde default)
- [ ] Verify signal-cli receives `--proxy` argument when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)