### PR TITLE
Add fuzz testing for external input boundaries

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "siggy-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+serde_json = "1"
+crossterm = "0.28"
+
+[dependencies.siggy]
+path = ".."
+
+[[bin]]
+name = "fuzz_json_rpc"
+path = "fuzz_targets/fuzz_json_rpc.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_input_edit"
+path = "fuzz_targets/fuzz_input_edit.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_key_combo"
+path = "fuzz_targets/fuzz_key_combo.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_command_parse"
+path = "fuzz_targets/fuzz_command_parse.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_command_parse.rs
+++ b/fuzz/fuzz_targets/fuzz_command_parse.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        // Should never panic regardless of input
+        let _ = siggy::input::parse_input(s);
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_input_edit.rs
+++ b/fuzz/fuzz_targets/fuzz_input_edit.rs
@@ -1,0 +1,93 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+/// Replicate the cursor helpers from app.rs to fuzz the same logic.
+fn next_char_pos(buf: &str, pos: usize) -> usize {
+    if pos >= buf.len() {
+        return buf.len();
+    }
+    pos + buf[pos..].chars().next().map_or(1, |c| c.len_utf8())
+}
+
+fn prev_char_pos(buf: &str, pos: usize) -> usize {
+    if pos == 0 {
+        return 0;
+    }
+    pos - buf[..pos].chars().next_back().map_or(1, |c| c.len_utf8())
+}
+
+fuzz_target!(|data: &[u8]| {
+    // Need at least 1 byte for the operation selector
+    if data.is_empty() {
+        return;
+    }
+
+    // Interpret the first bytes as initial UTF-8 buffer content
+    let split = data.len() / 2;
+    let buf_bytes = &data[..split];
+    let ops = &data[split..];
+
+    let Ok(initial) = std::str::from_utf8(buf_bytes) else {
+        return;
+    };
+
+    let mut buffer = initial.to_string();
+    let mut cursor: usize = 0;
+
+    // Apply a sequence of editing operations driven by the fuzzer
+    for &op in ops {
+        match op % 8 {
+            // Move right
+            0 => cursor = next_char_pos(&buffer, cursor),
+            // Move left
+            1 => cursor = prev_char_pos(&buffer, cursor),
+            // Backspace
+            2 => {
+                if cursor > 0 {
+                    cursor = prev_char_pos(&buffer, cursor);
+                    if cursor < buffer.len() && buffer.is_char_boundary(cursor) {
+                        buffer.remove(cursor);
+                    }
+                }
+            }
+            // Delete
+            3 => {
+                if cursor < buffer.len() && buffer.is_char_boundary(cursor) {
+                    buffer.remove(cursor);
+                }
+            }
+            // Insert ASCII char
+            4 => {
+                if buffer.is_char_boundary(cursor) {
+                    buffer.insert(cursor, 'a');
+                    cursor += 1;
+                }
+            }
+            // Insert multi-byte char
+            5 => {
+                if buffer.is_char_boundary(cursor) {
+                    buffer.insert(cursor, '\u{1F600}'); // 4-byte emoji
+                    cursor += 4;
+                }
+            }
+            // Home
+            6 => cursor = 0,
+            // End
+            7 => cursor = buffer.len(),
+            _ => unreachable!(),
+        }
+
+        // Invariant: cursor must always be at a valid char boundary
+        assert!(
+            cursor <= buffer.len(),
+            "cursor {cursor} past end {}",
+            buffer.len()
+        );
+        if cursor < buffer.len() {
+            assert!(
+                buffer.is_char_boundary(cursor),
+                "cursor {cursor} not on char boundary"
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_json_rpc.rs
+++ b/fuzz/fuzz_targets/fuzz_json_rpc.rs
@@ -1,0 +1,26 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use siggy::signal::types::JsonRpcResponse;
+use std::path::Path;
+
+fuzz_target!(|data: &[u8]| {
+    let download_dir = Path::new("/tmp");
+
+    // Fuzz the full JSON-RPC pipeline: deserialize arbitrary bytes, then parse
+    if let Ok(s) = std::str::from_utf8(data) {
+        if let Ok(resp) = serde_json::from_str::<JsonRpcResponse>(s) {
+            let _ = siggy::signal::client::parse_signal_event(&resp, download_dir);
+
+            // Also fuzz parse_rpc_result directly with the result field
+            if let Some(result) = &resp.result {
+                for method in &["send", "listContacts", "listGroups", "listIdentities"] {
+                    let _ = siggy::signal::client::parse_rpc_result(
+                        method,
+                        result,
+                        resp.id.as_deref(),
+                    );
+                }
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/fuzz_key_combo.rs
+++ b/fuzz/fuzz_targets/fuzz_key_combo.rs
@@ -1,0 +1,9 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        // Should never panic, only return Ok/Err
+        let _ = siggy::keybindings::parse_key_combo(s);
+    }
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+// Library entrypoint for fuzz testing and external consumers.
+// The main binary (main.rs) has its own module tree; this re-exports
+// only what fuzz harnesses need.
+
+pub mod config;
+#[allow(dead_code)]
+mod debug_log;
+pub mod input;
+pub mod keybindings;
+pub mod signal;

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -1108,7 +1108,7 @@ impl SignalClient {
     }
 }
 
-fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&str>) -> Option<SignalEvent> {
+pub fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&str>) -> Option<SignalEvent> {
     match method {
         "send" => {
             let id = rpc_id?.to_string();
@@ -1216,7 +1216,7 @@ fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&st
     }
 }
 
-fn parse_signal_event(
+pub fn parse_signal_event(
     resp: &JsonRpcResponse,
     download_dir: &std::path::Path,
 ) -> Option<SignalEvent> {

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -49,6 +49,7 @@ pub enum TrustLevel {
 }
 
 impl TrustLevel {
+    #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Self {
         match s {
             "UNTRUSTED" => TrustLevel::Untrusted,


### PR DESCRIPTION
## Summary
- Set up `cargo-fuzz` with four harness targets covering the main external input boundaries
- Add `src/lib.rs` to expose modules to fuzz harnesses (required since siggy is a binary crate)
- Make `parse_signal_event` and `parse_rpc_result` pub for the JSON-RPC harness
- Suppress a clippy lint on `TrustLevel::from_str` now visible through the lib crate

### Fuzz targets

| Target | What it fuzzes |
|---|---|
| `fuzz_json_rpc` | JSON-RPC deserialization + `parse_signal_event` / `parse_rpc_result` |
| `fuzz_input_edit` | UTF-8 cursor navigation and string mutation at byte boundaries |
| `fuzz_key_combo` | `parse_key_combo` with arbitrary strings from user TOML |
| `fuzz_command_parse` | `parse_input` with arbitrary slash commands |

### Usage
```sh
cargo install cargo-fuzz
cargo +nightly fuzz run fuzz_json_rpc
cargo +nightly fuzz run fuzz_input_edit
cargo +nightly fuzz run fuzz_key_combo
cargo +nightly fuzz run fuzz_command_parse
```

> **Note:** `cargo fuzz` requires **nightly Rust** and **Linux or macOS**. libfuzzer does not support Windows (MSVC).

Closes #172.

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (476 tests: 129 lib + 347 bin)
- [x] `cargo fuzz list` shows all four targets
- [x] All four targets compile successfully with nightly
- [ ] Run each target on Linux/macOS to verify no immediate crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)