### PR TITLE
Show spinner with status messages during startup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -288,6 +288,10 @@ pub struct App {
     pub connected: bool,
     /// True until the first ContactList event arrives (initial sync in progress)
     pub loading: bool,
+    /// Status message shown on the loading screen (e.g. "Loading contacts...")
+    pub startup_status: String,
+    /// Tick counter for the loading spinner animation
+    pub spinner_tick: usize,
     /// Current input mode (Normal or Insert)
     pub mode: InputMode,
     /// SQLite database for persistent storage
@@ -2459,6 +2463,8 @@ impl App {
             last_read_index: HashMap::new(),
             connected: false,
             loading: true,
+            startup_status: "Starting signal-cli...".to_string(),
+            spinner_tick: 0,
             mode: InputMode::Insert,
             db,
             connection_error: None,
@@ -4398,6 +4404,7 @@ impl App {
 
     fn handle_contact_list(&mut self, contacts: Vec<Contact>) {
         self.loading = false;
+        self.startup_status.clear();
         for contact in contacts {
             // Store name in lookup for future message resolution
             if let Some(ref name) = contact.name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -818,9 +818,13 @@ async fn run_app(
     app.sweep_expired_messages();
 
     // Ask primary device to sync contacts/groups, then fetch them (best-effort)
+    app.startup_status = "Syncing with primary device...".to_string();
     let _ = signal_client.send_sync_request().await;
+    app.startup_status = "Loading contacts...".to_string();
     let _ = signal_client.list_contacts().await;
+    app.startup_status = "Loading groups...".to_string();
     let _ = signal_client.list_groups().await;
+    app.startup_status = "Loading identities...".to_string();
     let _ = signal_client.list_identities().await;
 
     let mut last_expiry_sweep = Instant::now();
@@ -860,6 +864,12 @@ async fn run_app(
             }
             execute!(terminal.backend_mut(), EndSynchronizedUpdate)?;
             needs_redraw = false;
+        }
+
+        // Animate the loading spinner
+        if app.loading {
+            app.spinner_tick = app.spinner_tick.wrapping_add(1);
+            needs_redraw = true;
         }
 
         // Load older messages when scrolled to the top

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1722,13 +1722,15 @@ fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(theme.fg_secondary),
         )));
     } else if app.loading {
+        const SPINNER: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+        let spinner_char = SPINNER[app.spinner_tick % SPINNER.len()];
         lines.push(Line::from(Span::styled(
             "  siggy",
             Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
-            "  Loading...",
+            format!("  {spinner_char} {}", app.startup_status),
             Style::default().fg(theme.fg_muted),
         )));
     } else if app.conversation_order.is_empty() {


### PR DESCRIPTION
## Summary
- Animated braille spinner on the loading screen with status messages that update at each startup stage
- Stages: Starting signal-cli → Syncing → Loading contacts → Loading groups → Loading identities → Ready
- Closes #192

## Test plan
- [x] `cargo run` — spinner visible during startup, transitions to chat view once contacts load
- [x] CI passes (clippy + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)