### PR TITLE
Fix iTerm2 image squishing when partially scrolled

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -553,6 +553,8 @@ pub struct App {
     pub kitty_transmitted: HashSet<u32>,
     /// Images to transmit this frame: (id, path, cell_cols, cell_rows).
     pub kitty_pending_transmits: Vec<(u32, String, u16, u16)>,
+    /// Cache of cropped image base64 for iTerm2: (path, crop_top, height) → base64.
+    pub iterm2_crop_cache: HashMap<(String, u16, u16), String>,
 }
 
 /// A search result entry.
@@ -2595,6 +2597,7 @@ impl App {
             kitty_image_ids: HashMap::new(),
             kitty_transmitted: HashSet::new(),
             kitty_pending_transmits: Vec::new(),
+            iterm2_crop_cache: HashMap::new(),
         }
     }
 
@@ -2886,12 +2889,13 @@ impl App {
         None
     }
 
-    /// Clear Kitty image state so images are retransmitted.
+    /// Clear image state so images are retransmitted.
     /// Call on conversation switch (different images) and resize (different cell dimensions).
     pub fn clear_kitty_state(&mut self) {
         self.kitty_transmitted.clear();
         self.kitty_pending_transmits.clear();
         self.native_image_cache.clear();
+        self.iterm2_crop_cache.clear();
     }
 
     /// Reset typing state and queue a stop request if we were typing.

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -68,6 +68,43 @@ pub fn encode_native_png(path: &Path, cell_width: u32, cell_height: u32) -> Opti
     Some((base64::engine::general_purpose::STANDARD.encode(buf.into_inner()), new_w, new_h))
 }
 
+
+/// Crop and re-encode a cached full-size PNG for partial display.
+///
+/// Given the base64-encoded full image and its pixel height, returns a new
+/// base64 PNG cropped to the visible vertical slice. Used by iTerm2 which
+/// has no native source-crop parameter.
+pub fn crop_png_vertical(
+    b64_full: &str,
+    px_h: u32,
+    full_height_cells: u16,
+    crop_top_cells: u16,
+    visible_height_cells: u16,
+) -> Option<String> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD.decode(b64_full).ok()?;
+    let img = image::load_from_memory(&bytes).ok()?;
+    let (w, _) = img.dimensions();
+
+    let y_px = if full_height_cells > 0 {
+        crop_top_cells as u32 * px_h / full_height_cells as u32
+    } else {
+        0
+    };
+    let h_px = if full_height_cells > 0 {
+        (visible_height_cells as u32 * px_h / full_height_cells as u32).max(1)
+    } else {
+        px_h
+    };
+    let h_px = h_px.min(px_h.saturating_sub(y_px));
+
+    let cropped = img.crop_imm(0, y_px, w, h_px);
+
+    let mut buf = Cursor::new(Vec::new());
+    cropped.write_to(&mut buf, image::ImageFormat::Png).ok()?;
+    Some(base64::engine::general_purpose::STANDARD.encode(buf.into_inner()))
+}
+
 /// 256 combining diacritics for encoding row/column values 0-255 per the Kitty spec.
 /// Source: https://sw.kovidgoyal.net/kitty/_downloads/f0a0de9ec8d9ff4456206db8e0814937/rowcolumn-diacritics.txt
 const DIACRITICS: [char; 256] = [

--- a/src/main.rs
+++ b/src/main.rs
@@ -548,6 +548,23 @@ fn emit_native_images(
             None => continue,
         };
 
+        // Crop when partially scrolled out of view, with caching to avoid
+        // re-encoding every frame (which causes flicker in iTerm2).
+        let b64 = if img.crop_top > 0 || img.height < img.full_height {
+            let crop_key = (img.path.clone(), img.crop_top, img.height);
+            if let Some(cached) = app.iterm2_crop_cache.get(&crop_key) {
+                cached.clone()
+            } else {
+                let px_h = app.native_image_cache.get(&img.path).map(|c| c.2).unwrap_or(0);
+                let cropped = image_render::crop_png_vertical(&b64, px_h, img.full_height, img.crop_top, img.height)
+                    .unwrap_or(b64);
+                app.iterm2_crop_cache.insert(crop_key, cropped.clone());
+                cropped
+            }
+        } else {
+            b64
+        };
+
         queue!(backend, MoveTo(img.x, img.y))?;
 
         write!(


### PR DESCRIPTION
iTerm2 has no source-crop parameter, so when an image was partially scrolled out of view the full image was stretched into fewer rows.

Crop the PNG data to the visible region before sending it. Cropped results are cached by (path, crop_top, height) to avoid re-encoding every frame, which would cause flickering.

https://github.com/user-attachments/assets/332d3ee3-83d0-47d7-9f32-fb2e1a314a6c