### PR TITLE
Fix disappearing message icon clipping into timestamp

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -687,8 +687,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             // Timer indicator when disappearing messages are enabled
             if conv.expiration_timer > 0 {
                 let timer_label = format_compact_duration(conv.expiration_timer);
+                let icon = if app.nerd_fonts { "\u{F0150}" } else { "\u{23F1}" };
                 spans.push(Span::styled(
-                    format!("\u{23F1} {timer_label} "),
+                    format!("{icon} {timer_label} "),
                     Style::default().fg(theme.fg_muted),
                 ));
             }
@@ -893,8 +894,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             }
 
             if msg.expires_in_seconds > 0 {
+                let icon = if app.nerd_fonts { "\u{F0150}" } else { "\u{23F1}" };
                 spans.push(Span::styled(
-                    format!("\u{23F1}[{}] ", time),
+                    format!("{icon} [{}] ", time),
                     Style::default().fg(theme.fg_muted),
                 ));
             } else {


### PR DESCRIPTION
## Summary
- Add space between timer icon and timestamp bracket to prevent clipping
- Use nerd font clock icon when nerd fonts are enabled instead of emoji
- Closes #197

## Test plan
- [x] Verified icon no longer clips into timestamp bracket
- [x] Nerd font icon renders correctly when enabled
- [x] CI passes

Generated with [Claude Code](https://claude.com/claude-code)