### PR TITLE
Confirm before quitting with unsent text in input buffer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -273,6 +273,8 @@ pub struct App {
     pub status_message: String,
     /// Whether the app should quit
     pub should_quit: bool,
+    /// Pending quit confirmation (unsent text in input buffer)
+    pub quit_confirm: bool,
     /// Our own account number for identifying outgoing messages
     #[allow(dead_code)]
     pub account: String,
@@ -2458,6 +2460,7 @@ impl App {
             scroll_positions: HashMap::new(),
             status_message: "connecting...".to_string(),
             should_quit: false,
+            quit_confirm: false,
             account,
             sidebar_width: 22,
             sidebar_on_right: false,
@@ -2911,9 +2914,18 @@ impl App {
     /// Handle global keys that work in both Normal and Insert mode.
     /// Returns true if the key was consumed.
     pub fn handle_global_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> bool {
-        match self.keybindings.resolve(modifiers, code, BindingMode::Global) {
+        let action = self.keybindings.resolve(modifiers, code, BindingMode::Global);
+        if self.quit_confirm && !matches!(action, Some(KeyAction::Quit)) {
+            self.quit_confirm = false;
+            self.update_status();
+        }
+        match action {
             Some(KeyAction::Quit) => {
-                self.should_quit = true;
+                if self.input_buffer.is_empty() || self.quit_confirm {
+                    self.should_quit = true;
+                } else {
+                    self.quit_confirm = true;
+                }
                 true
             }
             Some(KeyAction::NextConversation) if !self.autocomplete_visible => {
@@ -5124,7 +5136,11 @@ impl App {
                 self.update_status();
             }
             InputAction::Quit => {
-                self.should_quit = true;
+                if self.input_buffer.is_empty() || self.quit_confirm {
+                    self.should_quit = true;
+                } else {
+                    self.quit_confirm = true;
+                }
             }
             InputAction::ToggleSidebar => {
                 self.sidebar_visible = !self.sidebar_visible;

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1974,6 +1974,20 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
 
 fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden: bool) {
     let theme = &app.theme;
+
+    // Override status bar with quit confirmation prompt
+    if app.quit_confirm {
+        let bar = Line::from(Span::styled(
+            " Unsent message in buffer. Press quit again to confirm.",
+            Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
+        ));
+        frame.render_widget(
+            Paragraph::new(bar).style(Style::default().bg(theme.statusbar_bg)),
+            area,
+        );
+        return;
+    }
+
     let mut segments: Vec<Span> = Vec::new();
 
     // Mode indicator


### PR DESCRIPTION
## Summary
- When input buffer has unsent text, first quit press shows a warning in the status bar
- Second quit press confirms and exits
- Any other keypress cancels the confirmation
- Works for both Ctrl+c (keybind) and /quit (command)
- Closes #189

## Test plan
- [x] Type text, press Ctrl+c - status bar shows warning, app stays open
- [x] Press Ctrl+c again - app quits
- [x] Type text, press Ctrl+c, then type anything else - confirmation cancelled
- [x] Empty input buffer - quits immediately without confirmation
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)