### PR TITLE
sort sidebar by recent activity upon receiving or sending message

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3502,6 +3502,8 @@ impl App {
             msg.source.clone()
         };
 
+        self.move_conversation_to_top(&conv_id);
+
         // Store source_name in contact lookup for future resolution (typing indicators, etc.)
         if !msg.is_outgoing {
             if let Some(ref name) = msg.source_name {
@@ -6200,6 +6202,16 @@ impl App {
         if let Err(e) = open::that(url) {
             self.status_message = format!("Failed to open URL: {e}");
         }
+    }
+
+    fn move_conversation_to_top(&mut self, id: &str) {
+        let pos = match self.conversation_order.iter().position(|c| c == id) {
+            Some(pos) => pos,
+            None => return,
+        };
+        
+        self.conversation_order.remove(pos);
+        self.conversation_order.insert(0, id.to_string());
     }
 }
 


### PR DESCRIPTION
currently entries on sidebar are loaded via `db::load_conversation_order` the messages are ordered by most recent messages, however, this only happens during startup of application. if a new message comes (or is sent) during runtime, they wont be reordered to properly reflect that.

this change introduces a new reordering method for the Vec of ids called `move_conversation_to_top`, and it's executed upon handle_message, in the case of receiving or sending.

solves #183 