### PR TITLE
Reorder sidebar on outgoing messages and forwards

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2311,6 +2311,7 @@ impl App {
                     let local_ts_ms = chrono::Utc::now().timestamp_millis();
                     self.show_forward = false;
                     self.status_message = format!("Forwarded to {name}");
+                    self.move_conversation_to_top(&conv_id);
                     return Some(SendRequest::Message {
                         recipient: conv_id,
                         body,
@@ -5364,6 +5365,7 @@ impl App {
                     self.scroll_offset = 0;
                     self.focused_msg_index = None;
                     self.reply_target = None;
+                    self.move_conversation_to_top(&conv_id);
                     return Some(SendRequest::Message {
                         recipient: conv_id,
                         body: wire_body,


### PR DESCRIPTION
## Summary

Follow-up to #205 - adds `move_conversation_to_top` calls to:
- Outgoing message send path (when you type and hit Enter)
- Forward message path (when you forward a message to another conversation)

The original PR only covered incoming messages. Without this, sending a message wouldn't bump the conversation to the top of the sidebar.

## Test plan

- [ ] Send a message in a conversation that isn't at the top of the sidebar - it should move to top
- [ ] Forward a message to a conversation that isn't at the top - it should move to top

🤖 Generated with [Claude Code](https://claude.com/claude-code)