### PR TITLE
fix: scope typing indicators to their conversation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -292,8 +292,8 @@ pub struct App {
     pub sidebar_width: u16,
     /// Display sidebar on the right side instead of left
     pub sidebar_on_right: bool,
-    /// Per-conversation typing indicators with expiry timestamp
-    pub typing_indicators: HashMap<String, Instant>,
+    /// Per-conversation typing indicators: conv_id → (sender_phone, expiry timestamp)
+    pub typing_indicators: HashMap<String, (String, Instant)>,
     /// Last-read message index per conversation (for unread marker)
     pub last_read_index: HashMap<String, usize>,
     /// Whether we are connected to signal-cli
@@ -3111,7 +3111,7 @@ impl App {
         let before = self.typing_indicators.len();
         let now = Instant::now();
         self.typing_indicators
-            .retain(|_, ts| now.duration_since(*ts).as_secs() < 5);
+            .retain(|_, (_, ts)| now.duration_since(*ts).as_secs() < 5);
         self.typing_indicators.len() != before
     }
 
@@ -3673,16 +3673,17 @@ impl App {
                 self.status_message = "send failed".to_string();
                 self.handle_send_failed(&rpc_id);
             }
-            SignalEvent::TypingIndicator { sender, sender_name, is_typing } => {
+            SignalEvent::TypingIndicator { sender, sender_name, is_typing, group_id } => {
                 // Store name in contact lookup if we learned it from this event
                 if let Some(ref name) = sender_name {
                     self.contact_names.entry(sender.clone()).or_insert_with(|| name.clone());
                 }
-                // Store typing state per-conversation (use sender as key for 1:1)
+                // Key by group ID for group messages, sender phone for 1:1
+                let conv_key = group_id.as_ref().unwrap_or(&sender).clone();
                 if is_typing {
-                    self.typing_indicators.insert(sender.clone(), Instant::now());
+                    self.typing_indicators.insert(conv_key, (sender.clone(), Instant::now()));
                 } else {
-                    self.typing_indicators.remove(&sender);
+                    self.typing_indicators.remove(&conv_key);
                 }
             }
             SignalEvent::ReactionReceived {
@@ -9091,6 +9092,7 @@ mod tests {
             sender: "+1".to_string(),
             sender_name: Some("Alice".to_string()),
             is_typing: true,
+            group_id: None,
         });
         assert!(app.typing_indicators.contains_key("+1"));
         assert_eq!(app.contact_names.get("+1").unwrap(), "Alice");
@@ -9099,6 +9101,7 @@ mod tests {
             sender: "+1".to_string(),
             sender_name: None,
             is_typing: false,
+            group_id: None,
         });
         assert!(!app.typing_indicators.contains_key("+1"));
     }
@@ -9277,5 +9280,58 @@ mod tests {
         msg.expires_in_seconds = 3600;
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         assert_eq!(app.conversations["+1"].expiration_timer, 3600);
+    }
+
+    // --- Typing indicator scoping ---
+
+    #[rstest]
+    fn group_typing_indicator_keyed_by_group_not_sender(mut app: App) {
+        // Alice types in group-a. The typing indicator must be stored under
+        // "group-a", not under Alice's phone number.
+        app.handle_signal_event(SignalEvent::TypingIndicator {
+            sender: "+1".to_string(),
+            sender_name: Some("Alice".to_string()),
+            is_typing: true,
+            group_id: Some("group-a".to_string()),
+        });
+
+        assert!(app.typing_indicators.contains_key("group-a"),
+            "typing indicator should be keyed by group ID");
+        assert!(!app.typing_indicators.contains_key("+1"),
+            "typing indicator must NOT be keyed by sender phone");
+        // Value stores the sender phone so we can resolve the display name
+        assert_eq!(app.typing_indicators["group-a"].0, "+1");
+    }
+
+    #[rstest]
+    fn group_typing_does_not_bleed_into_other_group(mut app: App) {
+        // Alice types in group-a. Viewing group-b must show no typing indicator.
+        app.get_or_create_conversation("group-a", "Group A", true);
+        app.get_or_create_conversation("group-b", "Group B", true);
+
+        app.handle_signal_event(SignalEvent::TypingIndicator {
+            sender: "+1".to_string(),
+            sender_name: Some("Alice".to_string()),
+            is_typing: true,
+            group_id: Some("group-a".to_string()),
+        });
+
+        // Viewing group-b: no indicator should be visible for it
+        assert!(!app.typing_indicators.contains_key("group-b"),
+            "group-a typing must not bleed into group-b");
+    }
+
+    #[rstest]
+    fn direct_typing_indicator_keyed_by_sender(mut app: App) {
+        // 1:1 typing (no group_id) must still be keyed by sender phone number.
+        app.handle_signal_event(SignalEvent::TypingIndicator {
+            sender: "+1".to_string(),
+            sender_name: None,
+            is_typing: true,
+            group_id: None,
+        });
+
+        assert!(app.typing_indicators.contains_key("+1"),
+            "1:1 typing indicator should be keyed by sender phone");
     }
 }

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -1360,7 +1360,11 @@ fn parse_typing_indicator(envelope: &serde_json::Value) -> Option<SignalEvent> {
         .and_then(|v| v.as_str())
         .map(|a| a == "STARTED")
         .unwrap_or(false);
-    Some(SignalEvent::TypingIndicator { sender, sender_name, is_typing })
+    let group_id = typing
+        .get("groupId")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    Some(SignalEvent::TypingIndicator { sender, sender_name, is_typing, group_id })
 }
 
 fn parse_receipt_message(envelope: &serde_json::Value) -> Option<SignalEvent> {
@@ -3498,6 +3502,52 @@ mod tests {
                 assert_eq!(identities[2].safety_number, "");
             }
             _ => panic!("Expected IdentityList"),
+        }
+    }
+
+    // --- Typing indicator parsing ---
+
+    #[test]
+    fn parse_typing_indicator_group_carries_group_id() {
+        // When a typing event arrives for a group message, the parsed event
+        // must include the group's ID so the app can key it correctly.
+        let params = json!({
+            "envelope": {
+                "sourceNumber": "+15551234567",
+                "sourceName": "Alice",
+                "typingMessage": {
+                    "action": "STARTED",
+                    "groupId": "group-abc"
+                }
+            }
+        });
+        let event = parse_signal_event(&make_resp(params), std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::TypingIndicator { sender, group_id, is_typing, .. } => {
+                assert_eq!(sender, "+15551234567");
+                assert_eq!(group_id, Some("group-abc".to_string()));
+                assert!(is_typing);
+            }
+            _ => panic!("Expected TypingIndicator"),
+        }
+    }
+
+    #[test]
+    fn parse_typing_indicator_direct_message_has_no_group_id() {
+        let params = json!({
+            "envelope": {
+                "sourceNumber": "+15551234567",
+                "typingMessage": {
+                    "action": "STARTED"
+                }
+            }
+        });
+        let event = parse_signal_event(&make_resp(params), std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::TypingIndicator { group_id, .. } => {
+                assert_eq!(group_id, None);
+            }
+            _ => panic!("Expected TypingIndicator"),
         }
     }
 }

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -124,6 +124,7 @@ pub enum SignalEvent {
         sender: String,
         sender_name: Option<String>,
         is_typing: bool,
+        group_id: Option<String>,
     },
     ReactionReceived {
         conv_id: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1058,21 +1058,15 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(ref conv_id) = app.active_conversation {
         let typers: Vec<String> = app
             .typing_indicators
-            .keys()
-            .filter(|sender| {
-                *sender == conv_id
-                    || app
-                        .conversations
-                        .get(conv_id)
-                        .is_some_and(|c| c.is_group)
-            })
-            .map(|s| {
-                if let Some(name) = app.contact_names.get(s) {
+            .iter()
+            .filter(|(key, _)| *key == conv_id)
+            .map(|(_, (sender, _))| {
+                if let Some(name) = app.contact_names.get(sender) {
                     name.clone()
-                } else if let Some(conv) = app.conversations.get(s) {
+                } else if let Some(conv) = app.conversations.get(sender) {
                     conv.name.clone()
                 } else {
-                    s.clone()
+                    sender.clone()
                 }
             })
             .collect();


### PR DESCRIPTION
Group typing events were incorrectly keyed by sender phone number instead of group ID, causing them to bleed into unrelated conversations. Two compounding bugs:

1. `parse_typing_indicator` ignored `typingMessage.groupId`, so group events were stored under the sender's phone number.
2. The `ui.rs` filter showed all stored indicators whenever the active conversation was *any* group, not just indicators for that specific group.