### PR TITLE
mark find_settings_profile as test only

### DIFF
--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -143,6 +143,7 @@ pub fn all_settings_profiles() -> Vec<SettingsProfile> {
 }
 
 /// Find a profile by name. Falls back to Default if not found.
+/// Only used in tests, so marked with cfg(test).
 #[cfg(test)]
 pub fn find_settings_profile(name: &str) -> SettingsProfile {
     all_settings_profiles()


### PR DESCRIPTION
cargo publish was warning about dead code for find_settings_profile. turns out it's only used in tests so i marked it with #[cfg(test)].

the function is still available for tests but won't be included in the release build anymore. added a comment explaining why too.

let me know if you prefer it removed completely instead!