### PR TITLE
feat: Release to homebrew

### DIFF
--- a/.github/actions/update-homebrew/action.yml
+++ b/.github/actions/update-homebrew/action.yml
@@ -1,0 +1,73 @@
+name: Update Homebrew Tap
+description: Updates Formula/siggy.rb in shwoop/homebrew-siggy with new version and checksums
+
+inputs:
+  tag:
+    description: Release tag (e.g. v1.5.0)
+    required: true
+  tap-token:
+    description: PAT with contents:write on shwoop/homebrew-siggy
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download macOS release archives
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.tap-token }}
+      run: |
+        gh release download "${{ inputs.tag }}" \
+          --repo johnsideserf/siggy \
+          --pattern "siggy-${{ inputs.tag }}-aarch64-apple-darwin.tar.gz" \
+          --pattern "siggy-${{ inputs.tag }}-x86_64-apple-darwin.tar.gz"
+
+    - name: Download source tarball
+      shell: bash
+      run: |
+        curl -sL -o "siggy-${{ inputs.tag }}-source.tar.gz" \
+          "https://github.com/johnsideserf/siggy/archive/refs/tags/${{ inputs.tag }}.tar.gz"
+
+    - name: Compute checksums
+      id: checksums
+      shell: bash
+      run: |
+        echo "arm64_mac=$(sha256sum "siggy-${{ inputs.tag }}-aarch64-apple-darwin.tar.gz" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        echo "x86_mac=$(sha256sum "siggy-${{ inputs.tag }}-x86_64-apple-darwin.tar.gz" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        echo "source=$(sha256sum "siggy-${{ inputs.tag }}-source.tar.gz" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+    - name: Update Homebrew formula
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        SHA_ARM64_MAC: ${{ steps.checksums.outputs.arm64_mac }}
+        SHA_X86_MAC: ${{ steps.checksums.outputs.x86_mac }}
+        SHA_SOURCE: ${{ steps.checksums.outputs.source }}
+        TAP_TOKEN: ${{ inputs.tap-token }}
+      run: |
+        VERSION="${TAG#v}"
+        git clone "https://x-access-token:${TAP_TOKEN}@github.com/shwoop/homebrew-siggy.git" tap
+        cd tap
+
+        F=Formula/siggy.rb
+
+        # Update version
+        sed -i "s/version \"[^\"]*\"/version \"${VERSION}\"/" "$F"
+
+        # Update arm64 mac url + sha256
+        sed -i "/Hardware::CPU.arm?/{n;s|url \"[^\"]*\"|url \"https://github.com/johnsideserf/siggy/releases/download/${TAG}/siggy-${TAG}-aarch64-apple-darwin.tar.gz\"|}" "$F"
+        sed -i "/aarch64-apple-darwin/{n;s/sha256 \"[^\"]*\"/sha256 \"${SHA_ARM64_MAC}\"/}" "$F"
+
+        # Update x86_64 mac url + sha256
+        sed -i "/Hardware::CPU.intel?/{n;s|url \"[^\"]*\"|url \"https://github.com/johnsideserf/siggy/releases/download/${TAG}/siggy-${TAG}-x86_64-apple-darwin.tar.gz\"|}" "$F"
+        sed -i "/x86_64-apple-darwin/{n;s/sha256 \"[^\"]*\"/sha256 \"${SHA_X86_MAC}\"/}" "$F"
+
+        # Update source tarball url + sha256
+        sed -i "s|/archive/refs/tags/v[^/]*.tar.gz|/archive/refs/tags/${TAG}.tar.gz|" "$F"
+        sed -i "/archive\/refs\/tags/{n;s/sha256 \"[^\"]*\"/sha256 \"${SHA_SOURCE}\"/}" "$F"
+
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add Formula/siggy.rb
+        git commit -m "Update siggy to ${TAG}"
+        git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,3 +90,15 @@ jobs:
         with:
           generate_release_notes: true
           files: siggy-*
+
+  update-homebrew:
+    name: Update Homebrew Tap
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/update-homebrew
+        with:
+          tag: ${{ github.ref_name }}
+          tap-token: ${{ secrets.TAP_TOKEN }}


### PR DESCRIPTION
Release siggy to homebrew with custom tap.

The PR still points to my forked repos, I will leave them this way so any proposed changes can be tested against it.

## Dependencies

* fork github.com/shwoop/homebrew-siggy
* break fork
* create PAT for new homebrew-siggy repo
* Add PAT an env secret to siggy repo

## Testing

created PAT for shwoop/homebrew-siggy:
<img width="845" height="719" alt="image" src="https://github.com/user-attachments/assets/4f056947-1d4e-403d-9a94-576df83eb36c" />

Added secret to the fork of siggy:
<img width="795" height="149" alt="image" src="https://github.com/user-attachments/assets/c0f32554-5531-4c72-aef6-809052601c11" />

Created some random releases to my fork, release action completed:
<img width="1332" height="414" alt="image" src="https://github.com/user-attachments/assets/444ea537-b119-4f5b-b1c0-ebcd65118d96" />

The tap has been updated to the new version:
https://github.com/shwoop/homebrew-siggy/commit/481cfa233ad48d81223242033906d6f38eabfae8

I can download it locally:
<img width="1497" height="733" alt="image" src="https://github.com/user-attachments/assets/cb1c2615-fc12-434f-a0ce-9aa7fe6a5158" />

