### PR TITLE
Refactor file picker domain out of App

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 
 use crate::db::Database;
 use crate::image_render;
+use crate::domain::FilePickerState;
 use crate::image_render::ImageProtocol;
 use crate::input::{self, InputAction, COMMANDS};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
@@ -433,20 +434,8 @@ pub struct App {
     pub pending_mentions: Vec<(String, Option<String>)>,
     /// Demo mode — prevents config writes
     pub is_demo: bool,
-    /// File browser overlay visible
-    pub show_file_browser: bool,
-    /// Current directory in file browser
-    pub file_browser_dir: PathBuf,
-    /// Directory entries: (name, is_dir, size_bytes)
-    pub file_browser_entries: Vec<(String, bool, u64)>,
-    /// Cursor position in file browser
-    pub file_browser_index: usize,
-    /// Type-to-filter text for file browser
-    pub file_browser_filter: String,
-    /// Filtered indices into file_browser_entries
-    pub file_browser_filtered: Vec<usize>,
-    /// Error message from directory read
-    pub file_browser_error: Option<String>,
+    /// File browser overlay state
+    pub file_picker: FilePickerState,
     /// File selected for sending as attachment
     pub pending_attachment: Option<PathBuf>,
     /// Directory for temporary clipboard paste files (PID-scoped to avoid conflicts)
@@ -2562,124 +2551,13 @@ impl App {
             self.status_message = "No active conversation. Use /join <name> first.".to_string();
             return;
         }
-        self.show_file_browser = true;
-        self.file_browser_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
-        self.file_browser_index = 0;
-        self.file_browser_filter.clear();
-        self.file_browser_error = None;
-        self.refresh_file_browser_entries();
-    }
-
-    /// Read the current directory and populate file_browser_entries.
-    fn refresh_file_browser_entries(&mut self) {
-        self.file_browser_entries.clear();
-        self.file_browser_error = None;
-        match std::fs::read_dir(&self.file_browser_dir) {
-            Ok(entries) => {
-                let mut dirs: Vec<(String, bool, u64)> = Vec::new();
-                let mut files: Vec<(String, bool, u64)> = Vec::new();
-                for entry in entries.flatten() {
-                    let name = entry.file_name().to_string_lossy().to_string();
-                    let meta = entry.metadata();
-                    let is_dir = meta.as_ref().map(|m| m.is_dir()).unwrap_or(false);
-                    let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
-                    if is_dir {
-                        dirs.push((name, true, 0));
-                    } else {
-                        files.push((name, false, size));
-                    }
-                }
-                dirs.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
-                files.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
-                self.file_browser_entries.extend(dirs);
-                self.file_browser_entries.extend(files);
-            }
-            Err(e) => {
-                self.file_browser_error = Some(format!("Cannot read directory: {e}"));
-            }
-        }
-        self.refresh_file_browser_filter();
-    }
-
-    /// Rebuild the filtered index list based on current filter text.
-    fn refresh_file_browser_filter(&mut self) {
-        let filter_lower = self.file_browser_filter.to_lowercase();
-        self.file_browser_filtered = self
-            .file_browser_entries
-            .iter()
-            .enumerate()
-            .filter(|(_, (name, _, _))| {
-                filter_lower.is_empty() || name.to_lowercase().contains(&filter_lower)
-            })
-            .map(|(i, _)| i)
-            .collect();
-        if self.file_browser_filtered.is_empty() {
-            self.file_browser_index = 0;
-        } else if self.file_browser_index >= self.file_browser_filtered.len() {
-            self.file_browser_index = self.file_browser_filtered.len() - 1;
-        }
+        self.file_picker.open();
     }
 
     /// Handle a key press while the file browser overlay is open.
     pub fn handle_file_browser_key(&mut self, code: KeyCode) {
-        match code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                if !self.file_browser_filtered.is_empty()
-                    && self.file_browser_index < self.file_browser_filtered.len() - 1
-                {
-                    self.file_browser_index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.file_browser_index = self.file_browser_index.saturating_sub(1);
-            }
-            KeyCode::Enter => {
-                if let Some(&entry_idx) = self.file_browser_filtered.get(self.file_browser_index) {
-                    let (name, is_dir, _) = self.file_browser_entries[entry_idx].clone();
-                    if is_dir {
-                        self.file_browser_dir = self.file_browser_dir.join(&name);
-                        self.file_browser_index = 0;
-                        self.file_browser_filter.clear();
-                        self.refresh_file_browser_entries();
-                    } else {
-                        let path = self.file_browser_dir.join(&name);
-                        self.pending_attachment = Some(path);
-                        self.show_file_browser = false;
-                    }
-                }
-            }
-            KeyCode::Backspace => {
-                if !self.file_browser_filter.is_empty() {
-                    self.file_browser_filter.pop();
-                    self.refresh_file_browser_filter();
-                } else {
-                    self.file_browser_navigate_up();
-                }
-            }
-            KeyCode::Char('-') => {
-                self.file_browser_navigate_up();
-            }
-            KeyCode::Esc => {
-                self.show_file_browser = false;
-            }
-            KeyCode::Char(c) => {
-                self.file_browser_filter.push(c);
-                self.refresh_file_browser_filter();
-            }
-            _ => {}
-        }
-    }
-
-    /// Navigate to the parent directory in the file browser.
-    fn file_browser_navigate_up(&mut self) {
-        if let Some(parent) = self.file_browser_dir.parent() {
-            let parent = parent.to_path_buf();
-            if parent != self.file_browser_dir {
-                self.file_browser_dir = parent;
-                self.file_browser_index = 0;
-                self.file_browser_filter.clear();
-                self.refresh_file_browser_entries();
-            }
+        if let Some(path) = self.file_picker.handle_key(code) {
+            self.pending_attachment = Some(path);
         }
     }
 
@@ -2822,13 +2700,7 @@ impl App {
             mention_trigger_pos: 0,
             pending_mentions: Vec::new(),
             is_demo: false,
-            show_file_browser: false,
-            file_browser_dir: dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
-            file_browser_entries: Vec::new(),
-            file_browser_index: 0,
-            file_browser_filter: String::new(),
-            file_browser_filtered: Vec::new(),
-            file_browser_error: None,
+            file_picker: FilePickerState::default(),
             pending_attachment: None,
             pending_paste_cleanups: HashMap::new(),
             paste_temp_path: {
@@ -3259,7 +3131,7 @@ impl App {
             let send = self.handle_delete_confirm_key(code);
             return (true, send);
         }
-        if self.show_file_browser {
+        if self.file_picker.visible {
             self.handle_file_browser_key(code);
             return (true, None);
         }
@@ -6510,7 +6382,7 @@ impl App {
             || self.show_help
             || self.show_contacts
             || self.show_search
-            || self.show_file_browser
+            || self.file_picker.visible
             || self.show_action_menu
             || self.show_reaction_picker
             || self.show_delete_confirm
@@ -8401,7 +8273,7 @@ mod tests {
 
         app.active_conversation = None;
         app.open_file_browser();
-        assert!(!app.show_file_browser);
+        assert!(!app.file_picker.visible);
         assert!(app.status_message.contains("No active conversation"));
     }
 
@@ -9225,9 +9097,9 @@ mod tests {
         assert!(app.has_overlay());
         app.show_search = false;
 
-        app.show_file_browser = true;
+        app.file_picker.visible = true;
         assert!(app.has_overlay());
-        app.show_file_browser = false;
+        app.file_picker.visible = false;
 
         app.show_action_menu = true;
         assert!(app.has_overlay());

--- a/src/domain/file_picker.rs
+++ b/src/domain/file_picker.rs
@@ -1,0 +1,160 @@
+use std::path::PathBuf;
+
+use crossterm::event::KeyCode;
+
+/// State for the file browser overlay used to select attachments.
+pub struct FilePickerState {
+    /// File browser overlay visible
+    pub visible: bool,
+    /// Current directory in file browser
+    pub dir: PathBuf,
+    /// Directory entries: (name, is_dir, size_bytes)
+    pub entries: Vec<(String, bool, u64)>,
+    /// Cursor position in file browser
+    pub index: usize,
+    /// Type-to-filter text for file browser
+    pub filter: String,
+    /// Filtered indices into entries
+    pub filtered: Vec<usize>,
+    /// Error message from directory read
+    pub error: Option<String>,
+}
+
+impl Default for FilePickerState {
+    fn default() -> Self {
+        Self {
+            visible: false,
+            dir: dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
+            entries: Vec::new(),
+            index: 0,
+            filter: String::new(),
+            filtered: Vec::new(),
+            error: None,
+        }
+    }
+}
+
+impl FilePickerState {
+    /// Reset state and open the file browser.
+    pub fn open(&mut self) {
+        self.visible = true;
+        self.dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        self.index = 0;
+        self.filter.clear();
+        self.error = None;
+        self.refresh_entries();
+    }
+
+    /// Read the current directory and populate entries.
+    pub fn refresh_entries(&mut self) {
+        self.entries.clear();
+        self.error = None;
+        match std::fs::read_dir(&self.dir) {
+            Ok(read_entries) => {
+                let mut dirs: Vec<(String, bool, u64)> = Vec::new();
+                let mut files: Vec<(String, bool, u64)> = Vec::new();
+                for entry in read_entries.flatten() {
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    let meta = entry.metadata();
+                    let is_dir = meta.as_ref().map(|m| m.is_dir()).unwrap_or(false);
+                    let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+                    if is_dir {
+                        dirs.push((name, true, 0));
+                    } else {
+                        files.push((name, false, size));
+                    }
+                }
+                dirs.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+                files.sort_by(|a, b| a.0.to_lowercase().cmp(&b.0.to_lowercase()));
+                self.entries.extend(dirs);
+                self.entries.extend(files);
+            }
+            Err(e) => {
+                self.error = Some(format!("Cannot read directory: {e}"));
+            }
+        }
+        self.refresh_filter();
+    }
+
+    /// Rebuild the filtered index list based on current filter text.
+    pub fn refresh_filter(&mut self) {
+        let filter_lower = self.filter.to_lowercase();
+        self.filtered = self
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, (name, _, _))| {
+                filter_lower.is_empty() || name.to_lowercase().contains(&filter_lower)
+            })
+            .map(|(i, _)| i)
+            .collect();
+        if self.filtered.is_empty() {
+            self.index = 0;
+        } else if self.index >= self.filtered.len() {
+            self.index = self.filtered.len() - 1;
+        }
+    }
+
+    /// Handle a key press while the file browser overlay is open.
+    /// Returns `Some(path)` when the user selects a file.
+    pub fn handle_key(&mut self, code: KeyCode) -> Option<PathBuf> {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if !self.filtered.is_empty() && self.index < self.filtered.len() - 1 {
+                    self.index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.index = self.index.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                if let Some(&entry_idx) = self.filtered.get(self.index) {
+                    let (name, is_dir, _) = self.entries[entry_idx].clone();
+                    if is_dir {
+                        self.dir = self.dir.join(&name);
+                        self.index = 0;
+                        self.filter.clear();
+                        self.refresh_entries();
+                    } else {
+                        let path = self.dir.join(&name);
+                        self.visible = false;
+                        return Some(path);
+                    }
+                }
+            }
+            KeyCode::Backspace => {
+                if !self.filter.is_empty() {
+                    self.filter.pop();
+                    self.refresh_filter();
+                } else {
+                    self.navigate_up();
+                }
+            }
+            KeyCode::Char('-') => {
+                self.navigate_up();
+            }
+            KeyCode::Esc => {
+                self.visible = false;
+            }
+            KeyCode::Char(c) => {
+                self.filter.push(c);
+                self.refresh_filter();
+            }
+            _ => {}
+        }
+        None
+    }
+
+    /// Navigate to the parent directory in the file browser.
+    fn navigate_up(&mut self) {
+        if let Some(parent) = self.dir.parent() {
+            let parent = parent.to_path_buf();
+            if parent != self.dir {
+                self.dir = parent;
+                self.index = 0;
+                self.filter.clear();
+                self.refresh_entries();
+            }
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,3 @@
+mod file_picker;
+
+pub use file_picker::FilePickerState;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod link;
 mod settings_profile;
 mod setup;
 mod signal;
+mod domain;
 mod theme;
 mod ui;
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -488,7 +488,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // File browser overlay
-    if app.show_file_browser {
+    if app.file_picker.visible {
         draw_file_browser(frame, app, size);
     }
 
@@ -2992,14 +2992,14 @@ pub(crate) fn format_file_size(bytes: u64) -> String {
 fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let visible_count = FILE_BROWSER_MAX_VISIBLE.min(
-        if app.file_browser_filtered.is_empty() { 1 } else { app.file_browser_filtered.len() }
+        if app.file_picker.filtered.is_empty() { 1 } else { app.file_picker.filtered.len() }
     );
     let pref_height = visible_count as u16 + 5; // border + header + footer
 
-    let title = if app.file_browser_filter.is_empty() {
+    let title = if app.file_picker.filter.is_empty() {
         " Attach File ".to_string()
     } else {
-        format!(" Attach File [{}] ", app.file_browser_filter)
+        format!(" Attach File [{}] ", app.file_picker.filter)
     };
 
     let (popup_area, block) = centered_popup(
@@ -3015,37 +3015,37 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     let mut lines: Vec<Line> = Vec::new();
 
     // Current path header
-    let dir_display = app.file_browser_dir.to_string_lossy();
+    let dir_display = app.file_picker.dir.to_string_lossy();
     let dir_truncated = truncate(&dir_display, inner_w.saturating_sub(2));
     lines.push(Line::from(Span::styled(
         format!("  {dir_truncated}"),
         Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
     )));
 
-    if let Some(ref err) = app.file_browser_error {
+    if let Some(ref err) = app.file_picker.error {
         lines.push(Line::from(Span::styled(
             format!("  {}", truncate(err, inner_w.saturating_sub(2))),
             Style::default().fg(theme.error),
         )));
-    } else if app.file_browser_filtered.is_empty() {
+    } else if app.file_picker.filtered.is_empty() {
         lines.push(Line::from(Span::styled(
             "  Empty directory",
             Style::default().fg(theme.fg_muted),
         )));
     } else {
         // Scroll the list so the selected item is always visible
-        let scroll_offset = if app.file_browser_index >= visible_rows {
-            app.file_browser_index - visible_rows + 1
+        let scroll_offset = if app.file_picker.index >= visible_rows {
+            app.file_picker.index - visible_rows + 1
         } else {
             0
         };
 
-        let end = (scroll_offset + visible_rows).min(app.file_browser_filtered.len());
+        let end = (scroll_offset + visible_rows).min(app.file_picker.filtered.len());
 
-        for (i, &entry_idx) in app.file_browser_filtered[scroll_offset..end].iter().enumerate() {
+        for (i, &entry_idx) in app.file_picker.filtered[scroll_offset..end].iter().enumerate() {
             let actual_index = scroll_offset + i;
-            let is_selected = actual_index == app.file_browser_index;
-            let (ref name, is_dir, size) = app.file_browser_entries[entry_idx];
+            let is_selected = actual_index == app.file_picker.index;
+            let (ref name, is_dir, size) = app.file_picker.entries[entry_idx];
 
             let size_str = if is_dir {
                 String::new()


### PR DESCRIPTION
Rebased version of #226 by @Dowsley onto current master (after #229 landed).

Extracts file picker state and logic from the App god object into a new `domain::FilePickerState` struct. This is the first step toward #221 and sets the pattern for future domain extractions.

## Changes
- New `src/domain/file_picker.rs` with self-contained `FilePickerState`
- 7 `file_browser_*` fields on App replaced with single `file_picker` field
- All file picker logic (open, navigate, filter, select) moved to `FilePickerState` methods
- `handle_key()` returns `Option<PathBuf>` on file selection
- UI reads state fields directly for rendering (pragmatic, no over-abstraction)

Original PR: #226
Closes #226

Co-Authored-By: Dowsley <joao.dowsley850@gmail.com>