### PR TITLE
Add type-to-filter search in sidebar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -307,6 +307,12 @@ pub struct App {
     pub sidebar_width: u16,
     /// Display sidebar on the right side instead of left
     pub sidebar_on_right: bool,
+    /// Sidebar filter mode active
+    pub sidebar_filter_active: bool,
+    /// Current filter text for sidebar
+    pub sidebar_filter: String,
+    /// Filtered conversation IDs matching the filter
+    pub sidebar_filtered: Vec<String>,
     /// Typing indicator state (inbound indicators + outbound typing tracking).
     pub typing: TypingState,
     /// Last-read message index per conversation (for unread marker).
@@ -2546,6 +2552,9 @@ impl App {
             account,
             sidebar_width: 22,
             sidebar_on_right: false,
+            sidebar_filter_active: false,
+            sidebar_filter: String::new(),
+            sidebar_filtered: Vec::new(),
             typing: TypingState::default(),
             last_read_index: HashMap::new(),
             connected: false,
@@ -2845,6 +2854,62 @@ impl App {
         self.sidebar_width = new_width;
     }
 
+    /// Refresh the filtered sidebar list based on the current filter text.
+    pub(crate) fn refresh_sidebar_filter(&mut self) {
+        let query = self.sidebar_filter.to_lowercase();
+        self.sidebar_filtered = self
+            .conversation_order
+            .iter()
+            .filter(|id| {
+                self.conversations
+                    .get(*id)
+                    .is_some_and(|c| c.name.to_lowercase().contains(&query))
+            })
+            .cloned()
+            .collect();
+    }
+
+    /// Clear sidebar filter state and restore the full list.
+    fn clear_sidebar_filter(&mut self) {
+        self.sidebar_filter_active = false;
+        self.sidebar_filter.clear();
+        self.sidebar_filtered.clear();
+    }
+
+    /// Handle a key press while sidebar filter is active.
+    fn handle_sidebar_filter_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => {
+                self.clear_sidebar_filter();
+            }
+            KeyCode::Enter => {
+                // Select the first matching conversation
+                let target = if self.sidebar_filtered.is_empty() {
+                    None
+                } else {
+                    Some(self.sidebar_filtered[0].clone())
+                };
+                self.clear_sidebar_filter();
+                if let Some(conv_id) = target {
+                    self.join_conversation(&conv_id);
+                }
+            }
+            KeyCode::Char(c) => {
+                self.sidebar_filter.push(c);
+                self.refresh_sidebar_filter();
+            }
+            KeyCode::Backspace => {
+                self.sidebar_filter.pop();
+                if self.sidebar_filter.is_empty() {
+                    self.clear_sidebar_filter();
+                } else {
+                    self.refresh_sidebar_filter();
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Mark current conversation as fully read
     pub fn mark_read(&mut self) {
         if let Some(ref conv_id) = self.active_conversation {
@@ -2997,6 +3062,13 @@ impl App {
                 self.focused_msg_index = None;
                 true
             }
+            Some(KeyAction::SidebarSearch) => {
+                self.sidebar_visible = true;
+                self.sidebar_filter_active = true;
+                self.sidebar_filter.clear();
+                self.sidebar_filtered.clear();
+                true
+            }
             _ => false,
         }
     }
@@ -3006,6 +3078,10 @@ impl App {
     /// command triggers a message send. Returns `None` otherwise.
     /// Returns `Ok(true)` if the key was consumed by an overlay.
     pub fn handle_overlay_key(&mut self, code: KeyCode) -> (bool, Option<SendRequest>) {
+        if self.sidebar_filter_active {
+            self.handle_sidebar_filter_key(code);
+            return (true, None);
+        }
         if self.show_poll_vote {
             let send = self.handle_poll_vote_key(code);
             return (true, send);
@@ -3177,6 +3253,13 @@ impl App {
                 self.input_cursor = 1;
                 self.mode = InputMode::Insert;
                 self.update_autocomplete();
+                None
+            }
+            Some(KeyAction::SidebarSearch) => {
+                self.sidebar_visible = true;
+                self.sidebar_filter_active = true;
+                self.sidebar_filter.clear();
+                self.sidebar_filtered.clear();
                 None
             }
             Some(KeyAction::ClearInput) => {
@@ -6062,6 +6145,7 @@ impl App {
         if self.conversation_order.is_empty() {
             return;
         }
+        self.clear_sidebar_filter();
         self.mark_read();
         self.save_scroll_position();
         self.pending_attachment = None;
@@ -6089,6 +6173,7 @@ impl App {
         if self.conversation_order.is_empty() {
             return;
         }
+        self.clear_sidebar_filter();
         self.mark_read();
         self.save_scroll_position();
         self.pending_attachment = None;
@@ -6334,8 +6419,14 @@ impl App {
         if let Some(inner) = self.mouse_sidebar_inner {
             if is_in_rect(col, row, inner) {
                 let index = (row - inner.y) as usize;
-                if index < self.conversation_order.len() {
-                    let conv_id = self.conversation_order[index].clone();
+                let sidebar_list = if self.sidebar_filter_active && !self.sidebar_filtered.is_empty() {
+                    &self.sidebar_filtered
+                } else {
+                    &self.conversation_order
+                };
+                if index < sidebar_list.len() {
+                    let conv_id = sidebar_list[index].clone();
+                    self.clear_sidebar_filter();
                     self.join_conversation(&conv_id);
                 }
                 return;
@@ -6383,9 +6474,12 @@ impl App {
             Some(pos) => pos,
             None => return,
         };
-        
+
         self.conversation_order.remove(pos);
         self.conversation_order.insert(0, id.to_string());
+        if self.sidebar_filter_active {
+            self.refresh_sidebar_filter();
+        }
     }
 }
 

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -55,6 +55,7 @@ pub enum KeyAction {
     PrevSearchResult,
     OpenActionMenu,
     PinMessage,
+    SidebarSearch,
     // Insert
     ExitInsert,
     SendMessage,
@@ -469,6 +470,7 @@ pub const NORMAL_ACTIONS: &[KeyAction] = &[
     KeyAction::PrevSearchResult,
     KeyAction::OpenActionMenu,
     KeyAction::PinMessage,
+    KeyAction::SidebarSearch,
 ];
 
 pub const INSERT_ACTIONS: &[KeyAction] = &[
@@ -522,6 +524,7 @@ pub fn action_label(action: KeyAction) -> &'static str {
         KeyAction::PrevSearchResult => "Previous search match",
         KeyAction::OpenActionMenu => "Action menu",
         KeyAction::PinMessage => "Pin/unpin message",
+        KeyAction::SidebarSearch => "Filter sidebar",
         KeyAction::ExitInsert => "Normal mode",
         KeyAction::SendMessage => "Send message",
         KeyAction::InsertNewline => "Insert newline",
@@ -591,6 +594,7 @@ pub fn default_profile() -> KeyBindings {
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('N'), KeyAction::PrevSearchResult);
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Enter, KeyAction::OpenActionMenu);
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('p'), KeyAction::PinMessage);
+    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('s'), KeyAction::SidebarSearch);
 
     // --- Insert ---
     bind(&mut insert, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ExitInsert);
@@ -652,6 +656,7 @@ pub fn emacs_profile() -> KeyBindings {
     bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('n'), KeyAction::NextSearchResult);
     bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('p'), KeyAction::PrevSearchResult);
     bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('m'), KeyAction::OpenActionMenu);
+    bind(&mut global, KeyModifiers::ALT, KeyCode::Char('s'), KeyAction::SidebarSearch);
 
     KeyBindings {
         profile_name: "Emacs".into(),
@@ -697,6 +702,7 @@ pub fn minimal_profile() -> KeyBindings {
     bind(&mut insert, KeyModifiers::NONE, KeyCode::F(6), KeyAction::DeleteMessage);
     bind(&mut insert, KeyModifiers::NONE, KeyCode::F(7), KeyAction::ForwardMessage);
     bind(&mut insert, KeyModifiers::NONE, KeyCode::F(8), KeyAction::OpenActionMenu);
+    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('s'), KeyAction::SidebarSearch);
 
     KeyBindings {
         profile_name: "Minimal".into(),

--- a/src/snapshots/siggy__ui__snapshot_tests__sidebar_filter.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__sidebar_filter.snap
@@ -1,0 +1,34 @@
+---
+source: src/ui.rs
+expression: output
+---
+ /ali                │╭ Alice ─────────────────────────────────────────────────────────────────────╮
+▸   Alice            ││[08:00] <Alice> Good morning! How's your day going?                         │
+                     ││    👍  1                                                                    │
+                     ││● [08:05] <you> Just getting started, coffee in hand                        │
+                     ││    ❤️  1                                                                    │
+                     ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
+                     ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │
+                     ││[08:20] <Alice> Ha! It gets easier once you build the habit                 │
+                     ││● [08:25] <you> That's what everyone says...                                │
+                     ││[08:30] <Alice> Trust me, after a week it becomes automatic                 │
+                     ││  ╭ <you> Just getting started, coffee in hand                              │
+                     ││[08:35] <Alice> Honestly same, I need my coffee first too                   │
+                     ││✓ [08:40] <you> Are you free this weekend?                                  │
+                     ││[08:42] <Alice> Yeah! What did you have in mind?                            │
+                     ││[08:45] <Alice> There's this farmers market: https://localmarket.example.com│
+                     ││  ├ Downtown Farmers Market                                                 │
+                     ││  ├ Fresh produce, artisan goods, and live music every Saturday…            │
+                     ││  ╰ https://localmarket.example.com                                         │
+                     ││○ [08:47] <you> Oh nice, what time should we go?                            │
+                     ││✓ [08:48] <Alice> Opens at 8, but 9 is fine. Less crowded.                  │
+                     ││○ [08:50] <you> Perfect, let's do 9                                         │
+                     ││○ [08:52] <Alice> I'll pick you up at 8:45                                  │
+                     ││○ [08:55] <you> (edited) Actually make it 8:30, I want to browse early      │
+                     ││[08:57] <Alice> Even better! See you Saturday                               │
+                     ││    🎉  1                                                                    │
+                     │╰────────────────────────────────────────────────────────────────────────────╯
+                     │╭────────────────────────────────────────────────────────────────────────────╮
+                     ││  Type a message...                                                         │
+                     │╰────────────────────────────────────────────────────────────────────────────╯
+ [INSERT] │  ● connected │ Alice │ 7 chats

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -575,8 +575,18 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
     let theme = &app.theme;
     let max_name_width = (area.width as usize).saturating_sub(5); // "• # " + margin
 
-    let items: Vec<ListItem> = app
-        .conversation_order
+    // Use filtered list when sidebar filter is active
+    let display_order: Vec<String> = if app.sidebar_filter_active {
+        if app.sidebar_filter.is_empty() {
+            app.conversation_order.clone()
+        } else {
+            app.sidebar_filtered.clone()
+        }
+    } else {
+        app.conversation_order.clone()
+    };
+
+    let items: Vec<ListItem> = display_order
         .iter()
         .map(|id| {
             let conv = &app.conversations[id];
@@ -645,11 +655,25 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
 
     let border_side = if app.sidebar_on_right { Borders::LEFT } else { Borders::RIGHT };
+    let title = if app.sidebar_filter_active {
+        if app.sidebar_filter.is_empty() {
+            " /_ ".to_string()
+        } else {
+            format!(" /{} ", app.sidebar_filter)
+        }
+    } else {
+        " Chats ".to_string()
+    };
+    let title_style = if app.sidebar_filter_active {
+        Style::default().fg(theme.warning).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
+    };
     let block = Block::default()
         .borders(border_side)
         .border_type(BorderType::Rounded)
-        .title(" Chats ")
-        .title_style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD));
+        .title(title)
+        .title_style(title_style);
     app.mouse_sidebar_inner = Some(block.inner(area));
 
     let sidebar = List::new(items).block(block);
@@ -4230,6 +4254,16 @@ mod snapshot_tests {
         // Dave's conversation has disappearing messages with timer icons
         let mut app = demo_app();
         app.active_conversation = Some("+15550004444".to_string());
+        let output = render_to_string(&mut app, 100, 30);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_sidebar_filter() {
+        let mut app = demo_app();
+        app.sidebar_filter_active = true;
+        app.sidebar_filter = "ali".to_string();
+        app.refresh_sidebar_filter();
         let output = render_to_string(&mut app, 100, 30);
         insta::assert_snapshot!(output);
     }


### PR DESCRIPTION
## Summary
- Press `s` in Normal mode to activate sidebar filter (Alt+s in Emacs, Ctrl+s in Minimal profile)
- Type to filter conversations by name, sidebar title shows `/query` while filtering
- Enter selects the first match, Esc or Backspace-to-empty cancels
- Tab/Shift-Tab conversation switching and mouse clicks clear the filter automatically
- Incoming messages that reorder the sidebar refresh the filtered list

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (385 tests, including new sidebar filter snapshot test)
- [x] Snapshot test verifies filtered sidebar shows only matching conversations
- [ ] CI passes
- [ ] Manual test: activate filter, type partial name, verify list narrows, Enter selects, Esc cancels

closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)