### PR TITLE
Show unread message count per conversation in sidebar

### DIFF
--- a/src/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family         ││    👍  1                                                                    │
-  • Carol            ││● [08:05] <you> Just getting started, coffee in hand                        │
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● [08:05] <you> Just getting started, coffee in hand                        │
     ##Rust Devs      ││    ❤️  1                                                                    │
     Bob              ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
 ▸   Alice            ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__chat_messages.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__chat_messages.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family         ││    👍  1                                                                    │
-  • Carol            ││● [08:05] <you> Just getting started, coffee in hand                        │
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● [08:05] <you> Just getting started, coffee in hand                        │
     ##Rust Devs      ││    ❤️  1                                                                    │
     Bob              ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
 ▸   Alice            ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__disappearing_messages.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__disappearing_messages.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Dave ⏱ 1d ─────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││  Disappearing messages set to 1 day                                        │
-  • ##Family         ││⏱ [08:00] <Dave> Meetup is at the usual place, 7pm                          │
-  • Carol            ││● ⏱ [08:05] <you> Got it, I'll be there                                     │
+  ? +15550007777 (1) ││  Disappearing messages set to 1 day                                        │
+  • ##Family (2)     ││⏱ [08:00] <Dave> Meetup is at the usual place, 7pm                          │
+  • Carol (1)        ││● ⏱ [08:05] <you> Got it, I'll be there                                     │
     ##Rust Devs      ││⏱ [08:06] <Dave> Bring your laptop if you want to hack on stuff             │
     Bob              ││                                                                            │
     Alice            ││                                                                            │

--- a/src/snapshots/siggy__ui__snapshot_tests__empty_conversation.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__empty_conversation.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Empty ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││                                                                            │
-  • ##Family         ││                                                                            │
-  • Carol            ││                                                                            │
+  ? +15550007777 (1) ││                                                                            │
+  • ##Family (2)     ││                                                                            │
+  • Carol (1)        ││                                                                            │
     ##Rust Devs      ││                                                                            │
     Bob              ││                                                                            │
     Alice            ││                                                                            │

--- a/src/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││╭ Help ──────────────────────────────────────────────╮                      │
-  • ##Family         │││  Commands                                          │                      │
-  • Carol            │││  /join <name>        Switch to a conversation      │                      │
+  ? +15550007777 (1) ││╭ Help ──────────────────────────────────────────────╮                      │
+  • ##Family (2)     │││  Commands                                          │                      │
+  • Carol (1)        │││  /join <name>        Switch to a conversation      │                      │
     ##Rust Devs      │││  /part               Leave current conversation    │                      │
     Bob              │││  /attach             Attach a file                 │ run                  │
 ▸   Alice            │││  /search <query>     Search messages               │d before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__insert_mode.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__insert_mode.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: insert_output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family         ││    👍  1                                                                    │
-  • Carol            ││● [08:05] <you> Just getting started, coffee in hand                        │
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● [08:05] <you> Just getting started, coffee in hand                        │
     ##Rust Devs      ││    ❤️  1                                                                    │
     Bob              ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
 ▸   Alice            ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__message_request.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__message_request.snap
@@ -4,8 +4,8 @@ expression: output
 ---
  Chats               │╭ +15550007777 ──────────────────────────────────────────────────────────────╮
 ▸ ? +15550007777     ││[14:00] <+15550007777> Hey, I got your number from the meetup. Is this the  │
-  • ##Family         ││right person?                                                               │
-  • Carol            ││                                                                            │
+  • ##Family (2)     ││right person?                                                               │
+  • Carol (1)        ││                                                                            │
     ##Rust Devs      ││                                                                            │
     Bob              ││                                                                            │
     Alice            ││                                                                            │

--- a/src/snapshots/siggy__ui__snapshot_tests__no_active_conversation.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__no_active_conversation.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ siggy ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││                                                                            │
-  • ##Family         ││  Welcome to siggy                                                          │
-  • Carol            ││                                                                            │
+  ? +15550007777 (1) ││                                                                            │
+  • ##Family (2)     ││  Welcome to siggy                                                          │
+  • Carol (1)        ││                                                                            │
     ##Rust Devs      ││  Getting started                                                           │
     Bob              ││  Tab / Shift+Tab    cycle through conversations                            │
     Alice            ││  /join <contact>    open a conversation by name or number                  │

--- a/src/snapshots/siggy__ui__snapshot_tests__normal_mode.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__normal_mode.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: normal_output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family         ││    👍  1                                                                    │
-  • Carol            ││● [08:05] <you> Just getting started, coffee in hand                        │
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● [08:05] <you> Just getting started, coffee in hand                        │
     ##Rust Devs      ││    ❤️  1                                                                    │
     Bob              ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
 ▸   Alice            ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__pinned_message.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__pinned_message.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ ##Rust Devs ───────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││📌  Alice: Has anyone tried the new async trait syntax?                      │
-  • ##Family         ││[10:30] <Alice> (pinned) Has anyone tried the new async trait syntax?       │
-  • Carol            ││    📌  1                                                                    │
+  ? +15550007777 (1) ││📌  Alice: Has anyone tried the new async trait syntax?                      │
+  • ##Family (2)     ││[10:30] <Alice> (pinned) Has anyone tried the new async trait syntax?       │
+  • Carol (1)        ││    📌  1                                                                    │
 ▸   ##Rust Devs      ││[10:32] <Bob> Yeah, it's so much cleaner than the pin-based approach        │
     Bob              ││[10:35] <Dave> I'm still wrapping my head around it                         │
     Alice            ││● [10:40] <you> The desugaring docs helped me a lot                         │

--- a/src/snapshots/siggy__ui__snapshot_tests__poll.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__poll.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ ##Rust Devs ───────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││📌  Alice: Has anyone tried the new async trait syntax?                      │
-  • ##Family         ││[10:30] <Alice> (pinned) Has anyone tried the new async trait syntax?       │
-  • Carol            ││    📌  1                                                                    │
+  ? +15550007777 (1) ││📌  Alice: Has anyone tried the new async trait syntax?                      │
+  • ##Family (2)     ││[10:30] <Alice> (pinned) Has anyone tried the new async trait syntax?       │
+  • Carol (1)        ││    📌  1                                                                    │
 ▸   ##Rust Devs      ││[10:32] <Bob> Yeah, it's so much cleaner than the pin-based approach        │
     Bob              ││[10:35] <Dave> I'm still wrapping my head around it                         │
     Alice            ││● [10:40] <you> The desugaring docs helped me a lot                         │

--- a/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family         ││    👍  1                                                                    │
-  • Carol            ││● ╭ Settings ──────────────────────────────────────╮                        │
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● ╭ Settings ──────────────────────────────────────╮                        │
     ##Rust Devs      ││  │  [x] Direct message notifications              │                        │
     Bob              ││[0│  [x] Group message notifications               │ a run                  │
 ▸   Alice            ││● │  [ ] Desktop notifications                     │bed before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__sidebar_layout.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__sidebar_layout.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family         ││    👍  1                                                                    │
-  • Carol            ││● [08:05] <you> Just getting started, coffee in hand                        │
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● [08:05] <you> Just getting started, coffee in hand                        │
     ##Rust Devs      ││    ❤️  1                                                                    │
     Bob              ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
 ▸   Alice            ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │

--- a/src/snapshots/siggy__ui__snapshot_tests__styled_text.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__styled_text.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ Bob ───────────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[10:05] <Bob> Can you review my PR? It's the auth refactor                  │
-  • ##Family         ││[10:08] <Bob> The key change is in verify_token() — switched from HMAC to   │
-  • Carol            ││Ed25519                                                                     │
+  ? +15550007777 (1) ││[10:05] <Bob> Can you review my PR? It's the auth refactor                  │
+  • ##Family (2)     ││[10:08] <Bob> The key change is in verify_token() — switched from HMAC to   │
+  • Carol (1)        ││Ed25519                                                                     │
     ##Rust Devs      ││● [10:12] <you> Looks good! Left a few comments on the error handling       │
 ▸   Bob              ││[10:15] <Bob> Thanks! I'll address those. Also the migration is             │
     Alice            ││backwards-compatible so no rush on deploy                                   │

--- a/src/snapshots/siggy__ui__snapshot_tests__unread_marker.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__unread_marker.snap
@@ -3,9 +3,9 @@ source: src/ui.rs
 expression: output
 ---
  Chats               │╭ ##Family ──────────────────────────────────────────────────────────────────╮
-  ? +15550007777     ││[12:00] <Mom> Dinner at our place Sunday?                                   │
+  ? +15550007777 (1) ││[12:00] <Mom> Dinner at our place Sunday?                                   │
 ▸   ##Family         ││[12:05] <Dad> I'll fire up the grill                                        │
-  • Carol            ││● [12:10] <you> Count me in!                                                │
+  • Carol (1)        ││● [12:10] <you> Count me in!                                                │
     ##Rust Devs      ││    ❤️  2                                                                    │
     Bob              ││─────────────────────────────── new messages ───────────────────────────────│
     Alice            ││[13:30] <Mom> Great! Bring dessert if you can                               │

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -643,6 +643,13 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
             };
             spans.push(Span::styled(name, name_style));
 
+            if has_unread && !is_active {
+                spans.push(Span::styled(
+                    format!(" ({})", conv.unread),
+                    Style::default().fg(theme.warning),
+                ));
+            }
+
             if is_muted {
                 spans.push(Span::styled(" ~", Style::default().fg(theme.fg_muted)));
             }


### PR DESCRIPTION
## Summary
- Display unread count as `(N)` after the conversation name in the sidebar
- Uses the existing warning color, shown alongside the unread dot indicator
- Only visible when conversation has unreads and is not the active conversation

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (385 tests)
- [x] Snapshot tests updated - Carol shows `(1)`, #Family shows `(2)`, Eve shows `(1)`
- [ ] CI passes

closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)