### PR TITLE
Add jump to quoted message and jump-back navigation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -441,6 +441,8 @@ pub struct App {
     pub focused_message_time: Option<DateTime<Utc>>,
     /// Index of the focused message in the active conversation (set during draw)
     pub focused_msg_index: Option<usize>,
+    /// Jump-back stack: saved (scroll_offset, focused_msg_index) before quote jumps
+    pub jump_stack: Vec<(usize, Option<usize>)>,
     /// Reaction picker overlay visible
     pub show_reaction_picker: bool,
     /// Selected index in the reaction picker
@@ -2440,6 +2442,49 @@ impl App {
         }
     }
 
+    /// Jump to the original message quoted by the currently focused message.
+    fn jump_to_quote(&mut self) {
+        let msg = match self.selected_message() {
+            Some(m) => m,
+            None => return,
+        };
+        let quote_ts = match &msg.quote {
+            Some(q) => q.timestamp_ms,
+            None => {
+                self.status_message = "No quote on this message".to_string();
+                return;
+            }
+        };
+
+        // Save current position for jump-back
+        self.jump_stack.push((self.scroll_offset, self.focused_msg_index));
+
+        // Try to find the quoted message
+        let conv_id = match self.active_conversation.as_ref() {
+            Some(id) => id.clone(),
+            None => return,
+        };
+        let found = self.conversations.get(&conv_id)
+            .and_then(|c| c.find_msg_idx(quote_ts))
+            .is_some();
+
+        if found {
+            self.jump_to_message_timestamp(quote_ts);
+        } else {
+            // Pop the saved position since we didn't actually jump
+            self.jump_stack.pop();
+            self.status_message = "Quoted message not in loaded history".to_string();
+        }
+    }
+
+    /// Jump back to the position before the last quote jump.
+    fn jump_back(&mut self) {
+        if let Some((offset, index)) = self.jump_stack.pop() {
+            self.scroll_offset = offset;
+            self.focused_msg_index = index;
+        }
+    }
+
     /// Jump to the next/previous search result in the active conversation.
     fn jump_to_search_result(&mut self, forward: bool) {
         let active = self.active_conversation.as_deref();
@@ -2610,6 +2655,7 @@ impl App {
             pending_receipts: Vec::new(),
             focused_message_time: None,
             focused_msg_index: None,
+            jump_stack: Vec::new(),
             show_reaction_picker: false,
             reaction_picker_index: 0,
             reaction_verbose: false,
@@ -3350,6 +3396,8 @@ impl App {
                 None
             }
             Some(KeyAction::PinMessage) => self.execute_pin_toggle(),
+            Some(KeyAction::JumpToQuote) => { self.jump_to_quote(); None }
+            Some(KeyAction::JumpBack) => { self.jump_back(); None }
             _ => None,
         }
     }
@@ -3495,6 +3543,8 @@ impl App {
                 None
             }
             Some(KeyAction::PinMessage) => self.execute_pin_toggle(),
+            Some(KeyAction::JumpToQuote) => { self.jump_to_quote(); None }
+            Some(KeyAction::JumpBack) => { self.jump_back(); None }
             _ => {
                 let needs_ac_update = matches!(
                     code,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -55,6 +55,8 @@ pub enum KeyAction {
     PrevSearchResult,
     OpenActionMenu,
     PinMessage,
+    JumpToQuote,
+    JumpBack,
     SidebarSearch,
     // Insert
     ExitInsert,
@@ -470,6 +472,8 @@ pub const NORMAL_ACTIONS: &[KeyAction] = &[
     KeyAction::PrevSearchResult,
     KeyAction::OpenActionMenu,
     KeyAction::PinMessage,
+    KeyAction::JumpToQuote,
+    KeyAction::JumpBack,
     KeyAction::SidebarSearch,
 ];
 
@@ -524,6 +528,8 @@ pub fn action_label(action: KeyAction) -> &'static str {
         KeyAction::PrevSearchResult => "Previous search match",
         KeyAction::OpenActionMenu => "Action menu",
         KeyAction::PinMessage => "Pin/unpin message",
+        KeyAction::JumpToQuote => "Jump to quoted message",
+        KeyAction::JumpBack => "Jump back",
         KeyAction::SidebarSearch => "Filter sidebar",
         KeyAction::ExitInsert => "Normal mode",
         KeyAction::SendMessage => "Send message",
@@ -594,6 +600,8 @@ pub fn default_profile() -> KeyBindings {
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('N'), KeyAction::PrevSearchResult);
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Enter, KeyAction::OpenActionMenu);
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('p'), KeyAction::PinMessage);
+    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('Q'), KeyAction::JumpToQuote);
+    bind(&mut normal, KeyModifiers::CONTROL, KeyCode::Char('o'), KeyAction::JumpBack);
     bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('s'), KeyAction::SidebarSearch);
 
     // --- Insert ---
@@ -656,6 +664,8 @@ pub fn emacs_profile() -> KeyBindings {
     bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('n'), KeyAction::NextSearchResult);
     bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('p'), KeyAction::PrevSearchResult);
     bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('m'), KeyAction::OpenActionMenu);
+    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('Q'), KeyAction::JumpToQuote);
+    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('o'), KeyAction::JumpBack);
     bind(&mut global, KeyModifiers::ALT, KeyCode::Char('s'), KeyAction::SidebarSearch);
 
     KeyBindings {
@@ -702,6 +712,8 @@ pub fn minimal_profile() -> KeyBindings {
     bind(&mut insert, KeyModifiers::NONE, KeyCode::F(6), KeyAction::DeleteMessage);
     bind(&mut insert, KeyModifiers::NONE, KeyCode::F(7), KeyAction::ForwardMessage);
     bind(&mut insert, KeyModifiers::NONE, KeyCode::F(8), KeyAction::OpenActionMenu);
+    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(9), KeyAction::JumpToQuote);
+    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(10), KeyAction::JumpBack);
     bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('s'), KeyAction::SidebarSearch);
 
     KeyBindings {


### PR DESCRIPTION
## Summary
- Press `Q` in Normal mode on a message with a quote to jump to the original quoted message
- Press `Ctrl+O` to jump back (stack-based, supports multiple jumps)
- Shows status message if the quoted message is not in loaded history
- Bindings: Default `Q`/`Ctrl+O`, Emacs `Alt+Shift+Q`/`Ctrl+O`, Minimal `F9`/`F10`

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (385 tests)
- [ ] CI passes
- [ ] Manual test: focus a quoted reply, press Q, verify viewport jumps to original, Ctrl+O returns

closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)