### PR TITLE
Add toggle to hide reactions entirely

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -447,6 +447,8 @@ pub struct App {
     pub show_reaction_picker: bool,
     /// Selected index in the reaction picker
     pub reaction_picker_index: usize,
+    /// Show emoji reactions on messages
+    pub show_reactions: bool,
     /// Show verbose reaction display (usernames instead of counts)
     pub reaction_verbose: bool,
     /// Groups indexed by group_id (with member lists for @mention autocomplete).
@@ -861,6 +863,14 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.nerd_fonts,
         set: |a, v| a.nerd_fonts = v,
         save: Some(|c, v| c.nerd_fonts = v),
+        on_toggle: None,
+    },
+    SettingDef {
+        label: "Show reactions",
+        hint: "Show emoji reactions on messages",
+        get: |a| a.show_reactions,
+        set: |a, v| a.show_reactions = v,
+        save: Some(|c, v| c.show_reactions = v),
         on_toggle: None,
     },
     SettingDef {
@@ -2673,6 +2683,7 @@ impl App {
             jump_stack: Vec::new(),
             show_reaction_picker: false,
             reaction_picker_index: 0,
+            show_reactions: true,
             reaction_verbose: false,
             groups: HashMap::new(),
             uuid_to_name: HashMap::new(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,10 @@ pub struct Config {
     #[serde(default)]
     pub nerd_fonts: bool,
 
+    /// Show emoji reactions on messages
+    #[serde(default = "default_true")]
+    pub show_reactions: bool,
+
     /// Show verbose reaction display (usernames instead of counts)
     #[serde(default)]
     pub reaction_verbose: bool,
@@ -149,6 +153,7 @@ impl Default for Config {
             show_receipts: true,
             color_receipts: true,
             nerd_fonts: false,
+            show_reactions: true,
             reaction_verbose: false,
             send_read_receipts: true,
             mouse_enabled: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -883,6 +883,7 @@ async fn run_app(
     app.show_receipts = config.show_receipts;
     app.color_receipts = config.color_receipts;
     app.nerd_fonts = config.nerd_fonts;
+    app.show_reactions = config.show_reactions;
     app.reaction_verbose = config.reaction_verbose;
     app.send_read_receipts = config.send_read_receipts;
     app.mouse_enabled = config.mouse_enabled;

--- a/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
@@ -17,16 +17,16 @@ expression: output
                      ││✓ │  [x] Read receipts                             │                        │
                      ││[0│  [x] Receipt colors                            │                        │
                      ││[0│  [ ] Nerd Font icons                           │/localmarket.example.com│
-                     ││  │  [ ] Verbose reactions                         │                        │
-                     ││  │  [x] Send read receipts                        │ry Saturday…            │
-                     ││  │  [x] Mouse support                             │                        │
-                     ││○ │  [ ] Sidebar on right                          │                        │
-                     ││✓ │  Notification preview: full                    │owded.                  │
+                     ││  │  [x] Show reactions                            │                        │
+                     ││  │  [ ] Verbose reactions                         │ry Saturday…            │
+                     ││  │  [x] Send read receipts                        │                        │
+                     ││○ │  [x] Mouse support                             │                        │
+                     ││✓ │  [ ] Sidebar on right                          │owded.                  │
+                     ││○ │  Notification preview: full                    │                        │
                      ││○ │  Theme: Default                                │                        │
-                     ││○ │  Keybindings: Default                          │                        │
-                     ││○ │  Profile: Default                              │nt to browse early      │
-                     ││[0│                                                │                        │
-                     ││  │  Play a sound for incoming direct messages     │                        │
+                     ││○ │  Keybindings: Default                          │nt to browse early      │
+                     ││[0│  Profile: Default                              │                        │
+                     ││  │                                                │                        │
                      │╰──╰────────────────────────────────────────────────╯────────────────────────╯
                      │╭────────────────────────────────────────────────────────────────────────────╮
                      ││  Type a message...                                                         │

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1077,8 +1077,8 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
             }
 
-            // Render reaction summary line (skip for deleted)
-            if !msg.is_deleted && !msg.reactions.is_empty() {
+            // Render reaction summary line (skip for deleted or when reactions hidden)
+            if app.show_reactions && !msg.is_deleted && !msg.reactions.is_empty() {
                 lines.push(build_reaction_summary(&msg.reactions, app.reaction_verbose, theme));
                 line_msg_idx.push(Some(msg_index));
             }


### PR DESCRIPTION
## Summary
- New `show_reactions` setting (default: true) in `/settings`
- When disabled, reaction summary lines are not rendered below messages
- Reaction picker (`r` key) still works - this only affects display
- Persisted to config.toml

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (385 tests)
- [x] Settings overlay snapshot updated with new "Show reactions" row
- [ ] CI passes

closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)