### PR TITLE
Eliminate redundant JVM spawn on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -257,30 +257,6 @@ async fn run_main_flow(
         db::Database::open(&db_path)?
     };
 
-    // Quick pre-flight: check if account is registered (skip if wizard already handled it)
-    if !setup_handled_linking {
-        match link::check_account_registered(config).await {
-            Ok(false) => {
-                // Not registered — run linking flow
-                match link::run_linking_flow(terminal, config).await {
-                    Ok(link::LinkResult::Success) => {}
-                    Ok(link::LinkResult::Cancelled) => {
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        let msg = format!("{e}");
-                        show_error_screen(terminal, "Device Linking Failed", &msg).await?;
-                        return Ok(());
-                    }
-                }
-            }
-            Ok(true) => {} // Good to go
-            Err(e) => {
-                debug_log::logf(format_args!("check_account_registered failed: {e}"));
-            }
-        }
-    }
-
     // In incognito mode, redirect attachments to a temp directory
     let incognito_tmp_dir = if incognito {
         let tmp = std::env::temp_dir().join(format!("siggy-incognito-{}", std::process::id()));
@@ -292,9 +268,10 @@ async fn run_main_flow(
         None
     };
 
-    // Spawn signal-cli backend
-    let signal_result = SignalClient::spawn(config).await;
-    let mut signal_client = match signal_result {
+    // Spawn signal-cli backend directly (skip the old pre-flight check that spawned
+    // a throwaway JVM process). If the account isn't registered, signal-cli will exit
+    // quickly and we fall back to the linking flow.
+    let mut signal_client = match SignalClient::spawn(config).await {
         Ok(client) => client,
         Err(e) => {
             let msg = format!("{e}");
@@ -302,6 +279,42 @@ async fn run_main_flow(
             return Ok(());
         }
     };
+
+    // Give signal-cli a brief window to fail if the account is unregistered.
+    // If the process exits early, check stderr and fall back to linking.
+    if !setup_handled_linking
+        && !signal_client
+            .wait_for_ready(std::time::Duration::from_millis(500))
+            .await
+    {
+        let stderr = signal_client.stderr_output();
+        debug_log::logf(format_args!(
+            "signal-cli exited early during startup, stderr: {stderr}"
+        ));
+        signal_client.shutdown().await?;
+
+        match link::run_linking_flow(terminal, config).await {
+            Ok(link::LinkResult::Success) => {}
+            Ok(link::LinkResult::Cancelled) => {
+                return Ok(());
+            }
+            Err(e) => {
+                let msg = format!("{e}");
+                show_error_screen(terminal, "Device Linking Failed", &msg).await?;
+                return Ok(());
+            }
+        }
+
+        // Re-spawn after successful linking
+        signal_client = match SignalClient::spawn(config).await {
+            Ok(client) => client,
+            Err(e) => {
+                let msg = format!("{e}");
+                show_error_screen(terminal, "Failed to Start signal-cli", &msg).await?;
+                return Ok(());
+            }
+        };
+    }
 
     // Run the app
     let result = run_app(terminal, MessagingBackend::Signal(&mut signal_client), config, database, incognito).await;

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -1102,6 +1102,20 @@ impl SignalClient {
         }
     }
 
+    /// Wait up to `timeout` for signal-cli to either stay alive (ready) or exit early
+    /// (likely unregistered). Returns `true` if the process is still running, `false`
+    /// if it exited during the window.
+    pub async fn wait_for_ready(&mut self, timeout: Duration) -> bool {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if self.try_child_exit().is_some() {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        true
+    }
+
     pub async fn shutdown(&mut self) -> Result<()> {
         let _ = self.child.kill().await;
         Ok(())


### PR DESCRIPTION
## Summary
- Removes the throwaway `signal-cli listContacts` pre-flight check that spawned a separate JVM process on every startup (~2-3s of Java startup time)
- Instead, spawns the real JSON-RPC session immediately and uses a new `wait_for_ready()` helper to detect if signal-cli exits within 500ms (indicating an unregistered account)
- If early exit is detected, falls back to the linking flow and re-spawns afterward

Closes #268

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Manual test with registered account: startup should be ~2-3s faster (no extra JVM spawn)
- [ ] Manual test with unregistered account: linking flow should still trigger correctly
- [ ] Manual test: kill signal-cli during startup - should show error screen, not hang


🤖 Generated with [Claude Code](https://claude.com/claude-code)