### PR TITLE
Add Sixel image protocol support for Windows Terminal (closes #272)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,10 +293,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -424,6 +456,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -729,6 +780,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,6 +876,12 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -1036,6 +1099,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +1273,12 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -1409,6 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1528,6 +1608,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4779c6901a562440c3786d08192c6fbda7c1c2060edd10006b05ee35d10f2d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1624,30 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "bytemuck",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1657,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1800,6 +1913,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.1.0",
+ "palette",
+ "rand 0.9.2",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1830,12 +1963,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1843,6 +1991,21 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "ratatui"
@@ -1930,6 +2093,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,6 +2130,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2073,6 +2276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,6 +2387,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "emojis",
+ "icy_sixel",
  "image",
  "insta",
  "notify-rust",
@@ -2329,6 +2542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,7 +2614,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -2859,7 +3078,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -2887,6 +3106,16 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]
@@ -3319,6 +3548,15 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ open = "5"
 notify-rust = "4"
 
 emojis = "0.8"
+icy_sixel = "0.5"
 
 [dev-dependencies]
 insta = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -121,6 +121,10 @@ pub struct ImageRenderResult {
     pub is_preview: bool,
     pub lines: Option<Vec<Line<'static>>>,
     pub image_path: Option<String>,
+    /// Pre-encoded PNG for native_image_cache: (path, base64, pixel_w, pixel_h)
+    pub pre_native_png: Option<(String, String, u32, u32)>,
+    /// Pre-encoded full Sixel for sixel_cache: (path, sixel_string)
+    pub pre_sixel: Option<(String, String)>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -392,22 +396,25 @@ pub struct App {
     pub identity_trust: HashMap<String, TrustLevel>,
     /// Confirmation pending for verify action (user must press v twice)
     pub verify_confirming: bool,
-    /// Show inline halfblock image previews in chat
-    pub inline_images: bool,
+    /// Image display mode: "native", "halfblock", or "none"
+    pub image_mode: String,
     /// Show link previews (title, description, thumbnail) for URLs
     pub show_link_previews: bool,
     /// Link regions detected in the last rendered frame (for OSC 8 injection)
     pub link_regions: Vec<crate::ui::LinkRegion>,
     /// Maps display text → hidden URL for attachment links (cleared each frame)
     pub link_url_map: HashMap<String, String>,
-    /// Detected terminal image protocol (Kitty, iTerm2, or Halfblock)
+    /// Detected terminal image protocol (Kitty, iTerm2, Sixel, or Halfblock)
     pub image_protocol: ImageProtocol,
+    /// Cell pixel dimensions (width, height) for Sixel encoding
+    pub cell_px: (u16, u16),
     /// Images visible on screen for native protocol overlay (cleared each frame)
     pub visible_images: Vec<VisibleImage>,
+    /// Previous scroll offset for Sixel stale pixel detection.
+    /// When scroll changes with Sixel visible, force full redraw to clear stale pixels.
+    pub sixel_prev_scroll: usize,
     /// Previous frame's visible images, for skipping redundant image redraws
     pub prev_visible_images: Vec<VisibleImage>,
-    /// Experimental: use native terminal image protocols (Kitty/iTerm2) instead of halfblock
-    pub native_images: bool,
     /// Cache of pre-resized PNGs for native protocol (path → (base64, pixel_w, pixel_h)).
     /// Populated: on-demand during native image rendering (get_or_cache_png in main.rs).
     /// Invalidation: cleared on terminal resize (clear_kitty_state). Persists across
@@ -609,6 +616,10 @@ pub struct App {
     /// Populated on-demand during iTerm2 rendering. Grows unbounded during session.
     /// Cleared on terminal resize (clear_kitty_state). Persists across conversation switches.
     pub iterm2_crop_cache: HashMap<(String, u16, u16), String>,
+    /// Cache of full Sixel-encoded images: path -> sixel_string.
+    /// Populated by pre-cache in ensure_active_images. Cleared on resize.
+    /// Partial crops are obtained instantly via `slice_sixel_bands()`.
+    pub sixel_cache: HashMap<String, String>,
     /// Current settings profile name
     pub settings_profile_name: String,
     /// Settings profile manager overlay visible
@@ -813,28 +824,12 @@ pub const SETTINGS: &[SettingDef] = &[
         on_toggle: None,
     },
     SettingDef {
-        label: "Inline image previews",
-        hint: "Render image attachments as previews in chat",
-        get: |a| a.inline_images,
-        set: |a, v| a.inline_images = v,
-        save: Some(|c, v| c.inline_images = v),
-        on_toggle: None, // UI checks the flag; cached lines stay in memory
-    },
-    SettingDef {
         label: "Link previews",
         hint: "Show title and thumbnail for URLs",
         get: |a| a.show_link_previews,
         set: |a, v| a.show_link_previews = v,
         save: Some(|c, v| c.show_link_previews = v),
         on_toggle: None, // UI checks the flag; cached lines stay in memory
-    },
-    SettingDef {
-        label: "Native images (experimental)",
-        hint: "Requires Kitty, Ghostty, WezTerm, or iTerm2",
-        get: |a| a.native_images,
-        set: |a, v| a.native_images = v,
-        save: Some(|c, v| c.native_images = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Date separators",
@@ -944,6 +939,7 @@ impl App {
         config.keybinding_profile = self.keybindings.profile_name.clone();
         config.settings_profile = self.settings_profile_name.clone();
         config.notification_preview = self.notification_preview.clone();
+        config.image_mode = self.image_mode.clone();
         for def in SETTINGS {
             if let Some(save_fn) = def.save {
                 save_fn(&mut config, (def.get)(self));
@@ -957,7 +953,7 @@ impl App {
         keybindings::save_overrides(&overrides);
     }
 
-    // Image lines are always cached in memory; the UI checks inline_images/show_link_previews
+    // Image lines are always cached in memory; the UI checks image_mode/show_link_previews
     // before displaying them. No refresh needed on toggle — it's just a visibility flag now.
 
     /// Drain completed background image renders and spawn new ones for the viewport.
@@ -984,12 +980,19 @@ impl App {
                         conv.messages[idx].image_lines =
                             Some(result.lines.unwrap_or_default());
                     }
+                    // Pre-populate native image caches from background task
+                    if let Some((path, b64, pw, ph)) = result.pre_native_png {
+                        self.native_image_cache.entry(path).or_insert((b64, pw, ph));
+                    }
+                    if let Some((path, sixel)) = result.pre_sixel {
+                        self.sixel_cache.entry(path).or_insert(sixel);
+                    }
                     drained = true;
                 }
             }
         }
 
-        if !self.inline_images {
+        if self.image_mode == "none" {
             return drained;
         }
         let Some(ref id) = self.active_conversation else { return drained };
@@ -1029,6 +1032,9 @@ impl App {
         }
 
         // Spawn background render tasks
+        let native_sixel = self.image_mode == "native"
+            && self.image_protocol == image_render::ImageProtocol::Sixel;
+        let cell_px = self.cell_px;
         for (ts, path, max_width, is_preview) in work {
             self.image_render_in_flight
                 .insert((id.clone(), ts, is_preview));
@@ -1036,12 +1042,43 @@ impl App {
             let cid = id.clone();
             tokio::task::spawn_blocking(move || {
                 let lines = image_render::render_image(Path::new(&path), max_width);
+
+                // Pre-encode PNG + full Sixel alongside halfblock so caches are
+                // populated before the image first appears in the viewport.
+                let (pre_native_png, pre_sixel) = if native_sixel {
+                    let cell_w = lines.as_ref()
+                        .and_then(|l| l.first())
+                        .map(|l| l.width().saturating_sub(2) as u32)
+                        .unwrap_or(0);
+                    let cell_h = lines.as_ref().map(|l| l.len() as u32).unwrap_or(0);
+                    if cell_w > 0 && cell_h > 0 {
+                        let png = image_render::encode_native_png(
+                            Path::new(&path), cell_w, cell_h,
+                        );
+                        let sixel = png.as_ref().and_then(|p| {
+                            image_render::encode_sixel(
+                                &p.0,
+                                cell_w as u16, cell_h as u16, cell_px,
+                            )
+                        });
+                        let pre_png = png.map(|(b64, pw, ph)| (path.clone(), b64, pw, ph));
+                        let pre_six = sixel.map(|s| (path.clone(), s));
+                        (pre_png, pre_six)
+                    } else {
+                        (None, None)
+                    }
+                } else {
+                    (None, None)
+                };
+
                 let _ = tx.send(ImageRenderResult {
                     conv_id: cid,
                     timestamp_ms: ts,
                     is_preview,
                     lines,
                     image_path: if is_preview { Some(path) } else { None },
+                    pre_native_png,
+                    pre_sixel,
                 });
             });
         }
@@ -1050,12 +1087,13 @@ impl App {
     }
 
     /// Handle a key press while the settings overlay is open.
-    /// After toggles: Preview at SETTINGS.len(), Theme at +1, Keybindings at +2, Profile at +3.
+    /// After toggles: Preview at SETTINGS.len(), Image mode at +1, Theme at +2, Keybindings at +3, Profile at +4.
     pub fn handle_settings_key(&mut self, code: KeyCode) {
         let preview_index = SETTINGS.len();
-        let theme_index = SETTINGS.len() + 1;
-        let kb_index = SETTINGS.len() + 2;
-        let profile_index = SETTINGS.len() + 3;
+        let image_mode_index = SETTINGS.len() + 1;
+        let theme_index = SETTINGS.len() + 2;
+        let kb_index = SETTINGS.len() + 3;
+        let profile_index = SETTINGS.len() + 4;
         let max_index = profile_index;
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
@@ -1078,6 +1116,12 @@ impl App {
                         "full" => "sender".to_string(),
                         "sender" => "minimal".to_string(),
                         _ => "full".to_string(),
+                    };
+                } else if self.settings_index == image_mode_index {
+                    self.image_mode = match self.image_mode.as_str() {
+                        "native" => "halfblock".to_string(),
+                        "halfblock" => "none".to_string(),
+                        _ => "native".to_string(),
                     };
                 } else if self.settings_index == theme_index {
                     self.show_settings = false;
@@ -2670,14 +2714,15 @@ impl App {
             verify_identities: Vec::new(),
             identity_trust: HashMap::new(),
             verify_confirming: false,
-            inline_images: true,
+            image_mode: "halfblock".to_string(),
             show_link_previews: true,
             link_regions: Vec::new(),
             link_url_map: HashMap::new(),
             image_protocol: image_render::detect_protocol(),
+            cell_px: image_render::detect_cell_pixel_size(),
             visible_images: Vec::new(),
             prev_visible_images: Vec::new(),
-            native_images: false,
+            sixel_prev_scroll: 0,
             native_image_cache: HashMap::new(),
             prev_active_conversation: None,
             incognito: false,
@@ -2779,6 +2824,7 @@ impl App {
             kitty_transmitted: HashSet::new(),
             kitty_pending_transmits: Vec::new(),
             iterm2_crop_cache: HashMap::new(),
+            sixel_cache: HashMap::new(),
             settings_profile_name: "Default".to_string(),
             show_settings_profile_manager: false,
             settings_profile_manager_index: 0,
@@ -3087,9 +3133,9 @@ impl App {
     }
 
     /// Clear terminal image placement state so images are retransmitted on the next frame.
-    /// The expensive base64 caches (native_image_cache, iterm2_crop_cache) are preserved
-    /// so switching back to a conversation doesn't re-decode images from disk.
-    /// Call on conversation switch.
+    /// The expensive caches (native_image_cache, iterm2_crop_cache,
+    /// sixel_cache) are preserved so switching back to a conversation doesn't
+    /// re-decode images from disk. Call on conversation switch.
     pub fn clear_kitty_placements(&mut self) {
         self.kitty_transmitted.clear();
         self.kitty_pending_transmits.clear();
@@ -3097,10 +3143,16 @@ impl App {
 
     /// Full image state reset: clear both terminal placements and base64 caches.
     /// Call on terminal resize (cell dimensions change, so cached PNGs need re-encoding).
+    ///
+    /// Sixel caches survive resize: encoding depends on cell_px (from config,
+    /// not terminal size) and halfblock dimensions (fixed at max_width=40).
+    /// Only screen positions change, which ratatui recomputes automatically.
     pub fn clear_kitty_state(&mut self) {
         self.clear_kitty_placements();
-        self.native_image_cache.clear();
-        self.iterm2_crop_cache.clear();
+        if self.image_protocol != ImageProtocol::Sixel {
+            self.native_image_cache.clear();
+            self.iterm2_crop_cache.clear();
+        }
     }
 
     /// Reset typing state and queue a stop request if we were typing.
@@ -3935,7 +3987,7 @@ impl App {
                 if let Some(dm) = conv.messages.iter_mut().rev()
                     .find(|m| m.timestamp_ms == msg_ts_ms && !m.body.starts_with('['))
                 {
-                    let (img_lines, img_path) = if self.show_link_previews && self.inline_images {
+                    let (img_lines, img_path) = if self.show_link_previews && self.image_mode != "none" {
                         if let Some(ref p) = preview.image_path {
                             (image_render::render_image(Path::new(p), 30), Some(p.clone()))
                         } else {
@@ -5271,7 +5323,7 @@ impl App {
                         let is_image = matches!(ext.as_str(), "png" | "jpg" | "jpeg" | "gif" | "webp");
                         let prefix = if is_image { "image" } else { "attachment" };
                         let body = if text.is_empty() { format!("[{prefix}: {fname}]") } else { format!("[{prefix}: {fname}] {text}") };
-                        let (img_lines, img_path) = if is_image && self.inline_images {
+                        let (img_lines, img_path) = if is_image && self.image_mode != "none" {
                             (image_render::render_image(path, 40), Some(path.to_string_lossy().into_owned()))
                         } else {
                             (None, None)

--- a/src/config.rs
+++ b/src/config.rs
@@ -36,16 +36,28 @@ pub struct Config {
     #[serde(default = "default_clipboard_clear_seconds")]
     pub clipboard_clear_seconds: u64,
 
-    /// Show inline halfblock image previews in chat
-    #[serde(default = "default_true")]
+    /// Image display mode: "native" (terminal protocol), "halfblock", or "none"
+    #[serde(default)]
+    pub image_mode: String,
+
+    /// Override cell pixel width for Sixel sizing (0 = auto-detect)
+    #[serde(default)]
+    pub cell_pixel_width: u16,
+
+    /// Override cell pixel height for Sixel sizing (0 = auto-detect)
+    #[serde(default)]
+    pub cell_pixel_height: u16,
+
+    /// Legacy: show inline halfblock image previews (migrated to image_mode)
+    #[serde(default = "default_true", skip_serializing)]
     pub inline_images: bool,
 
     /// Show link previews (title, description, thumbnail) for URLs in messages
     #[serde(default = "default_true")]
     pub show_link_previews: bool,
 
-    /// Experimental: use native terminal image protocols (Kitty/iTerm2) over halfblock
-    #[serde(default)]
+    /// Legacy: use native terminal image protocols (migrated to image_mode)
+    #[serde(default, skip_serializing)]
     pub native_images: bool,
 
     /// Show date separator lines between messages from different days
@@ -150,6 +162,9 @@ impl Default for Config {
             desktop_notifications: false,
             notification_preview: default_notification_preview(),
             clipboard_clear_seconds: default_clipboard_clear_seconds(),
+            image_mode: "halfblock".to_string(),
+            cell_pixel_width: 0,
+            cell_pixel_height: 0,
             inline_images: true,
             show_link_previews: true,
             native_images: false,
@@ -197,8 +212,18 @@ impl Config {
         if config_path.exists() {
             let contents = std::fs::read_to_string(&config_path)
                 .with_context(|| format!("Failed to read config from {}", config_path.display()))?;
-            let config: Config = toml::from_str(&contents)
+            let mut config: Config = toml::from_str(&contents)
                 .with_context(|| format!("Failed to parse config from {}", config_path.display()))?;
+            // Migrate legacy inline_images/native_images to image_mode
+            if config.image_mode.is_empty() {
+                config.image_mode = if config.native_images {
+                    "native".to_string()
+                } else if config.inline_images {
+                    "halfblock".to_string()
+                } else {
+                    "none".to_string()
+                };
+            }
             Ok(config)
         } else {
             Ok(Config::default())

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -14,6 +14,8 @@ pub enum ImageProtocol {
     Kitty,
     /// iTerm2 Inline Images Protocol (iTerm2, WezTerm)
     Iterm2,
+    /// Sixel (Windows Terminal, foot, mlterm, xterm)
+    Sixel,
     /// Unicode halfblock fallback (universal)
     Halfblock,
 }
@@ -29,6 +31,9 @@ pub fn detect_protocol() -> ImageProtocol {
             "iTerm.app" | "WezTerm" => return ImageProtocol::Iterm2,
             _ => {}
         }
+    }
+    if std::env::var("WT_SESSION").is_ok() {
+        return ImageProtocol::Sixel;
     }
     ImageProtocol::Halfblock
 }
@@ -68,6 +73,186 @@ pub fn encode_native_png(path: &Path, cell_width: u32, cell_height: u32) -> Opti
     Some((base64::engine::general_purpose::STANDARD.encode(buf.into_inner()), new_w, new_h))
 }
 
+
+/// Detect the pixel dimensions of a single terminal cell.
+///
+/// Tries `crossterm::terminal::window_size()` (pixel dimensions ÷ cell grid).
+/// Falls back to a platform-specific default: 10×20 for Windows Terminal
+/// (typical Cascadia Code at default DPI), 8×16 elsewhere.
+pub fn detect_cell_pixel_size() -> (u16, u16) {
+    if let Ok(ws) = crossterm::terminal::window_size() {
+        if ws.width > 0 && ws.height > 0 && ws.columns > 0 && ws.rows > 0 {
+            return (ws.width / ws.columns, ws.height / ws.rows);
+        }
+    }
+    if std::env::var("WT_SESSION").is_ok() {
+        (10, 20) // Windows Terminal with Cascadia Code at typical DPI
+    } else {
+        (8, 16)
+    }
+}
+
+/// Encode a pre-sized image as a Sixel DCS string (CPU-bound).
+///
+/// Decodes the base64 PNG, resizes to fill the target cell area, and
+/// Sixel-encodes.  Designed to run on a blocking thread via `spawn_blocking`.
+pub fn encode_sixel(
+    b64_png: &str,
+    width_cells: u16,
+    height_cells: u16,
+    cell_px: (u16, u16),
+) -> Option<String> {
+    use base64::Engine;
+    let bytes = base64::engine::general_purpose::STANDARD.decode(b64_png).ok()?;
+    let img = image::load_from_memory(&bytes).ok()?;
+    let (w, h) = img.dimensions();
+    if w == 0 || h == 0 {
+        return None;
+    }
+
+    let target_w = (width_cells as u32 * cell_px.0 as u32).max(1);
+    let target_h = (height_cells as u32 * cell_px.1 as u32).max(1);
+
+    let scale = f64::min(target_w as f64 / w as f64, target_h as f64 / h as f64);
+    let new_w = ((w as f64 * scale).round() as u32).max(1);
+    let new_h = ((h as f64 * scale).round() as u32).max(1);
+
+    let resized = img.resize_exact(new_w, new_h, image::imageops::FilterType::Triangle);
+    let rgba = resized.to_rgba8().into_raw();
+
+    icy_sixel::sixel_encode(
+        &rgba,
+        new_w as usize,
+        new_h as usize,
+        &icy_sixel::EncodeOptions::default(),
+    )
+    .ok()
+}
+
+/// Slice a cached full-size Sixel DCS string to extract only the visible bands.
+///
+/// This is an instant string operation - no image decoding or re-encoding.
+/// Each Sixel band represents 6 pixel rows.  We compute which bands correspond
+/// to the visible cell range and reconstruct the DCS with just those bands.
+///
+/// Returns `None` if the Sixel string cannot be parsed or the crop is empty.
+pub fn slice_sixel_bands(
+    full_sixel: &str,
+    cell_px_h: u16,
+    _full_height_cells: u16,
+    crop_top_cells: u16,
+    visible_height_cells: u16,
+) -> Option<String> {
+    // Find DCS body boundaries: ESC P [params] q [body] ESC \
+    let body_start = full_sixel.find('q')? + 1;
+    let body_end = full_sixel.rfind("\x1b\\")?;
+    if body_start >= body_end {
+        return None;
+    }
+
+    let dcs_header = &full_sixel[..body_start]; // includes "q"
+    let body = &full_sixel[body_start..body_end];
+
+    // Separate preamble (raster attrs + color definitions) from pixel data.
+    let preamble_end = find_preamble_end(body);
+    let preamble = &body[..preamble_end];
+    let pixel_data = &body[preamble_end..];
+
+    // Split pixel data into bands (separated by '-', the Graphics New Line).
+    // Filter empty elements: icy_sixel adds a trailing '-' after the last
+    // band, which creates a spurious empty element in the split.
+    let bands: Vec<&str> = pixel_data.split('-').filter(|b| !b.is_empty()).collect();
+    let total_bands = bands.len();
+    if total_bands == 0 {
+        return None;
+    }
+
+    // Calculate which bands correspond to the visible region.
+    // Use FLOOR division for take_bands to prevent overflow into adjacent
+    // cells. icy_sixel rounds up to a multiple of 6 pixel rows, so the
+    // cached Sixel often has 1 extra band. Clipping it prevents artifacts.
+    let skip_px = crop_top_cells as usize * cell_px_h as usize;
+    let vis_px = visible_height_cells as usize * cell_px_h as usize;
+
+    let skip_bands = skip_px / 6;
+    let take_bands = vis_px / 6; // floor - never overflow cell area
+
+    let start = skip_bands.min(total_bands);
+    let end = (start + take_bands).min(total_bands);
+
+    if start >= end {
+        return None;
+    }
+
+    // Reconstruct the DCS, stripping raster attributes. The raster declares
+    // image dimensions ("Pan;Pad;Ph;Pv) which WT uses for cursor positioning.
+    // After slicing, these dimensions are wrong and can corrupt WT's state.
+    // Raster attributes are optional per the Sixel spec - terminals determine
+    // dimensions from the actual pixel data instead.
+    let mut result = String::with_capacity(full_sixel.len());
+    result.push_str(dcs_header);
+
+    // Skip raster attributes, keep only color definitions
+    if let Some(raster_content) = preamble.strip_prefix('"') {
+        let raster_len = raster_content
+            .find(|c: char| !c.is_ascii_digit() && c != ';')
+            .unwrap_or(raster_content.len());
+        // Everything after the raster digits is color definitions
+        result.push_str(&raster_content[raster_len..]);
+    } else {
+        result.push_str(preamble);
+    }
+
+    for (i, band) in bands[start..end].iter().enumerate() {
+        if i > 0 {
+            result.push('-');
+        }
+        result.push_str(band);
+    }
+    result.push_str("\x1b\\");
+
+    Some(result)
+}
+
+/// Find where the preamble (raster attributes + color definitions) ends
+/// and actual pixel data begins in a Sixel body.
+///
+/// Raster attributes: `"Pan;Pad;Ph;Pv`
+/// Color definitions: `#Pc;Pu;Px;Py;Pz` (semicolon after color number)
+/// Color selection (pixel data): `#Pc` followed by pixel data chars (no semicolon)
+fn find_preamble_end(body: &str) -> usize {
+    let bytes = body.as_bytes();
+    let mut i = 0;
+
+    // Skip optional raster attributes: "digits;digits;...
+    if i < bytes.len() && bytes[i] == b'"' {
+        i += 1;
+        while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b';') {
+            i += 1;
+        }
+    }
+
+    // Skip color definitions: #Pc;Pu;Px;Py;Pz (has ; after color number)
+    while i < bytes.len() && bytes[i] == b'#' {
+        let mark = i;
+        i += 1;
+        // Read color number (Pc)
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b';' {
+            // Color definition - skip through it
+            while i < bytes.len() && (bytes[i].is_ascii_digit() || bytes[i] == b';') {
+                i += 1;
+            }
+        } else {
+            // Color selection (part of pixel data) - revert
+            return mark;
+        }
+    }
+
+    i
+}
 
 /// Crop and re-encode a cached full-size PNG for partial display.
 ///
@@ -251,4 +436,164 @@ pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
     }
 
     Some(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a synthetic Sixel DCS string with the given number of bands.
+    /// Each band is a simple pixel row for testing.
+    fn make_sixel(num_bands: usize) -> String {
+        // DCS header + raster attrs + 2 color definitions + bands + ST
+        let mut s = String::from("\x1bPq\"1;1;10;");
+        s.push_str(&(num_bands * 6).to_string()); // vertical pixel count
+        s.push_str("#0;2;100;0;0#1;2;0;100;0"); // two color definitions
+        for i in 0..num_bands {
+            if i > 0 {
+                s.push('-');
+            }
+            // Each band: select color 0, write some pixel data
+            s.push_str("#0???");
+        }
+        s.push_str("\x1b\\");
+        s
+    }
+
+    #[test]
+    fn slice_no_crop_exact_bands() {
+        // cell_px_h=6, 10 cells = 60px = 10 bands. Sixel has exactly 10 bands.
+        // Raster is stripped but all 10 bands are preserved.
+        let sixel = make_sixel(10);
+        let result = slice_sixel_bands(&sixel, 6, 10, 0, 10).unwrap();
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        assert_eq!(pixel_data.split('-').count(), 10);
+        // Raster attributes are stripped
+        assert!(!result.contains("\"1;1;"));
+        // Color definitions preserved
+        assert!(result.contains("#0;2;100;0;0"));
+    }
+
+    #[test]
+    fn slice_crop_top() {
+        // 10 bands, cell_px_h=6, so 1 band per cell.
+        // Crop top 3 cells = skip 3 bands, take remaining 7.
+        let sixel = make_sixel(10);
+        let result = slice_sixel_bands(&sixel, 6, 10, 3, 7).unwrap();
+        // Should have 7 bands
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        let band_count = pixel_data.split('-').count();
+        assert_eq!(band_count, 7);
+    }
+
+    #[test]
+    fn slice_crop_bottom() {
+        // 10 bands, take only 4 from top.
+        let sixel = make_sixel(10);
+        let result = slice_sixel_bands(&sixel, 6, 10, 0, 4).unwrap();
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        let band_count = pixel_data.split('-').count();
+        assert_eq!(band_count, 4);
+    }
+
+    #[test]
+    fn slice_middle() {
+        // 20 bands, cell_px_h=6 (1 band per cell). Skip 5, take 8.
+        let sixel = make_sixel(20);
+        let result = slice_sixel_bands(&sixel, 6, 20, 5, 8).unwrap();
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        let band_count = pixel_data.split('-').count();
+        assert_eq!(band_count, 8);
+    }
+
+    #[test]
+    fn slice_preserves_color_defs() {
+        let sixel = make_sixel(5);
+        let result = slice_sixel_bands(&sixel, 6, 5, 2, 3).unwrap();
+        // Color definitions should be preserved
+        assert!(result.contains("#0;2;100;0;0"));
+        assert!(result.contains("#1;2;0;100;0"));
+    }
+
+    #[test]
+    fn slice_empty_crop_returns_none() {
+        let sixel = make_sixel(5);
+        // Skip all bands
+        let result = slice_sixel_bands(&sixel, 6, 5, 5, 0);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_preamble_end_basic() {
+        let body = "\"1;1;10;60#0;2;100;0;0#1;2;0;100;0#0???-#0???";
+        let end = find_preamble_end(body);
+        // Should stop at the #0 that's a color selection (no ; after digits)
+        assert_eq!(&body[end..end + 2], "#0");
+        // And the char after the digits should be '?' (pixel data)
+        assert_eq!(body.as_bytes()[end + 2], b'?');
+    }
+
+    #[test]
+    fn slice_with_larger_cell_px() {
+        // cell_px_h=20, full_height=5 cells = 100px = 17 bands (ceil(100/6))
+        // crop_top=2 cells = 40px = skip 6 bands (40/6=6.67, floor=6)
+        // visible=3 cells = 60px = take 10 bands (floor(60/6)=10)
+        let sixel = make_sixel(17);
+        let result = slice_sixel_bands(&sixel, 20, 5, 2, 3).unwrap();
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        let band_count = pixel_data.split('-').count();
+        assert_eq!(band_count, 10);
+    }
+
+    #[test]
+    fn slice_clips_overflow_band() {
+        // Simulate icy_sixel adding an extra band: 18 cells * 20px = 360px
+        // = 60 bands needed, but Sixel has 61 bands (366px).
+        // Floor division should clip to 60 bands, not 61.
+        let sixel = make_sixel(61); // 61 bands like real icy_sixel output
+        let result = slice_sixel_bands(&sixel, 20, 18, 0, 18).unwrap();
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        let band_count = pixel_data.split('-').count();
+        // 18 cells * 20px = 360px. floor(360/6) = 60 bands, NOT 61.
+        assert_eq!(band_count, 60);
+    }
+
+    #[test]
+    fn slice_clips_full_image_overflow() {
+        // Full image (no crop) should still clip the extra band.
+        // 30 cells * 20px = 600px = 100 bands, but Sixel has 101.
+        let sixel = make_sixel(101);
+        let result = slice_sixel_bands(&sixel, 20, 30, 0, 30).unwrap();
+        let body_start = result.find('q').unwrap() + 1;
+        let body_end = result.rfind("\x1b\\").unwrap();
+        let body = &result[body_start..body_end];
+        let preamble_end = find_preamble_end(body);
+        let pixel_data = &body[preamble_end..];
+        let band_count = pixel_data.split('-').count();
+        assert_eq!(band_count, 100);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -546,6 +546,45 @@ fn emit_native_images(
         return Ok(());
     }
 
+    // Sixel: slice the cached full Sixel to the visible region (instant string op).
+    if protocol == image_render::ImageProtocol::Sixel {
+        if app.has_overlay() || app.visible_images.is_empty() {
+            app.visible_images.clear();
+            return Ok(());
+        }
+
+        // Dedup: skip Sixel emit when images haven't moved (avoids cursor
+        // flash from large Sixel writes on every mouse-move/redraw).
+        if app.visible_images == app.prev_visible_images {
+            app.visible_images.clear();
+            return Ok(());
+        }
+
+        let images = std::mem::take(&mut app.visible_images);
+        queue!(backend, Hide, SavePosition)?;
+
+        for img in &images {
+            if let Some(full_sixel) = app.sixel_cache.get(&img.path) {
+                let sliced = image_render::slice_sixel_bands(
+                    full_sixel,
+                    app.cell_px.1,
+                    img.full_height,
+                    img.crop_top,
+                    img.height,
+                );
+                if let Some(sixel) = sliced {
+                    queue!(backend, MoveTo(img.x, img.y))?;
+                    write!(backend, "{sixel}")?;
+                }
+            }
+        }
+
+        queue!(backend, RestorePosition, Show)?;
+        app.prev_visible_images = images;
+        return Ok(());
+    }
+
+    // iTerm2: only re-render when images change (dedup avoids flicker).
     if app.visible_images == app.prev_visible_images {
         return Ok(());
     }
@@ -592,7 +631,7 @@ fn emit_native_images(
     }
 
     queue!(backend, RestorePosition)?;
-    backend.flush()?;
+    // No flush - let EndSynchronizedUpdate send everything atomically.
 
     app.prev_visible_images = images;
     Ok(())
@@ -889,9 +928,8 @@ async fn run_app(
     app.desktop_notifications = config.desktop_notifications;
     app.notification_preview = config.notification_preview.clone();
     app.clipboard_clear_seconds = config.clipboard_clear_seconds;
-    app.inline_images = config.inline_images;
+    app.image_mode = config.image_mode.clone();
     app.show_link_previews = config.show_link_previews;
-    app.native_images = config.native_images;
     app.incognito = incognito;
     app.date_separators = config.date_separators;
     app.show_receipts = config.show_receipts;
@@ -903,6 +941,9 @@ async fn run_app(
     app.send_read_receipts = config.send_read_receipts;
     app.mouse_enabled = config.mouse_enabled;
     app.sidebar_on_right = config.sidebar_on_right;
+    if config.cell_pixel_width > 0 && config.cell_pixel_height > 0 {
+        app.cell_px = (config.cell_pixel_width, config.cell_pixel_height);
+    }
     app.available_themes = theme::all_themes();
     app.theme = theme::find_theme(&config.theme);
     let mut kb = keybindings::find_profile(&config.keybinding_profile);
@@ -954,28 +995,55 @@ async fn run_app(
     loop {
         // Only redraw when state has changed (avoids resetting cursor blink timer every 50ms)
         if needs_redraw {
-            // Wrap entire render (clear + text + image overlay) in synchronized
-            // update so the terminal renders everything atomically.
+            let native = app.image_mode == "native";
+            let sixel_mode = native
+                && app.image_protocol == image_render::ImageProtocol::Sixel;
+
+            // Always start sync update for atomic rendering (prevents cursor flicker).
             queue!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
 
             // Force full redraw when active conversation changes (clears native image artifacts)
-            if app.native_images && app.active_conversation != app.prev_active_conversation {
+            if native && app.active_conversation != app.prev_active_conversation {
                 app.prev_active_conversation = app.active_conversation.clone();
                 terminal.clear()?;
             }
+            // Sixel: force full redraw when scroll changes so ratatui resends
+            // ALL cells. The text output (inside sync) overwrites the terminal
+            // buffer, then after EndSync our Sixel overlays at the new positions.
+            // Without this, stale Sixel pixels persist at old image positions
+            // because ratatui's diff only sends changed cells.
+            if sixel_mode && app.scroll_offset != app.sixel_prev_scroll {
+                app.sixel_prev_scroll = app.scroll_offset;
+                app.prev_visible_images.clear();
+                terminal.clear()?;
+            }
             terminal.draw(|frame| ui::draw(frame, &mut app))?;
-            let has_post_draw = !app.link_regions.is_empty() || app.native_images;
+            // Post-draw work that needs cursor hidden: OSC8 links use MoveTo,
+            // and non-Sixel native images write escape sequences. Sixel emit
+            // happens outside sync and handles its own cursor.
+            let has_post_draw = !app.link_regions.is_empty()
+                || (native && !sixel_mode);
             if has_post_draw && app.mode == InputMode::Insert {
                 queue!(terminal.backend_mut(), Hide)?;
             }
             emit_osc8_links(terminal.backend_mut(), &app.link_regions, app.theme.link)?;
-            if app.native_images {
+            if native && !sixel_mode {
                 emit_native_images(terminal.backend_mut(), &mut app)?;
             }
             if has_post_draw && app.mode == InputMode::Insert {
                 queue!(terminal.backend_mut(), Show)?;
             }
             execute!(terminal.backend_mut(), EndSynchronizedUpdate)?;
+            // Sixel: emit AFTER sync update ends. WT composites text ON TOP
+            // of Sixel within sync, so text can't clear stale pixels. Outside
+            // sync, the text from ratatui's diff has already been processed,
+            // and our Sixel overlays cleanly on top. SavePosition/RestorePosition
+            // in emit keeps cursor at the input bar (no Hide/Show needed).
+            if sixel_mode {
+                use std::io::Write;
+                emit_native_images(terminal.backend_mut(), &mut app)?;
+                terminal.backend_mut().flush()?;
+            }
             needs_redraw = false;
         }
 

--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -2,16 +2,16 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::App;
 
-/// A settings profile: a named collection of the 14 persisted display toggles.
+/// A settings profile: a named collection of persisted display settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SettingsProfile {
     pub name: String,
     pub notify_direct: bool,
     pub notify_group: bool,
     pub desktop_notifications: bool,
-    pub inline_images: bool,
+    #[serde(default = "default_halfblock")]
+    pub image_mode: String,
     pub show_link_previews: bool,
-    pub native_images: bool,
     pub date_separators: bool,
     pub show_receipts: bool,
     pub color_receipts: bool,
@@ -22,15 +22,18 @@ pub struct SettingsProfile {
     pub sidebar_on_right: bool,
 }
 
+fn default_halfblock() -> String {
+    "halfblock".to_string()
+}
+
 pub fn default_profile() -> SettingsProfile {
     SettingsProfile {
         name: "Default".to_string(),
         notify_direct: true,
         notify_group: true,
         desktop_notifications: false,
-        inline_images: true,
+        image_mode: "halfblock".to_string(),
         show_link_previews: true,
-        native_images: false,
         date_separators: true,
         show_receipts: true,
         color_receipts: true,
@@ -48,9 +51,8 @@ pub fn minimal_profile() -> SettingsProfile {
         notify_direct: false,
         notify_group: false,
         desktop_notifications: false,
-        inline_images: false,
+        image_mode: "none".to_string(),
         show_link_previews: false,
-        native_images: false,
         date_separators: false,
         show_receipts: false,
         color_receipts: false,
@@ -68,9 +70,8 @@ pub fn full_profile() -> SettingsProfile {
         notify_direct: true,
         notify_group: true,
         desktop_notifications: true,
-        inline_images: true,
+        image_mode: "native".to_string(),
         show_link_previews: true,
-        native_images: true,
         date_separators: true,
         show_receipts: true,
         color_receipts: true,
@@ -208,9 +209,8 @@ impl SettingsProfile {
             notify_direct: app.notify_direct,
             notify_group: app.notify_group,
             desktop_notifications: app.desktop_notifications,
-            inline_images: app.inline_images,
+            image_mode: app.image_mode.clone(),
             show_link_previews: app.show_link_previews,
-            native_images: app.native_images,
             date_separators: app.date_separators,
             show_receipts: app.show_receipts,
             color_receipts: app.color_receipts,
@@ -222,14 +222,13 @@ impl SettingsProfile {
         }
     }
 
-    /// Apply this profile to the app, setting all 14 toggle fields.
+    /// Apply this profile to the app.
     pub fn apply_to(&self, app: &mut App) {
         app.notify_direct = self.notify_direct;
         app.notify_group = self.notify_group;
         app.desktop_notifications = self.desktop_notifications;
-        app.inline_images = self.inline_images;
+        app.image_mode = self.image_mode.clone();
         app.show_link_previews = self.show_link_previews;
-        app.native_images = self.native_images;
         app.date_separators = self.date_separators;
         app.show_receipts = self.show_receipts;
         app.color_receipts = self.color_receipts;
@@ -245,9 +244,8 @@ impl SettingsProfile {
         self.notify_direct == app.notify_direct
             && self.notify_group == app.notify_group
             && self.desktop_notifications == app.desktop_notifications
-            && self.inline_images == app.inline_images
+            && self.image_mode == app.image_mode
             && self.show_link_previews == app.show_link_previews
-            && self.native_images == app.native_images
             && self.date_separators == app.date_separators
             && self.show_receipts == app.show_receipts
             && self.color_receipts == app.color_receipts
@@ -298,9 +296,8 @@ mod tests {
         assert!(!p.notify_direct);
         assert!(!p.notify_group);
         assert!(!p.desktop_notifications);
-        assert!(!p.inline_images);
+        assert_eq!(p.image_mode, "none");
         assert!(!p.show_link_previews);
-        assert!(!p.native_images);
         assert!(!p.date_separators);
         assert!(!p.show_receipts);
         assert!(!p.color_receipts);
@@ -317,9 +314,8 @@ mod tests {
         assert!(p.notify_direct);
         assert!(p.notify_group);
         assert!(p.desktop_notifications);
-        assert!(p.inline_images);
+        assert_eq!(p.image_mode, "native");
         assert!(p.show_link_previews);
-        assert!(p.native_images);
         assert!(p.date_separators);
         assert!(p.show_receipts);
         assert!(p.color_receipts);

--- a/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
@@ -10,23 +10,23 @@ expression: output
     Bob              ││[0│  [x] Group message notifications               │ a run                  │
 ▸   Alice            ││● │  [ ] Desktop notifications                     │bed before 7            │
     Dave             ││[0│  [x] Sidebar visible                           │e habit                 │
-                     ││● │  [x] Inline image previews                     │                        │
-                     ││[0│  [x] Link previews                             │tomatic                 │
-                     ││  │  [ ] Native images (experimental)              │                        │
-                     ││[0│  [ ] Date separators                           │t too                   │
-                     ││✓ │  [x] Read receipts                             │                        │
-                     ││[0│  [x] Receipt colors                            │                        │
-                     ││[0│  [ ] Nerd Font icons                           │/localmarket.example.com│
-                     ││  │  [ ] Emoji to text                             │                        │
-                     ││  │  [x] Show reactions                            │ry Saturday…            │
+                     ││● │  [x] Link previews                             │                        │
+                     ││[0│  [ ] Date separators                           │tomatic                 │
+                     ││  │  [x] Read receipts                             │                        │
+                     ││[0│  [x] Receipt colors                            │t too                   │
+                     ││✓ │  [ ] Nerd Font icons                           │                        │
+                     ││[0│  [ ] Emoji to text                             │                        │
+                     ││[0│  [x] Show reactions                            │/localmarket.example.com│
                      ││  │  [ ] Verbose reactions                         │                        │
-                     ││○ │  [x] Send read receipts                        │                        │
-                     ││✓ │  [x] Mouse support                             │owded.                  │
+                     ││  │  [x] Send read receipts                        │ry Saturday…            │
+                     ││  │  [x] Mouse support                             │                        │
                      ││○ │  [ ] Sidebar on right                          │                        │
-                     ││○ │  Notification preview: full                    │                        │
-                     ││○ │  Theme: Default                                │nt to browse early      │
-                     ││[0│  Keybindings: Default                          │                        │
-                     ││  │  Profile: Default                              │                        │
+                     ││✓ │  Notification preview: full                    │owded.                  │
+                     ││○ │  Image mode: halfblock                         │                        │
+                     ││○ │  Theme: Default                                │                        │
+                     ││○ │  Keybindings: Default                          │nt to browse early      │
+                     ││[0│  Profile: Default                              │                        │
+                     ││  │                                                │                        │
                      │╰──╰────────────────────────────────────────────────╯────────────────────────╯
                      │╭────────────────────────────────────────────────────────────────────────────╮
                      ││  Type a message...                                                         │

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -929,7 +929,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     let mut line_msg_idx: Vec<Option<usize>> = Vec::new();
 
     // Track images for native protocol overlay: (first_line_index, line_count, path)
-    let use_native = app.native_images && app.image_protocol != ImageProtocol::Halfblock;
+    let use_native = app.image_mode == "native" && app.image_protocol != ImageProtocol::Halfblock;
     let mut image_records: Vec<(usize, usize, String)> = Vec::new();
 
     for (i, msg) in visible.iter().enumerate() {
@@ -1073,7 +1073,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             line_msg_idx.push(Some(msg_index));
 
             // Render inline image preview if available (skip for deleted, skip if images disabled)
-            if !msg.is_deleted && app.inline_images {
+            if !msg.is_deleted && app.image_mode != "none" {
                 if let Some(ref image_lines) = msg.image_lines {
                     let first_idx = lines.len();
                     let count = image_lines.len();
@@ -1124,7 +1124,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                     line_msg_idx.push(Some(msg_index));
 
                     // Render link preview thumbnail (only when images enabled)
-                    if app.inline_images {
+                    if app.image_mode != "none" {
                         if let Some(ref img_lines) = msg.preview_image_lines {
                             let first_idx = lines.len();
                             let count = img_lines.len();
@@ -1341,6 +1341,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     if use_native && app.image_protocol == ImageProtocol::Kitty {
         patch_kitty_placeholders(frame, app);
     }
+    // Note: Sixel does NOT use set_skip. ratatui writes halfblock at image cells,
+    // which clears stale Sixel pixels from previous positions when images scroll.
+    // Sixel is then overlaid outside the synchronized update (see main.rs).
 
     // Scrollbar on right border, inset to preserve rounded corners
     if content_height > available_height {
@@ -2383,8 +2386,26 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(app.notification_preview.clone(), preview_value_style),
     ]));
 
-    // Theme selector entry (index == SETTINGS.len() + 1)
-    let is_theme_selected = app.settings_index == SETTINGS.len() + 1;
+    // Image mode cycle entry (index == SETTINGS.len() + 1)
+    let image_mode_index = SETTINGS.len() + 1;
+    let is_image_mode_selected = app.settings_index == image_mode_index;
+    let image_mode_style = if is_image_mode_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme.fg_secondary)
+    };
+    let image_mode_value_style = if is_image_mode_selected {
+        Style::default().bg(theme.bg_selected).fg(theme.accent)
+    } else {
+        Style::default().fg(theme.accent)
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  Image mode: ", image_mode_style),
+        Span::styled(app.image_mode.clone(), image_mode_value_style),
+    ]));
+
+    // Theme selector entry (index == SETTINGS.len() + 2)
+    let is_theme_selected = app.settings_index == SETTINGS.len() + 2;
     let theme_style = if is_theme_selected {
         Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
     } else {
@@ -2400,8 +2421,8 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(app.theme.name.clone(), theme_value_style),
     ]));
 
-    // Keybindings selector entry (index == SETTINGS.len() + 2)
-    let is_kb_selected = app.settings_index == SETTINGS.len() + 2;
+    // Keybindings selector entry (index == SETTINGS.len() + 3)
+    let is_kb_selected = app.settings_index == SETTINGS.len() + 3;
     let kb_style = if is_kb_selected {
         Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
     } else {
@@ -2417,8 +2438,8 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         Span::styled(app.keybindings.profile_name.clone(), kb_value_style),
     ]));
 
-    // Settings profile selector entry (index == SETTINGS.len() + 3)
-    let is_profile_selected = app.settings_index == SETTINGS.len() + 3;
+    // Settings profile selector entry (index == SETTINGS.len() + 4)
+    let is_profile_selected = app.settings_index == SETTINGS.len() + 4;
     let profile_style = if is_profile_selected {
         Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
     } else {
@@ -2440,9 +2461,10 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         match app.settings_index - SETTINGS.len() {
             0 => "Control message content in notifications",
-            1 => "Switch between color themes",
-            2 => "Switch between keybinding presets",
-            3 => "h/l cycle, Enter manage settings profiles",
+            1 => "native (terminal protocol), halfblock, or none",
+            2 => "Switch between color themes",
+            3 => "Switch between keybinding presets",
+            4 => "h/l cycle, Enter manage settings profiles",
             _ => "",
         }
     };


### PR DESCRIPTION
## Summary
- Adds native Sixel image rendering for Windows Terminal, replacing halfblock art with pixel-accurate inline images
- Uses instant Sixel DCS band slicing for partial images during scroll - no async re-encoding, no flicker
- Refactors image settings: `image_mode` ("native"/"halfblock"/"none") replaces `inline_images` + `native_images` booleans with backward-compatible config migration
- New config options: `cell_pixel_width`/`cell_pixel_height` for Sixel sizing (default 10x20 for WT)

### How it works
1. Pre-cache: `ensure_active_images` encodes full Sixel alongside halfblock render in background
2. Slice: `slice_sixel_bands()` extracts visible bands from cached DCS string (instant string op, ~10 unit tests)
3. Emit: Sixel written after `EndSynchronizedUpdate` (WT workaround - composites text ON TOP of Sixel within sync)
4. Clear: `terminal.clear()` on scroll change forces ratatui full redraw to clear stale Sixel pixels

### WT-specific workarounds
- Sixel emitted outside synchronized updates (WT compositing bug)
- Raster attributes stripped when slicing (WT uses declared Pv for cursor positioning)
- Trailing empty band from icy_sixel filtered (adds spurious GNL)
- Floor division for band count (prevents 6px overflow into adjacent cells)
- Sixel caches survive terminal resize (encoding depends on config cell_px, not terminal size)

## Test plan
- [x] `cargo clippy --tests -- -D warnings && cargo test` passes (411 tests including 10 new slice tests)
- [x] Scroll through conversation with images in WT - native Sixel renders correctly
- [x] Partial images (top/bottom clipped by scroll) show correct portion
- [x] Overlays (/settings, /help) properly hide Sixel images
- [x] Resize terminal - images survive without re-encoding lag
- [x] Switch conversations - images render in new conversation
- [x] `image_mode = "halfblock"` still works as before
- [x] `image_mode = "none"` disables all image rendering
- [x] Old config with `inline_images`/`native_images` migrates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)