### PR TITLE
Persist sidebar width in config

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -795,6 +795,7 @@ impl App {
         config.settings_profile = self.settings_profiles.name.clone();
         config.notification_preview = self.notifications.notification_preview.clone();
         config.image_mode = self.image.image_mode.clone();
+        config.sidebar_width = self.sidebar_width;
         for def in SETTINGS {
             if let Some(save_fn) = def.save {
                 save_fn(&mut config, (def.get)(self));
@@ -2780,6 +2781,7 @@ impl App {
     pub fn resize_sidebar(&mut self, delta: i16) {
         let new_width = (self.sidebar_width as i16 + delta).clamp(14, 40) as u16;
         self.sidebar_width = new_width;
+        self.save_settings();
     }
 
     /// Refresh the filtered sidebar list based on the current filter text.

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,6 +100,10 @@ pub struct Config {
     #[serde(default)]
     pub sidebar_on_right: bool,
 
+    /// Sidebar width in columns (14-40, default 22)
+    #[serde(default = "default_sidebar_width")]
+    pub sidebar_width: u16,
+
     /// Color theme name (matches a built-in or custom theme)
     #[serde(default = "default_theme")]
     pub theme: String,
@@ -141,6 +145,10 @@ fn default_clipboard_clear_seconds() -> u64 {
     30
 }
 
+fn default_sidebar_width() -> u16 {
+    22
+}
+
 fn default_signal_cli_path() -> String {
     "signal-cli".to_string()
 }
@@ -178,6 +186,7 @@ impl Default for Config {
             send_read_receipts: true,
             mouse_enabled: true,
             sidebar_on_right: false,
+            sidebar_width: default_sidebar_width(),
             theme: default_theme(),
             keybinding_profile: default_keybinding_profile(),
             settings_profile: default_settings_profile(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -941,6 +941,7 @@ async fn run_app(
     app.send_read_receipts = config.send_read_receipts;
     app.mouse_enabled = config.mouse_enabled;
     app.sidebar_on_right = config.sidebar_on_right;
+    app.sidebar_width = config.sidebar_width.clamp(14, 40);
     if config.cell_pixel_width > 0 && config.cell_pixel_height > 0 {
         app.image.cell_px = (config.cell_pixel_width, config.cell_pixel_height);
     }


### PR DESCRIPTION
## Summary

- Adds `sidebar_width` field to config.toml (default 22, range 14-40)
- Saves automatically when user resizes with Ctrl+Left/Right
- Restores on startup with clamp validation

## Test plan

- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Manual: resize sidebar, restart siggy, verify width persists

Closes #264