### PR TITLE
feat: open attachments and URLs from action menu (closes #188)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10174,4 +10174,24 @@ mod tests {
         assert!(!items.iter().any(|a| a.label == "Open attachment"), "should not have Open attachment");
         assert!(!items.iter().any(|a| a.label == "Open link"), "should not have Open link");
     }
+
+    #[rstest]
+    fn action_menu_respects_focused_msg_index(mut app: App) {
+        // Message 0: has a URL
+        let msg1 = make_msg("+1", Some("check https://example.com"), None, false);
+        app.handle_signal_event(SignalEvent::MessageReceived(msg1));
+        // Message 1: plain text (last/newest)
+        let msg2 = make_msg("+1", Some("just text"), None, false);
+        app.handle_signal_event(SignalEvent::MessageReceived(msg2));
+        app.active_conversation = Some("+1".to_string());
+
+        // Without focus, defaults to last message (plain text) — no Open link
+        let items = app.action_menu_items();
+        assert!(!items.iter().any(|a| a.label == "Open link"), "last msg has no URL");
+
+        // Focus the first message (the one with a URL)
+        app.focused_msg_index = Some(0);
+        let items = app.action_menu_items();
+        assert!(items.iter().any(|a| a.label == "Open link"), "focused msg has URL, should show Open link");
+    }
 }


### PR DESCRIPTION
## Summary

- Adds "Open attachment" and "Open link" items to the Normal mode action menu (Enter key)
- When a focused message has a downloaded attachment (`file:///` URI in body), shows "Open attachment" (shortcut: `o`)
- When a focused message has an HTTP/HTTPS URL, shows "Open link" (shortcut: `l`)
- Opens files/URLs using the system default application via the `open` crate (xdg-open on Linux, open on macOS, start on Windows)
- New `open_file()` validates file exists before opening, shows status message on success/failure

## Test plan

- [x] 7 unit tests for URI/URL extraction helpers (file URIs, HTTP URLs, edge cases)
- [x] 4 unit tests for action menu items (attachment, link, both, plain text)
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] Full test suite: 423 tests pass
- [ ] Manual test: receive image attachment, focus message, Enter -> "Open attachment"
- [ ] Manual test: receive message with URL, focus message, Enter -> "Open link"

Generated with [Claude Code](https://claude.com/claude-code)