### PR TITLE
Group settings by category with section headers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -380,6 +380,10 @@ pub struct App {
     pub show_settings: bool,
     /// Cursor position in settings list
     pub settings_index: usize,
+    /// Customize sub-menu overlay visible (Theme, Keybindings, Profile)
+    pub show_customize: bool,
+    /// Cursor position in customize sub-menu
+    pub customize_index: usize,
     /// Help overlay visible
     pub show_help: bool,
     /// State for the contacts list overlay
@@ -667,7 +671,28 @@ pub struct SettingDef {
     on_toggle: Option<fn(&mut App)>,
 }
 
+/// Section boundary indices within the SETTINGS array.
+pub const SETTINGS_SECTION_DISPLAY: usize = 3;
+pub const SETTINGS_SECTION_MESSAGES: usize = 9;
+pub const SETTINGS_SECTION_INTERFACE: usize = 12;
+
+/// Visual order of settings items (logical indices into the combined toggle+special list).
+/// Toggle indices 0..SETTINGS.len() map to SETTINGS entries.
+/// Special indices: SETTINGS.len() = preview, +1 = image mode, +2 = customize.
+/// Navigation walks this array so j/k follows the visual layout.
+pub const SETTINGS_VISUAL_ORDER: &[usize] = &[
+    // Notifications
+    0, 1, 2, 15, // DM, Group, Desktop, Notification preview
+    // Display
+    3, 4, 5, 6, 7, 8, 16, // Link previews .. Emoji to text, Image mode
+    // Messages
+    9, 10, 11, // Show reactions, Verbose reactions, Send read receipts
+    // Interface
+    12, 13, 14, 17, // Sidebar visible, Mouse, Sidebar on right, Customize...
+];
+
 pub const SETTINGS: &[SettingDef] = &[
+    // — Notifications (0–2) —
     SettingDef {
         label: "Direct message notifications",
         hint: "Play a sound for incoming direct messages",
@@ -692,21 +717,14 @@ pub const SETTINGS: &[SettingDef] = &[
         save: Some(|c, v| c.desktop_notifications = v),
         on_toggle: None,
     },
-    SettingDef {
-        label: "Sidebar visible",
-        hint: "Show the conversation list sidebar",
-        get: |a| a.sidebar_visible,
-        set: |a, v| a.sidebar_visible = v,
-        save: None, // runtime-only, not persisted
-        on_toggle: None,
-    },
+    // — Display (3–8) —
     SettingDef {
         label: "Link previews",
         hint: "Show title and thumbnail for URLs",
         get: |a| a.image.show_link_previews,
         set: |a, v| a.image.show_link_previews = v,
         save: Some(|c, v| c.show_link_previews = v),
-        on_toggle: None, // UI checks the flag; cached lines stay in memory
+        on_toggle: None,
     },
     SettingDef {
         label: "Date separators",
@@ -748,6 +766,7 @@ pub const SETTINGS: &[SettingDef] = &[
         save: Some(|c, v| c.emoji_to_text = v),
         on_toggle: None,
     },
+    // — Messages (9–11) —
     SettingDef {
         label: "Show reactions",
         hint: "Show emoji reactions on messages",
@@ -770,6 +789,15 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.send_read_receipts,
         set: |a, v| a.send_read_receipts = v,
         save: Some(|c, v| c.send_read_receipts = v),
+        on_toggle: None,
+    },
+    // — Interface (12–14) —
+    SettingDef {
+        label: "Sidebar visible",
+        hint: "Show the conversation list sidebar",
+        get: |a| a.sidebar_visible,
+        set: |a, v| a.sidebar_visible = v,
+        save: None, // runtime-only, not persisted
         on_toggle: None,
     },
     SettingDef {
@@ -965,28 +993,28 @@ impl App {
     }
 
     /// Handle a key press while the settings overlay is open.
-    /// After toggles: Preview at SETTINGS.len(), Image mode at +1, Theme at +2, Keybindings at +3, Profile at +4.
+    /// Navigation follows SETTINGS_VISUAL_ORDER so j/k matches the visual layout.
+    /// After toggles: Preview at SETTINGS.len(), Image mode at +1, Customize at +2.
     pub fn handle_settings_key(&mut self, code: KeyCode) {
         let preview_index = SETTINGS.len();
         let image_mode_index = SETTINGS.len() + 1;
-        let theme_index = SETTINGS.len() + 2;
-        let kb_index = SETTINGS.len() + 3;
-        let profile_index = SETTINGS.len() + 4;
-        let max_index = profile_index;
+        let customize_index = SETTINGS.len() + 2;
+
+        // Find current position in visual order
+        let visual_pos = SETTINGS_VISUAL_ORDER.iter()
+            .position(|&i| i == self.settings_index)
+            .unwrap_or(0);
+
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
-                if self.settings_index < max_index {
-                    self.settings_index += 1;
+                if visual_pos + 1 < SETTINGS_VISUAL_ORDER.len() {
+                    self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.settings_index = self.settings_index.saturating_sub(1);
-            }
-            KeyCode::Char('h') | KeyCode::Left if self.settings_index == profile_index => {
-                self.cycle_settings_profile(false);
-            }
-            KeyCode::Char('l') | KeyCode::Right if self.settings_index == profile_index => {
-                self.cycle_settings_profile(true);
+                if visual_pos > 0 {
+                    self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
+                }
             }
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
                 if self.settings_index == preview_index {
@@ -1001,22 +1029,9 @@ impl App {
                         "halfblock" => "none".to_string(),
                         _ => "native".to_string(),
                     };
-                } else if self.settings_index == theme_index {
-                    self.show_settings = false;
-                    self.save_settings();
-                    self.theme_picker.show = true;
-                    self.theme_picker.index = self.theme_picker.available_themes.iter()
-                        .position(|t| t.name == self.theme.name)
-                        .unwrap_or(0);
-                } else if self.settings_index == kb_index {
-                    self.show_settings = false;
-                    self.save_settings();
-                    self.keybindings_overlay.show = true;
-                    self.keybindings_overlay.index = 0;
-                } else if self.settings_index == profile_index {
-                    self.show_settings = false;
-                    self.save_settings();
-                    self.open_settings_profile_manager();
+                } else if self.settings_index == customize_index {
+                    self.show_customize = true;
+                    self.customize_index = 0;
                 } else {
                     self.toggle_setting(self.settings_index);
                 }
@@ -1030,23 +1045,44 @@ impl App {
         }
     }
 
-    /// Cycle through settings profiles (left/right on the profile row).
-    /// Uses deferred hooks since the user can't see messages while the overlay is open.
-    fn cycle_settings_profile(&mut self, forward: bool) {
-        if self.settings_profiles.available.is_empty() {
-            return;
+    /// Handle a key press in the Customize sub-menu (Theme, Keybindings, Profile).
+    pub fn handle_customize_key(&mut self, code: KeyCode) {
+        const ITEMS: usize = 3; // Theme, Keybindings, Profile
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if self.customize_index + 1 < ITEMS {
+                    self.customize_index += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.customize_index = self.customize_index.saturating_sub(1);
+            }
+            KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
+                self.show_customize = false;
+                self.show_settings = false;
+                self.save_settings();
+                match self.customize_index {
+                    0 => {
+                        self.theme_picker.show = true;
+                        self.theme_picker.index = self.theme_picker.available_themes.iter()
+                            .position(|t| t.name == self.theme.name)
+                            .unwrap_or(0);
+                    }
+                    1 => {
+                        self.keybindings_overlay.show = true;
+                        self.keybindings_overlay.index = 0;
+                    }
+                    2 => {
+                        self.open_settings_profile_manager();
+                    }
+                    _ => {}
+                }
+            }
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.show_customize = false;
+            }
+            _ => {}
         }
-        let current_idx = self.settings_profiles.available.iter()
-            .position(|p| p.name == self.settings_profiles.name)
-            .unwrap_or(0);
-        let new_idx = if forward {
-            (current_idx + 1) % self.settings_profiles.available.len()
-        } else {
-            (current_idx + self.settings_profiles.available.len() - 1)
-                % self.settings_profiles.available.len()
-        };
-        let profile = self.settings_profiles.available[new_idx].clone();
-        self.apply_settings_profile_deferred(&profile);
     }
 
     /// Apply a profile without firing expensive hooks (image re-rendering).
@@ -2624,6 +2660,8 @@ impl App {
             autocomplete_index: 0,
             show_settings: false,
             settings_index: 0,
+            show_customize: false,
+            customize_index: 0,
             show_help: false,
             contacts_overlay: ContactsOverlayState::default(),
             verify: VerifyOverlayState::default(),
@@ -3196,6 +3234,10 @@ impl App {
         }
         if self.keybindings_overlay.show {
             self.handle_keybindings_key(code);
+            return (true, None);
+        }
+        if self.show_customize {
+            self.handle_customize_key(code);
             return (true, None);
         }
         if self.show_settings {

--- a/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
@@ -1,34 +1,35 @@
 ---
 source: src/ui.rs
+assertion_line: 4364
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
   ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
-  • ##Family (2)     ││    👍  1                                                                    │
-  • Carol (1)        ││● ╭ Settings ──────────────────────────────────────╮                        │
-    ##Rust Devs      ││  │  [x] Direct message notifications              │                        │
-    Bob              ││[0│  [x] Group message notifications               │ a run                  │
-▸   Alice            ││● │  [ ] Desktop notifications                     │bed before 7            │
-    Dave             ││[0│  [x] Sidebar visible                           │e habit                 │
-                     ││● │  [x] Link previews                             │                        │
-                     ││[0│  [ ] Date separators                           │tomatic                 │
-                     ││  │  [x] Read receipts                             │                        │
-                     ││[0│  [x] Receipt colors                            │t too                   │
-                     ││✓ │  [ ] Nerd Font icons                           │                        │
-                     ││[0│  [ ] Emoji to text                             │                        │
-                     ││[0│  [x] Show reactions                            │/localmarket.example.com│
-                     ││  │  [ ] Verbose reactions                         │                        │
-                     ││  │  [x] Send read receipts                        │ry Saturday…            │
-                     ││  │  [x] Mouse support                             │                        │
-                     ││○ │  [ ] Sidebar on right                          │                        │
-                     ││✓ │  Notification preview: full                    │owded.                  │
-                     ││○ │  Image mode: halfblock                         │                        │
-                     ││○ │  Theme: Default                                │                        │
-                     ││○ │  Keybindings: Default                          │nt to browse early      │
-                     ││[0│  Profile: Default                              │                        │
-                     ││  │                                                │                        │
-                     │╰──╰────────────────────────────────────────────────╯────────────────────────╯
-                     │╭────────────────────────────────────────────────────────────────────────────╮
+  • ##Family (2)     ││  ╭ Settings ──────────────────────────────────────╮                        │
+  • Carol (1)        ││● │  Notifications                                 │                        │
+    ##Rust Devs      ││  │    [x] Direct message notifications            │                        │
+    Bob              ││[0│    [x] Group message notifications             │ a run                  │
+▸   Alice            ││● │    [ ] Desktop notifications                   │bed before 7            │
+    Dave             ││[0│    Notification preview: full                  │e habit                 │
+                     ││● │  Display                                       │                        │
+                     ││[0│    [x] Link previews                           │tomatic                 │
+                     ││  │    [ ] Date separators                         │                        │
+                     ││[0│    [x] Read receipts                           │t too                   │
+                     ││✓ │    [x] Receipt colors                          │                        │
+                     ││[0│    [ ] Nerd Font icons                         │                        │
+                     ││[0│    [ ] Emoji to text                           │/localmarket.example.com│
+                     ││  │    Image mode: halfblock                       │                        │
+                     ││  │  Messages                                      │ry Saturday…            │
+                     ││  │    [x] Show reactions                          │                        │
+                     ││○ │    [ ] Verbose reactions                       │                        │
+                     ││✓ │    [x] Send read receipts                      │owded.                  │
+                     ││○ │  Interface                                     │                        │
+                     ││○ │    [x] Sidebar visible                         │                        │
+                     ││○ │    [x] Mouse support                           │nt to browse early      │
+                     ││[0│    [ ] Sidebar on right                        │                        │
+                     ││  │    Customize...                                │                        │
+                     │╰──│  Play a sound for incoming direct messages     │────────────────────────╯
+                     │╭──╰────────────────────────────────────────────────╯────────────────────────╮
                      ││  Type a message...                                                         │
                      │╰────────────────────────────────────────────────────────────────────────────╯
  [INSERT] │  ● connected │ Alice │ 7 chats

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,7 +10,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, VisibleImage, PIN_DURATIONS, QUICK_REACTIONS, SETTINGS};
+use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, SettingDef, VisibleImage, PIN_DURATIONS, QUICK_REACTIONS, SETTINGS};
 use crate::domain::CATEGORIES;
 use crate::keybindings::{self, BindingMode, KeyAction};
 use crate::list_overlay;
@@ -26,7 +26,7 @@ const MSG_WINDOW_MULTIPLIER: usize = 10;
 
 // Popup dimensions
 const SETTINGS_POPUP_WIDTH: u16 = 50;
-const SETTINGS_POPUP_HEIGHT: u16 = 18;
+const SETTINGS_POPUP_HEIGHT: u16 = 25;
 const CONTACTS_POPUP_WIDTH: u16 = 50;
 const CONTACTS_MAX_VISIBLE: usize = 20;
 const FILE_BROWSER_POPUP_WIDTH: u16 = 60;
@@ -536,6 +536,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // Settings overlay (overlays everything)
     if app.show_settings {
         draw_settings(frame, app, size);
+    }
+
+    // Customize sub-menu overlay (Theme, Keybindings, Profile)
+    if app.show_customize {
+        draw_customize(frame, app, size);
     }
 
     // Help overlay (overlays everything)
@@ -2436,13 +2441,15 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
 fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
-    let height = SETTINGS_POPUP_HEIGHT + 5; // extra lines for preview + theme + keybindings + profile + hint
+    let height = SETTINGS_POPUP_HEIGHT;
     let (popup_area, block) = centered_popup(
         frame, area, SETTINGS_POPUP_WIDTH, height, " Settings ", theme,
     );
 
-    let mut lines: Vec<Line> = Vec::new();
-    for (i, def) in SETTINGS.iter().enumerate() {
+    let header_style = Style::default().fg(theme.fg_muted).add_modifier(Modifier::BOLD);
+
+    // Render a toggle row
+    let render_toggle = |lines: &mut Vec<Line>, i: usize, def: &SettingDef| {
         let enabled = app.setting_value(i);
         let checkbox = if enabled { "[x]" } else { "[ ]" };
         let is_selected = i == app.settings_index;
@@ -2458,99 +2465,57 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             Style::default().fg(theme.fg_muted)
         };
-
         lines.push(Line::from(vec![
-            Span::styled(format!("  {} ", checkbox), check_style),
+            Span::styled(format!("    {} ", checkbox), check_style),
             Span::styled(def.label.to_string(), style),
         ]));
-    }
+    };
 
-    // Notification preview cycle entry (index == SETTINGS.len())
+    // Render a special (non-toggle) row
+    let render_special = |lines: &mut Vec<Line>, label: &str, value: &str, index: usize| {
+        let is_selected = app.settings_index == index;
+        let label_style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        let value_style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(theme.accent)
+        } else {
+            Style::default().fg(theme.accent)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("    {label}"), label_style),
+            Span::styled(value.to_string(), value_style),
+        ]));
+    };
+
+    use crate::app::{SETTINGS_SECTION_DISPLAY, SETTINGS_SECTION_MESSAGES, SETTINGS_SECTION_INTERFACE};
+
     let preview_index = SETTINGS.len();
-    let is_preview_selected = app.settings_index == preview_index;
-    let preview_style = if is_preview_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(theme.fg_secondary)
-    };
-    let preview_value_style = if is_preview_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.accent)
-    } else {
-        Style::default().fg(theme.accent)
-    };
-    lines.push(Line::from(vec![
-        Span::styled("  Notification preview: ", preview_style),
-        Span::styled(app.notifications.notification_preview.clone(), preview_value_style),
-    ]));
-
-    // Image mode cycle entry (index == SETTINGS.len() + 1)
     let image_mode_index = SETTINGS.len() + 1;
-    let is_image_mode_selected = app.settings_index == image_mode_index;
-    let image_mode_style = if is_image_mode_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(theme.fg_secondary)
-    };
-    let image_mode_value_style = if is_image_mode_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.accent)
-    } else {
-        Style::default().fg(theme.accent)
-    };
-    lines.push(Line::from(vec![
-        Span::styled("  Image mode: ", image_mode_style),
-        Span::styled(app.image.image_mode.clone(), image_mode_value_style),
-    ]));
+    let customize_index = SETTINGS.len() + 2;
 
-    // Theme selector entry (index == SETTINGS.len() + 2)
-    let is_theme_selected = app.settings_index == SETTINGS.len() + 2;
-    let theme_style = if is_theme_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(theme.fg_secondary)
-    };
-    let theme_value_style = if is_theme_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.accent)
-    } else {
-        Style::default().fg(theme.accent)
-    };
-    lines.push(Line::from(vec![
-        Span::styled("  Theme: ", theme_style),
-        Span::styled(app.theme.name.clone(), theme_value_style),
-    ]));
+    let mut lines: Vec<Line> = Vec::new();
 
-    // Keybindings selector entry (index == SETTINGS.len() + 3)
-    let is_kb_selected = app.settings_index == SETTINGS.len() + 3;
-    let kb_style = if is_kb_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(theme.fg_secondary)
-    };
-    let kb_value_style = if is_kb_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.accent)
-    } else {
-        Style::default().fg(theme.accent)
-    };
-    lines.push(Line::from(vec![
-        Span::styled("  Keybindings: ", kb_style),
-        Span::styled(app.keybindings.profile_name.clone(), kb_value_style),
-    ]));
+    // — Notifications —
+    lines.push(Line::from(Span::styled("  Notifications", header_style)));
+    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_DISPLAY) { render_toggle(&mut lines, i, def); }
+    render_special(&mut lines, "Notification preview: ", &app.notifications.notification_preview, preview_index);
 
-    // Settings profile selector entry (index == SETTINGS.len() + 4)
-    let is_profile_selected = app.settings_index == SETTINGS.len() + 4;
-    let profile_style = if is_profile_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
-    } else {
-        Style::default().fg(theme.fg_secondary)
-    };
-    let profile_value_style = if is_profile_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.accent)
-    } else {
-        Style::default().fg(theme.accent)
-    };
-    lines.push(Line::from(vec![
-        Span::styled("  Profile: ", profile_style),
-        Span::styled(app.settings_profiles.name.clone(), profile_value_style),
-    ]));
+    // — Display —
+    lines.push(Line::from(Span::styled("  Display", header_style)));
+    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_MESSAGES).skip(SETTINGS_SECTION_DISPLAY) { render_toggle(&mut lines, i, def); }
+    render_special(&mut lines, "Image mode: ", &app.image.image_mode, image_mode_index);
+
+    // — Messages —
+    lines.push(Line::from(Span::styled("  Messages", header_style)));
+    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_INTERFACE).skip(SETTINGS_SECTION_MESSAGES) { render_toggle(&mut lines, i, def); }
+
+    // — Interface —
+    lines.push(Line::from(Span::styled("  Interface", header_style)));
+    for (i, def) in SETTINGS.iter().enumerate().skip(SETTINGS_SECTION_INTERFACE) { render_toggle(&mut lines, i, def); }
+    render_special(&mut lines, "Customize...", "", customize_index);
 
     // Hint line for the currently selected item
     let hint = if app.settings_index < SETTINGS.len() {
@@ -2559,17 +2524,36 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         match app.settings_index - SETTINGS.len() {
             0 => "Control message content in notifications",
             1 => "native (terminal protocol), halfblock, or none",
-            2 => "Switch between color themes",
-            3 => "Switch between keybinding presets",
-            4 => "h/l cycle, Enter manage settings profiles",
+            2 => "Theme, keybindings, and settings profiles",
             _ => "",
         }
     };
-    lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         format!("  {hint}"),
         Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
     )));
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_customize(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let items = ["Theme", "Keybindings", "Settings profile"];
+    let (popup_area, block) = centered_popup(
+        frame, area, 30, 5, " Customize ", theme,
+    );
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, label) in items.iter().enumerate() {
+        let is_selected = i == app.customize_index;
+        let style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        lines.push(Line::from(Span::styled(format!("  {label}"), style)));
+    }
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);


### PR DESCRIPTION
## Summary
- Add section headers (Notifications, Display, Messages, Interface) to the `/settings` overlay for easier scanning
- Reorder toggles into logical groups matching their function
- Consolidate Theme, Keybindings, and Settings Profile into a "Customize..." sub-menu to keep the popup compact within standard terminal heights

Closes #207

## Test plan
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` — all 462 tests pass
- [x] Settings snapshot updated and verified
- [ ] Manual: open `/settings`, verify j/k navigation skips headers and follows visual order
- [ ] Manual: select "Customize..." → verify sub-menu opens with Theme/Keybindings/Profile options
- [ ] Manual: Esc from customize returns to settings overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)