### PR TITLE
Force Node.js 24 for action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
         with:
           generate_release_notes: true
           files: siggy-*


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to the release workflow's `action-gh-release` step
- `softprops/action-gh-release@v2` still uses Node.js 20, which GitHub is deprecating (June 2026 forced migration, Sept 2026 removal)
- Upstream has an open PR (softprops/action-gh-release#670) for native Node 24 support but it hasn't merged yet

Closes #300.

## Test plan
- [x] Workflow YAML is valid
- [ ] Next release tag push will confirm the action runs without deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)