### PR TITLE
Feat: Add delete conversation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ On first launch, the setup wizard guides you through locating signal-cli, enteri
 ## Configuration
 
 Config is loaded from:
+
 - **Linux/macOS:** `~/.config/siggy/config.toml`
 - **Windows:** `%APPDATA%\siggy\config.toml`
 
@@ -117,6 +118,7 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 - **Reply / quote** -- Press `q` on a focused message to reply with quoted context
 - **Edit messages** -- Press `e` to edit your own sent messages
 - **Delete messages** -- Press `d` to delete locally or remotely (for your own messages)
+- **Delete conversations** -- Use `/delete` to remove the current conversation
 - **Message search** -- `/search <query>` with `n`/`N` to jump between results
 - **@mentions** -- Type `@` in group chats to mention members with autocomplete
 - **Message selection** -- Focused message highlight when scrolling; `J`/`K` to jump between messages
@@ -138,24 +140,25 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 
 ## Commands
 
-| Command | Alias | Description |
-|---|---|---|
-| `/join <name>` | `/j` | Switch to a conversation by contact name, number, or group |
-| `/part` | `/p` | Leave current conversation |
-| `/attach` | `/a` | Open file browser to attach a file |
-| `/search <query>` | `/s` | Search messages in current (or all) conversations |
-| `/sidebar` | `/sb` | Toggle sidebar visibility |
-| `/bell [type]` | `/notify` | Toggle notifications (`direct`, `group`, or both) |
-| `/mute` | | Mute/unmute current conversation |
-| `/block` | | Block current contact or group |
-| `/unblock` | | Unblock current contact or group |
-| `/disappearing <dur>` | `/dm` | Set disappearing message timer (`off`, `30s`, `5m`, `1h`, `1d`, `1w`) |
-| `/group` | `/g` | Open group management menu |
-| `/theme` | `/t` | Open theme picker |
-| `/contacts` | `/c` | Browse synced contacts |
-| `/settings` | | Open settings overlay |
-| `/help` | `/h` | Show help overlay |
-| `/quit` | `/q` | Exit siggy |
+| Command               | Alias     | Description                                                           |
+| --------------------- | --------- | --------------------------------------------------------------------- |
+| `/join <name>`        | `/j`      | Switch to a conversation by contact name, number, or group            |
+| `/part`               | `/p`      | Leave current conversation                                            |
+| `/delete`             |           | Delete current conversation                                           |
+| `/attach`             | `/a`      | Open file browser to attach a file                                    |
+| `/search <query>`     | `/s`      | Search messages in current (or all) conversations                     |
+| `/sidebar`            | `/sb`     | Toggle sidebar visibility                                             |
+| `/bell [type]`        | `/notify` | Toggle notifications (`direct`, `group`, or both)                     |
+| `/mute`               |           | Mute/unmute current conversation                                      |
+| `/block`              |           | Block current contact or group                                        |
+| `/unblock`            |           | Unblock current contact or group                                      |
+| `/disappearing <dur>` | `/dm`     | Set disappearing message timer (`off`, `30s`, `5m`, `1h`, `1d`, `1w`) |
+| `/group`              | `/g`      | Open group management menu                                            |
+| `/theme`              | `/t`      | Open theme picker                                                     |
+| `/contacts`           | `/c`      | Browse synced contacts                                                |
+| `/settings`           |           | Open settings overlay                                                 |
+| `/help`               | `/h`      | Show help overlay                                                     |
+| `/quit`               | `/q`      | Exit siggy                                                            |
 
 Type `/` to open the autocomplete popup. Use `Tab` to complete, arrow keys to navigate.
 
@@ -167,50 +170,50 @@ The app uses vim-style modal editing with two modes: **Insert** (default) and **
 
 ### Global (both modes)
 
-| Key | Action |
-|---|---|
-| `Ctrl+C` | Quit |
-| `Tab` / `Shift+Tab` | Next / previous conversation |
-| `PgUp` / `PgDn` | Scroll messages (5 lines) |
-| `Ctrl+Left` / `Ctrl+Right` | Resize sidebar |
+| Key                        | Action                       |
+| -------------------------- | ---------------------------- |
+| `Ctrl+C`                   | Quit                         |
+| `Tab` / `Shift+Tab`        | Next / previous conversation |
+| `PgUp` / `PgDn`            | Scroll messages (5 lines)    |
+| `Ctrl+Left` / `Ctrl+Right` | Resize sidebar               |
 
 ### Normal mode
 
 Press `Esc` to enter Normal mode.
 
-| Key | Action |
-|---|---|
-| `j` / `k` | Scroll down / up 1 line |
-| `J` / `K` | Jump to previous / next message |
-| `Ctrl+D` / `Ctrl+U` | Scroll down / up half page |
-| `g` / `G` | Scroll to top / bottom |
-| `h` / `l` | Move cursor left / right |
-| `w` / `b` | Word forward / back |
-| `0` / `$` | Start / end of line |
-| `x` | Delete character at cursor |
-| `D` | Delete from cursor to end |
-| `y` / `Y` | Copy message body / full line |
-| `r` | React to focused message |
-| `q` | Reply / quote focused message |
-| `e` | Edit own sent message |
-| `d` | Delete message (local or remote) |
-| `n` / `N` | Jump to next / previous search match |
-| `i` | Enter Insert mode |
-| `a` | Enter Insert mode (cursor right 1) |
-| `I` / `A` | Enter Insert mode at start / end of line |
-| `o` | Enter Insert mode (clear buffer) |
-| `/` | Enter Insert mode with `/` pre-typed |
+| Key                 | Action                                   |
+| ------------------- | ---------------------------------------- |
+| `j` / `k`           | Scroll down / up 1 line                  |
+| `J` / `K`           | Jump to previous / next message          |
+| `Ctrl+D` / `Ctrl+U` | Scroll down / up half page               |
+| `g` / `G`           | Scroll to top / bottom                   |
+| `h` / `l`           | Move cursor left / right                 |
+| `w` / `b`           | Word forward / back                      |
+| `0` / `$`           | Start / end of line                      |
+| `x`                 | Delete character at cursor               |
+| `D`                 | Delete from cursor to end                |
+| `y` / `Y`           | Copy message body / full line            |
+| `r`                 | React to focused message                 |
+| `q`                 | Reply / quote focused message            |
+| `e`                 | Edit own sent message                    |
+| `d`                 | Delete message (local or remote)         |
+| `n` / `N`           | Jump to next / previous search match     |
+| `i`                 | Enter Insert mode                        |
+| `a`                 | Enter Insert mode (cursor right 1)       |
+| `I` / `A`           | Enter Insert mode at start / end of line |
+| `o`                 | Enter Insert mode (clear buffer)         |
+| `/`                 | Enter Insert mode with `/` pre-typed     |
 
 ### Insert mode (default)
 
-| Key | Action |
-|---|---|
-| `Esc` | Switch to Normal mode |
-| `Enter` | Send message / execute command |
-| `Backspace` / `Delete` | Delete characters |
-| `Up` / `Down` | Recall input history |
-| `Left` / `Right` | Move cursor |
-| `Home` / `End` | Jump to start / end of line |
+| Key                    | Action                         |
+| ---------------------- | ------------------------------ |
+| `Esc`                  | Switch to Normal mode          |
+| `Enter`                | Send message / execute command |
+| `Backspace` / `Delete` | Delete characters              |
+| `Up` / `Down`          | Recall input history           |
+| `Left` / `Right`       | Move cursor                    |
+| `Home` / `End`         | Jump to start / end of line    |
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ On first launch, the setup wizard guides you through locating signal-cli, enteri
 ## Configuration
 
 Config is loaded from:
-
 - **Linux/macOS:** `~/.config/siggy/config.toml`
 - **Windows:** `%APPDATA%\siggy\config.toml`
 
@@ -118,7 +117,7 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 - **Reply / quote** -- Press `q` on a focused message to reply with quoted context
 - **Edit messages** -- Press `e` to edit your own sent messages
 - **Delete messages** -- Press `d` to delete locally or remotely (for your own messages)
-- **Delete conversations** -- Use `/delete` to remove the current conversation
+- **Delete conversations** -- Use `/delete` to delete the current conversation locally
 - **Message search** -- `/search <query>` with `n`/`N` to jump between results
 - **@mentions** -- Type `@` in group chats to mention members with autocomplete
 - **Message selection** -- Focused message highlight when scrolling; `J`/`K` to jump between messages
@@ -140,25 +139,25 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 
 ## Commands
 
-| Command               | Alias     | Description                                                           |
-| --------------------- | --------- | --------------------------------------------------------------------- |
-| `/join <name>`        | `/j`      | Switch to a conversation by contact name, number, or group            |
-| `/part`               | `/p`      | Leave current conversation                                            |
-| `/delete`             |           | Delete current conversation                                           |
-| `/attach`             | `/a`      | Open file browser to attach a file                                    |
-| `/search <query>`     | `/s`      | Search messages in current (or all) conversations                     |
-| `/sidebar`            | `/sb`     | Toggle sidebar visibility                                             |
-| `/bell [type]`        | `/notify` | Toggle notifications (`direct`, `group`, or both)                     |
-| `/mute`               |           | Mute/unmute current conversation                                      |
-| `/block`              |           | Block current contact or group                                        |
-| `/unblock`            |           | Unblock current contact or group                                      |
-| `/disappearing <dur>` | `/dm`     | Set disappearing message timer (`off`, `30s`, `5m`, `1h`, `1d`, `1w`) |
-| `/group`              | `/g`      | Open group management menu                                            |
-| `/theme`              | `/t`      | Open theme picker                                                     |
-| `/contacts`           | `/c`      | Browse synced contacts                                                |
-| `/settings`           |           | Open settings overlay                                                 |
-| `/help`               | `/h`      | Show help overlay                                                     |
-| `/quit`               | `/q`      | Exit siggy                                                            |
+| Command | Alias | Description |
+|---|---|---|
+| `/join <name>` | `/j` | Switch to a conversation by contact name, number, or group |
+| `/part` | `/p` | Leave current conversation |
+| `/delete` | | Delete current conversation |
+| `/attach` | `/a` | Open file browser to attach a file |
+| `/search <query>` | `/s` | Search messages in current (or all) conversations |
+| `/sidebar` | `/sb` | Toggle sidebar visibility |
+| `/bell [type]` | `/notify` | Toggle notifications (`direct`, `group`, or both) |
+| `/mute` | | Mute/unmute current conversation |
+| `/block` | | Block current contact or group |
+| `/unblock` | | Unblock current contact or group |
+| `/disappearing <dur>` | `/dm` | Set disappearing message timer (`off`, `30s`, `5m`, `1h`, `1d`, `1w`) |
+| `/group` | `/g` | Open group management menu |
+| `/theme` | `/t` | Open theme picker |
+| `/contacts` | `/c` | Browse synced contacts |
+| `/settings` | | Open settings overlay |
+| `/help` | `/h` | Show help overlay |
+| `/quit` | `/q` | Exit siggy |
 
 Type `/` to open the autocomplete popup. Use `Tab` to complete, arrow keys to navigate.
 
@@ -170,50 +169,50 @@ The app uses vim-style modal editing with two modes: **Insert** (default) and **
 
 ### Global (both modes)
 
-| Key                        | Action                       |
-| -------------------------- | ---------------------------- |
-| `Ctrl+C`                   | Quit                         |
-| `Tab` / `Shift+Tab`        | Next / previous conversation |
-| `PgUp` / `PgDn`            | Scroll messages (5 lines)    |
-| `Ctrl+Left` / `Ctrl+Right` | Resize sidebar               |
+| Key | Action |
+|---|---|
+| `Ctrl+C` | Quit |
+| `Tab` / `Shift+Tab` | Next / previous conversation |
+| `PgUp` / `PgDn` | Scroll messages (5 lines) |
+| `Ctrl+Left` / `Ctrl+Right` | Resize sidebar |
 
 ### Normal mode
 
 Press `Esc` to enter Normal mode.
 
-| Key                 | Action                                   |
-| ------------------- | ---------------------------------------- |
-| `j` / `k`           | Scroll down / up 1 line                  |
-| `J` / `K`           | Jump to previous / next message          |
-| `Ctrl+D` / `Ctrl+U` | Scroll down / up half page               |
-| `g` / `G`           | Scroll to top / bottom                   |
-| `h` / `l`           | Move cursor left / right                 |
-| `w` / `b`           | Word forward / back                      |
-| `0` / `$`           | Start / end of line                      |
-| `x`                 | Delete character at cursor               |
-| `D`                 | Delete from cursor to end                |
-| `y` / `Y`           | Copy message body / full line            |
-| `r`                 | React to focused message                 |
-| `q`                 | Reply / quote focused message            |
-| `e`                 | Edit own sent message                    |
-| `d`                 | Delete message (local or remote)         |
-| `n` / `N`           | Jump to next / previous search match     |
-| `i`                 | Enter Insert mode                        |
-| `a`                 | Enter Insert mode (cursor right 1)       |
-| `I` / `A`           | Enter Insert mode at start / end of line |
-| `o`                 | Enter Insert mode (clear buffer)         |
-| `/`                 | Enter Insert mode with `/` pre-typed     |
+| Key | Action |
+|---|---|
+| `j` / `k` | Scroll down / up 1 line |
+| `J` / `K` | Jump to previous / next message |
+| `Ctrl+D` / `Ctrl+U` | Scroll down / up half page |
+| `g` / `G` | Scroll to top / bottom |
+| `h` / `l` | Move cursor left / right |
+| `w` / `b` | Word forward / back |
+| `0` / `$` | Start / end of line |
+| `x` | Delete character at cursor |
+| `D` | Delete from cursor to end |
+| `y` / `Y` | Copy message body / full line |
+| `r` | React to focused message |
+| `q` | Reply / quote focused message |
+| `e` | Edit own sent message |
+| `d` | Delete message (local or remote) |
+| `n` / `N` | Jump to next / previous search match |
+| `i` | Enter Insert mode |
+| `a` | Enter Insert mode (cursor right 1) |
+| `I` / `A` | Enter Insert mode at start / end of line |
+| `o` | Enter Insert mode (clear buffer) |
+| `/` | Enter Insert mode with `/` pre-typed |
 
 ### Insert mode (default)
 
-| Key                    | Action                         |
-| ---------------------- | ------------------------------ |
-| `Esc`                  | Switch to Normal mode          |
-| `Enter`                | Send message / execute command |
-| `Backspace` / `Delete` | Delete characters              |
-| `Up` / `Down`          | Recall input history           |
-| `Left` / `Right`       | Move cursor                    |
-| `Home` / `End`         | Jump to start / end of line    |
+| Key | Action |
+|---|---|
+| `Esc` | Switch to Normal mode |
+| `Enter` | Send message / execute command |
+| `Backspace` / `Delete` | Delete characters |
+| `Up` / `Down` | Recall input history |
+| `Left` / `Right` | Move cursor |
+| `Home` / `End` | Jump to start / end of line |
 
 ## Architecture
 

--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -8,6 +8,7 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 |---|---|---|---|
 | `/join` | `/j` | `<name>` | Switch to a conversation by contact name, number, or group |
 | `/part` | `/p` | | Leave current conversation |
+| `/delete` | | | Delete current conversation |
 | `/search` | `/s` | `<query>` | Search messages across all conversations |
 | `/attach` | `/a` | | Open file browser to attach a file |
 | `/paste` | `/pa` | | Paste from clipboard (text or image) |
@@ -73,6 +74,14 @@ complete the selection.
 ```
 /mute
 ```
+
+**Delete the current conversation:**
+```
+/delete
+```
+
+Deletes the conversation from Siggy locally. For pending message requests, this
+also sends Signal's request-delete response.
 
 **Search for a message:**
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -302,6 +302,8 @@ pub struct App {
     pub reply_target: Option<(String, String, i64)>,
     /// Delete confirmation overlay visible
     pub show_delete_confirm: bool,
+    /// Conversation delete confirmation overlay visible
+    pub show_conversation_delete_confirm: bool,
     /// Message being edited: (timestamp_ms, conv_id)
     pub editing_message: Option<(i64, String)>,
     /// Search overlay state
@@ -2522,6 +2524,7 @@ impl App {
             },
             reply_target: None,
             show_delete_confirm: false,
+            show_conversation_delete_confirm: false,
             editing_message: None,
             search: SearchState::default(),
             pending_typing_stop: None,
@@ -2959,6 +2962,10 @@ impl App {
         }
         if self.action_menu.show {
             let send = self.handle_action_menu_key(code);
+            return (true, send);
+        }
+        if self.show_conversation_delete_confirm {
+            let send = self.handle_conversation_delete_confirm_key(code);
             return (true, send);
         }
         if self.show_delete_confirm {
@@ -4070,6 +4077,21 @@ impl App {
         }
     }
 
+    /// Handle a key press in the conversation delete confirmation overlay.
+    pub fn handle_conversation_delete_confirm_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        match code {
+            KeyCode::Char('y') => {
+                self.show_conversation_delete_confirm = false;
+                self.delete_active_conversation()
+            }
+            KeyCode::Char('n') | KeyCode::Esc => {
+                self.show_conversation_delete_confirm = false;
+                None
+            }
+            _ => None,
+        }
+    }
+
     fn handle_edit_received(&mut self, conv_id: &str, target_timestamp: i64, new_body: &str) {
         if let Some(conv) = self.store.conversations.get_mut(conv_id) {
             if let Some(idx) = conv.find_msg_idx(target_timestamp) {
@@ -4985,7 +5007,11 @@ impl App {
                 self.update_status();
             }
             InputAction::DeleteConversation => {
-                return self.delete_active_conversation();
+                if self.active_conversation.is_some() {
+                    self.show_conversation_delete_confirm = true;
+                } else {
+                    self.status_message = "No active conversation to delete".to_string();
+                }
             }
             InputAction::Quit => {
                 if self.input_buffer.is_empty() || self.quit_confirm {
@@ -6114,6 +6140,7 @@ impl App {
             || self.action_menu.show
             || self.reactions.show_picker
             || self.emoji_picker.visible
+            || self.show_conversation_delete_confirm
             || self.show_delete_confirm
             || self.group_menu.state.is_some()
             || self.show_message_request
@@ -9417,6 +9444,10 @@ mod tests {
         assert!(app.has_overlay());
         app.emoji_picker.visible = false;
 
+        app.show_conversation_delete_confirm = true;
+        assert!(app.has_overlay());
+        app.show_conversation_delete_confirm = false;
+
         app.show_delete_confirm = true;
         assert!(app.has_overlay());
         app.show_delete_confirm = false;
@@ -9494,6 +9525,48 @@ mod tests {
         app.handle_normal_key(KeyModifiers::NONE, KeyCode::Char('d'));
         assert_eq!(app.pending_normal_key, None);
         assert!(app.show_delete_confirm);
+    }
+
+    #[rstest]
+    fn slash_delete_shows_conversation_delete_confirm(mut app: App) {
+        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.input_buffer = "/delete".to_string();
+
+        let req = app.handle_input();
+
+        assert!(req.is_none());
+        assert!(app.show_conversation_delete_confirm);
+        assert!(app.active_conversation.is_some());
+        assert!(app.store.conversations.contains_key("+1"));
+    }
+
+    #[rstest]
+    fn conversation_delete_confirm_yes_deletes_conversation(mut app: App) {
+        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.show_conversation_delete_confirm = true;
+
+        let req = app.handle_overlay_key(KeyCode::Char('y')).1;
+
+        assert!(req.is_none());
+        assert!(!app.show_conversation_delete_confirm);
+        assert_eq!(app.active_conversation, None);
+        assert!(!app.store.conversations.contains_key("+1"));
+    }
+
+    #[rstest]
+    fn conversation_delete_confirm_cancel_keeps_conversation(mut app: App) {
+        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.show_conversation_delete_confirm = true;
+
+        let req = app.handle_overlay_key(KeyCode::Char('n')).1;
+
+        assert!(req.is_none());
+        assert!(!app.show_conversation_delete_confirm);
+        assert_eq!(app.active_conversation.as_deref(), Some("+1"));
+        assert!(app.store.conversations.contains_key("+1"));
     }
 
     #[rstest]

--- a/src/app.rs
+++ b/src/app.rs
@@ -4984,6 +4984,9 @@ impl App {
                 self.reset_typing_with_stop();
                 self.update_status();
             }
+            InputAction::DeleteConversation => {
+                return self.delete_active_conversation();
+            }
             InputAction::Quit => {
                 if self.input_buffer.is_empty() || self.quit_confirm {
                     self.should_quit = true;
@@ -5845,6 +5848,60 @@ impl App {
             self.update_status();
         } else {
             self.status_message = format!("Conversation not found: {target}");
+        }
+    }
+
+    fn delete_active_conversation(&mut self) -> Option<SendRequest> {
+        let conv_id = match self.active_conversation.clone() {
+            Some(id) => id,
+            None => {
+                self.status_message = "No active conversation to delete".to_string();
+                return None;
+            }
+        };
+
+        let (name, is_group, accepted) = match self.store.conversations.get(&conv_id) {
+            Some(conv) => (conv.name.clone(), conv.is_group, conv.accepted),
+            None => {
+                self.status_message = "Active conversation no longer exists".to_string();
+                self.active_conversation = None;
+                return None;
+            }
+        };
+
+        self.store.conversations.remove(&conv_id);
+        self.store.conversation_order.retain(|id| id != &conv_id);
+        self.store.last_read_index.remove(&conv_id);
+        self.store.has_more_messages.remove(&conv_id);
+        self.store.groups.remove(&conv_id);
+        self.scroll_positions.remove(&conv_id);
+        self.muted_conversations.remove(&conv_id);
+        self.blocked_conversations.remove(&conv_id);
+        self.db_warn_visible(self.db.delete_conversation(&conv_id), "delete_conversation");
+
+        self.active_conversation = None;
+        self.scroll_offset = 0;
+        self.focused_msg_index = None;
+        self.pending_attachment = None;
+        self.reply_target = None;
+        self.editing_message = None;
+        self.show_message_request = false;
+        self.reset_typing_with_stop();
+        self.clear_kitty_placements();
+        if self.sidebar_filter_active {
+            self.refresh_sidebar_filter();
+        }
+
+        self.status_message = format!("Deleted conversation \"{name}\"");
+
+        if !accepted {
+            Some(SendRequest::MessageRequestResponse {
+                recipient: conv_id,
+                is_group,
+                response_type: "delete".to_string(),
+            })
+        } else {
+            None
         }
     }
 
@@ -8478,6 +8535,66 @@ mod tests {
         app.input_cursor = 5;
         app.handle_input();
         assert!(app.pending_attachment.is_none());
+    }
+
+    #[rstest]
+    fn delete_command_removes_active_conversation(mut app: App) {
+        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.scroll_positions.insert("+1".to_string(), (3, Some(0)));
+        app.store.last_read_index.insert("+1".to_string(), 1);
+        app.store.has_more_messages.insert("+1".to_string());
+        app.db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello world", false, None, 1000).unwrap();
+        app.input_buffer = "/delete".to_string();
+        app.input_cursor = 7;
+
+        let result = app.handle_input();
+
+        assert!(result.is_none());
+        assert!(!app.store.conversations.contains_key("+1"));
+        assert!(!app.store.conversation_order.iter().any(|id| id == "+1"));
+        assert!(!app.scroll_positions.contains_key("+1"));
+        assert!(!app.store.last_read_index.contains_key("+1"));
+        assert!(!app.store.has_more_messages.contains("+1"));
+        assert_eq!(app.active_conversation, None);
+        assert!(app.status_message.contains("Deleted conversation"));
+        assert!(app.db.load_messages_page("+1", 10, 0).unwrap().is_empty());
+    }
+
+    #[rstest]
+    fn delete_command_on_message_request_returns_remote_delete(mut app: App) {
+        app.store.get_or_create_conversation("+15550007777", "+15550007777", false, &app.db);
+        if let Some(conv) = app.store.conversations.get_mut("+15550007777") {
+            conv.accepted = false;
+        }
+        app.db.update_accepted("+15550007777", false).unwrap();
+        app.active_conversation = Some("+15550007777".to_string());
+        app.input_buffer = "/delete".to_string();
+        app.input_cursor = 7;
+
+        let result = app.handle_input();
+
+        match result {
+            Some(SendRequest::MessageRequestResponse { recipient, is_group, response_type }) => {
+                assert_eq!(recipient, "+15550007777");
+                assert!(!is_group);
+                assert_eq!(response_type, "delete");
+            }
+            _ => panic!("expected message request delete send request"),
+        }
+        assert!(!app.store.conversations.contains_key("+15550007777"));
+        assert_eq!(app.active_conversation, None);
+    }
+
+    #[rstest]
+    fn delete_command_without_active_conversation_sets_error(mut app: App) {
+        app.input_buffer = "/delete".to_string();
+        app.input_cursor = 7;
+
+        let result = app.handle_input();
+
+        assert!(result.is_none());
+        assert!(app.status_message.contains("No active conversation"));
     }
 
     #[rstest]

--- a/src/input.rs
+++ b/src/input.rs
@@ -9,6 +9,7 @@ pub struct CommandInfo {
 pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo { name: "/join",     alias: "/j",  args: "<name>",  description: "Switch to a conversation" },
     CommandInfo { name: "/part",     alias: "/p",  args: "",        description: "Leave current conversation" },
+    CommandInfo { name: "/delete",   alias: "",    args: "",        description: "Delete current conversation" },
     CommandInfo { name: "/sidebar",  alias: "/sb", args: "",        description: "Toggle sidebar" },
     CommandInfo { name: "/bell",     alias: "",    args: "[type]",  description: "Toggle notifications (direct/group)" },
     CommandInfo { name: "/mute",     alias: "",    args: "",        description: "Mute/unmute current chat" },
@@ -42,6 +43,8 @@ pub enum InputAction {
     Join(String),
     /// Leave current conversation (go back to no selection)
     Part,
+    /// Delete the current conversation
+    DeleteConversation,
     /// Quit the application
     Quit,
     /// Toggle sidebar visibility
@@ -118,6 +121,7 @@ pub fn parse_input(input: &str) -> InputAction {
             }
         }
         "/part" | "/p" => InputAction::Part,
+        "/delete" => InputAction::DeleteConversation,
         "/quit" | "/q" => InputAction::Quit,
         "/sidebar" | "/sb" => InputAction::ToggleSidebar,
         "/bell" | "/notify" => {
@@ -315,11 +319,12 @@ mod tests {
     use super::*;
     use rstest::rstest;
 
-    // --- No-arg commands: 19 cases → 1 parameterized test ---
+    // --- No-arg commands: 30 cases → 1 parameterized test ---
 
     #[rstest]
     #[case("/part", InputAction::Part)]
     #[case("/p", InputAction::Part)]
+    #[case("/delete", InputAction::DeleteConversation)]
     #[case("/quit", InputAction::Quit)]
     #[case("/q", InputAction::Quit)]
     #[case("/sidebar", InputAction::ToggleSidebar)]

--- a/src/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
@@ -7,9 +7,10 @@ expression: output
   • ##Family (2)     │││  Commands                                          │                      │
   • Carol (1)        │││  /join <name>        Switch to a conversation      │                      │
     ##Rust Devs      │││  /part               Leave current conversation    │                      │
-    Bob              │││  /attach             Attach a file                 │ run                  │
-▸   Alice            │││  /search <query>     Search messages               │d before 7            │
-    Dave             │││  /sidebar            Toggle sidebar visibility     │habit                 │
+    Bob              │││  /delete             Delete current conversation   │ run                  │
+▸   Alice            │││  /attach             Attach a file                 │d before 7            │
+    Dave             │││  /search <query>     Search messages               │habit                 │
+                     │││  /sidebar            Toggle sidebar visibility     │                      │
                      │││  /bell [type]        Toggle notifications          │                      │
                      │││  /mute               Mute/unmute conversation      │matic                 │
                      │││  /contacts           Browse contacts               │                      │

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -589,6 +589,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         draw_emoji_picker(frame, app, size);
     }
 
+    // Conversation delete confirmation overlay
+    if app.show_conversation_delete_confirm {
+        draw_conversation_delete_confirm(frame, app, size);
+    }
+
     // Delete confirmation overlay
     if app.show_delete_confirm {
         draw_delete_confirm(frame, app, size);
@@ -1943,6 +1948,23 @@ fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             format!("  {prompt}"),
+            Style::default().fg(theme.fg),
+        )),
+    ];
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_conversation_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let (popup_area, block) = centered_popup(
+        frame, area, 50, 5, " Delete Conversation ", theme,
+    );
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Delete conversation locally? (y)es / (n)o",
             Style::default().fg(theme.fg),
         )),
     ];
@@ -4301,6 +4323,15 @@ mod snapshot_tests {
         app.show_help = true;
         let output = render_to_string(&mut app, 100, 30);
         insta::assert_snapshot!(output);
+    }
+
+    #[test]
+    fn test_conversation_delete_confirm_overlay() {
+        let mut app = demo_app();
+        app.show_conversation_delete_confirm = true;
+        let output = render_to_string(&mut app, 100, 30);
+        assert!(output.contains("Delete Conversation"));
+        assert!(output.contains("Delete conversation locally? (y)es / (n)o"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2563,6 +2563,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
     let commands: &[(&str, &str)] = &[
         ("/join <name>", "Switch to a conversation"),
         ("/part", "Leave current conversation"),
+        ("/delete", "Delete current conversation"),
         ("/attach", "Attach a file"),
         ("/search <query>", "Search messages"),
         ("/sidebar", "Toggle sidebar visibility"),


### PR DESCRIPTION
## Summary

- Closes #311 
- Adds a `/delete` slash command to remove the active conversation from local
  state and the database.
- Adds a confirmation overlay to prevent accidental conversation deletion.
- Updates help text, docs, and tests for the new command flow.

## Test plan

- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes
- [x] Tested manually in the TUI

Drafted with codex + gpt-5.4, then reviewed and validated by @jackplus-xyz