### PR TITLE
Align native image placement with Paragraph's actual word wrap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["signal", "tui", "terminal", "messenger", "ratatui"]
 categories = ["command-line-utilities"]
 
 [dependencies]
-ratatui = "0.30"
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = "0.29"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1215,11 +1215,19 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         }
     }
 
-    // Compute actual content height accounting for line wrapping
-    let content_height: usize = lines.iter().map(|line| {
-        let w = line.width();
-        if w == 0 { 1 } else { w.div_ceil(inner_width.max(1)) }
-    }).sum();
+    // Compute actual content height using ratatui's word-wrap algorithm so that
+    // image-position calculations below align with how the Paragraph widget
+    // actually renders. A character-based div_ceil approximation diverges from
+    // WordWrapper on realistic text and shifts Kitty placeholder cells off their
+    // halfblock origins, which caused images to clip into neighboring messages.
+    let inner_w_u16 = inner.width.max(1);
+    let line_heights: Vec<usize> = lines.iter().map(|line| {
+        Paragraph::new(line.clone())
+            .wrap(Wrap { trim: false })
+            .line_count(inner_w_u16)
+            .max(1)
+    }).collect();
+    let content_height: usize = line_heights.iter().sum();
 
     // Bottom-align by default; scroll_offset shifts the view upward
     let base_scroll = content_height.saturating_sub(available_height);
@@ -1243,13 +1251,10 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     if app.mode == InputMode::Normal && (app.scroll_offset > 0 || app.focused_msg_index.is_some()) {
         if let Some(fi) = app.focused_msg_index {
             // J/K already set focused_msg_index — ensure it's visible by adjusting scroll.
-            let iw = inner_width.max(1);
             let mut msg_start: Option<usize> = None;
             let mut msg_end = 0usize;
             let mut cumul = 0usize;
-            for (idx, line) in lines.iter().enumerate() {
-                let w = line.width();
-                let h = if w == 0 { 1 } else { w.div_ceil(iw) };
+            for (idx, &h) in line_heights.iter().enumerate() {
                 if line_msg_idx.get(idx) == Some(&Some(fi)) {
                     if msg_start.is_none() {
                         msg_start = Some(cumul);
@@ -1284,13 +1289,13 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Compute screen positions for native protocol image overlay (before lines is consumed)
     if !image_records.is_empty() {
-        // Build cumulative wrapped-line positions
+        // Build cumulative wrapped-line positions from the pre-computed heights so
+        // that image placements line up exactly with Paragraph's rendered rows.
         let mut wrapped_positions: Vec<usize> = Vec::with_capacity(lines.len() + 1);
         let mut cumulative = 0usize;
-        for line in &lines {
+        for &h in &line_heights {
             wrapped_positions.push(cumulative);
-            let w = line.width();
-            cumulative += if w == 0 { 1 } else { w.div_ceil(inner_width.max(1)) };
+            cumulative += h;
         }
 
         for (first_idx, count, path) in &image_records {


### PR DESCRIPTION
## Summary
- Fixes native image clipping/positioning: halfblock art visible underneath Kitty-rendered images, images drifting into neighboring messages
- Root cause: `div_ceil(line.width(), inner_width)` char-wrap approximation disagrees with `Paragraph::wrap`'s WordWrapper. For realistic message text, the two can differ by several rows, which shifts where the Kitty Unicode Placeholder cells get patched relative to where Paragraph actually drew the halfblock source
- Fix: switch to `Paragraph::line_count` (requires `unstable-rendered-line-info` feature on ratatui 0.30) and pre-compute a `line_heights` Vec once per frame for reuse in `content_height`, focused-message scroll-into-view, and image position lookup

## Evidence of the mismatch
Quick probe against ratatui 0.30:

| text                                   | width | `div_ceil`  | Paragraph rows |
|----------------------------------------|-------|-------------|----------------|
| `one two three four five`              | 12    | 2           | 3              |
| `Lorem ipsum dolor sit amet, ...`      | 15    | 4           | 5              |
| `aaaaaaaaaa bbbbbbbbbb cccccccccc`     | 10    | 4           | 3              |

Any divergence shifts the halfblock-origin y-coordinate by that many rows, which is exactly the user-visible drift.

## Test plan
- [x] `cargo clippy --tests -- -D warnings` clean
- [x] `cargo test --release` (619 tests) pass including UI snapshot tests
- [ ] Manual: scroll through a conversation with native images in Ghostty/Kitty — confirm halfblock bleed-through is gone and images align with their message

🤖 Generated with [Claude Code](https://claude.com/claude-code)