### PR TITLE
chore: bump action-gh-release to v3, remove Node 24 workaround

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,9 +86,7 @@ jobs:
           merge-multiple: true
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        env:
-          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: siggy-*


### PR DESCRIPTION
## Summary

- Bumps \`softprops/action-gh-release\` from v2 to v3.
- Removes the \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true\` env var added in #308. v3 moves the action runtime to Node 24 natively, making the workaround redundant.
- Combined here (rather than letting dependabot's #320 handle just the bump) so the now-dead env var doesn't linger.

## Test plan

- [ ] CI passes
- [x] Release workflow only triggers on tag push, so no runtime verification until next release. The v3 changelog confirms no other breaking changes - same inputs/outputs as v2, just a runtime bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)