### PR TITLE
chore: pin Rust toolchain to 1.95.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,17 @@ Use prefixed names: `feature/`, `fix/`, `refactor/`, `docs/` (e.g. `feature/dark
 
 Trivial docs-only changes (CLAUDE.md tweaks, typo fixes) may be committed directly to master. All code changes must go through a PR.
 
+## Toolchain
+
+The Rust toolchain is pinned in `rust-toolchain.toml` to keep CI deterministic - a new stable Rust release cannot break CI without a PR.
+
+### Updating the pin
+
+1. Read the [Rust release blog](https://blog.rust-lang.org/) for the new version.
+2. Bump `channel` in `rust-toolchain.toml`.
+3. Run `cargo clippy --tests -- -D warnings` locally; fix any new lints.
+4. Open a PR. CI will run against the new pin.
+
 ## Releases
 
 CI runs automatically on every push/PR (`.github/workflows/ci.yml`). Releases are triggered by pushing a version tag.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- Adds \`rust-toolchain.toml\` pinning stable to 1.95.0.
- Adds a "Toolchain" section to CLAUDE.md describing the bump workflow.
- Prevents a repeat of the April 11-19 outage where Rust 1.95's new clippy lints broke CI without any code change.

See \`docs/superpowers/specs/2026-04-19-repo-hygiene-design.md\`.

## Test plan

- [x] \`cargo clippy --tests -- -D warnings\` passes locally against pinned toolchain.
- [x] \`cargo test\` passes (472 tests).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)