### PR TITLE
chore: enforce cargo fmt in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Format check
+        run: cargo fmt --check
+
       - name: Clippy
         run: cargo clippy --tests -- -D warnings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,19 +7,28 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Instant;
 
-use crate::autocomplete::AutocompleteState;
 pub use crate::autocomplete::AutocompleteMode;
-use crate::conversation_store::{ConversationStore, db_warn, short_name};
+use crate::autocomplete::AutocompleteState;
+use crate::conversation_store::{db_warn, short_name, ConversationStore};
 pub use crate::conversation_store::{Conversation, DisplayMessage, Quote};
 use crate::db::Database;
+use crate::domain::{
+    ActionMenuState, ContactsOverlayState, EmojiPickerAction, EmojiPickerSource, EmojiPickerState,
+    FilePickerState, ForwardOverlayState, GroupMenuOverlayState, ImageState,
+    KeybindingsOverlayState, NotificationState, PinDurationOverlayState, PollVoteOverlayState,
+    ProfileOverlayState, ReactionState, SearchAction, SearchState, SettingsProfileOverlayState,
+    ThemePickerState, TypingState, VerifyOverlayState,
+};
 use crate::image_render;
-use crate::list_overlay::{self, classify_list_key, ListKeyAction};
-use crate::domain::{EmojiPickerAction, EmojiPickerSource, EmojiPickerState, ActionMenuState, ContactsOverlayState, FilePickerState, ForwardOverlayState, GroupMenuOverlayState, ImageState, KeybindingsOverlayState, NotificationState, PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState, ReactionState, SearchAction, SearchState, SettingsProfileOverlayState, ThemePickerState, TypingState, VerifyOverlayState};
 use crate::image_render::ImageProtocol;
 use crate::input::{self, InputAction, COMMANDS};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
+use crate::list_overlay::{self, classify_list_key, ListKeyAction};
+use crate::signal::types::{
+    Contact, Group, IdentityInfo, MessageStatus, PollData, PollOption, PollVote, Reaction,
+    SignalEvent, SignalMessage, StyleType, TrustLevel,
+};
 use crate::theme::{self, Theme};
-use crate::signal::types::{Contact, Group, IdentityInfo, MessageStatus, PollData, PollOption, PollVote, Reaction, SignalEvent, SignalMessage, StyleType, TrustLevel};
 
 /// Sentinel lifetime for paste temp files awaiting send confirmation from signal-cli.
 /// If signal-cli never confirms, the file is deleted after this many seconds.
@@ -30,22 +39,30 @@ const PASTE_CLEANUP_DELAY_SECS: u64 = 10;
 
 /// Find the byte position one character forward from `pos` in `buf`.
 fn next_char_pos(buf: &str, pos: usize) -> usize {
-    if pos >= buf.len() { return buf.len(); }
+    if pos >= buf.len() {
+        return buf.len();
+    }
     pos + buf[pos..].chars().next().map_or(1, |c| c.len_utf8())
 }
 
 /// Find the byte position one character backward from `pos` in `buf`.
 fn prev_char_pos(buf: &str, pos: usize) -> usize {
-    if pos == 0 { return 0; }
+    if pos == 0 {
+        return 0;
+    }
     pos - buf[..pos].chars().next_back().map_or(1, |c| c.len_utf8())
 }
 
 /// Snap a byte position to the nearest valid char boundary at or before `pos`.
 fn floor_char_boundary(buf: &str, pos: usize) -> usize {
     let pos = pos.min(buf.len());
-    if buf.is_char_boundary(pos) { return pos; }
+    if buf.is_char_boundary(pos) {
+        return pos;
+    }
     let mut p = pos;
-    while p > 0 && !buf.is_char_boundary(p) { p -= 1; }
+    while p > 0 && !buf.is_char_boundary(p) {
+        p -= 1;
+    }
     p
 }
 
@@ -60,7 +77,13 @@ impl App {
 }
 
 /// Fire an OS-level desktop notification (runs on a blocking thread to avoid stalling async).
-fn show_desktop_notification(sender: &str, body: &str, is_group: bool, group_name: Option<&str>, preview_level: &str) {
+fn show_desktop_notification(
+    sender: &str,
+    body: &str,
+    is_group: bool,
+    group_name: Option<&str>,
+    preview_level: &str,
+) {
     let (title, preview) = match preview_level {
         "minimal" => ("New message".to_string(), String::new()),
         "sender" => {
@@ -133,13 +156,13 @@ pub enum InputMode {
 /// Which sub-overlay of the /group menu is currently active.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GroupMenuState {
-    Menu,           // top-level flyout
-    Members,        // read-only member list
-    AddMember,      // contact picker (type-to-filter)
-    RemoveMember,   // member picker (type-to-filter)
-    Rename,         // text input (pre-filled)
-    Create,         // text input (empty)
-    LeaveConfirm,   // y/n confirmation
+    Menu,         // top-level flyout
+    Members,      // read-only member list
+    AddMember,    // contact picker (type-to-filter)
+    RemoveMember, // member picker (type-to-filter)
+    Rename,       // text input (pre-filled)
+    Create,       // text input (empty)
+    LeaveConfirm, // y/n confirmation
 }
 
 /// An action available in the message action menu.
@@ -327,7 +350,7 @@ pub struct App {
     pub jump_stack: Vec<(usize, Option<usize>)>,
     /// Reaction display preferences and picker overlay state
     pub reactions: ReactionState,
-        /// Emoji picker overlay state
+    /// Emoji picker overlay state
     pub emoji_picker: EmojiPickerState,
     /// Demo mode — prevents config writes
     pub is_demo: bool,
@@ -401,7 +424,16 @@ pub struct App {
     pub sync: SyncState,
 }
 
-pub const QUICK_REACTIONS: &[&str] = &["\u{1f44d}", "\u{1f44e}", "\u{2764}\u{fe0f}", "\u{1f602}", "\u{1f62e}", "\u{1f622}", "\u{1f64f}", "\u{1f525}"];
+pub const QUICK_REACTIONS: &[&str] = &[
+    "\u{1f44d}",
+    "\u{1f44e}",
+    "\u{2764}\u{fe0f}",
+    "\u{1f602}",
+    "\u{1f62e}",
+    "\u{1f622}",
+    "\u{1f64f}",
+    "\u{1f525}",
+];
 
 pub const PIN_DURATIONS: &[(i64, &str)] = &[
     (-1, "Forever"),
@@ -684,7 +716,9 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.mouse_enabled,
         set: |a, v| a.mouse_enabled = v,
         save: Some(|c, v| c.mouse_enabled = v),
-        on_toggle: Some(|a| { a.pending_mouse_toggle = Some(a.mouse_enabled); }),
+        on_toggle: Some(|a| {
+            a.pending_mouse_toggle = Some(a.mouse_enabled);
+        }),
     },
     SettingDef {
         label: "Sidebar on right",
@@ -761,12 +795,14 @@ impl App {
                             conv.messages[idx].preview_image_path = Some(p);
                         }
                     } else {
-                        conv.messages[idx].image_lines =
-                            Some(result.lines.unwrap_or_default());
+                        conv.messages[idx].image_lines = Some(result.lines.unwrap_or_default());
                     }
                     // Pre-populate native image caches from background task
                     if let Some((path, b64, pw, ph)) = result.pre_native_png {
-                        self.image.native_image_cache.entry(path).or_insert((b64, pw, ph));
+                        self.image
+                            .native_image_cache
+                            .entry(path)
+                            .or_insert((b64, pw, ph));
                     }
                     if let Some((path, sixel)) = result.pre_sixel {
                         self.image.sixel_cache.entry(path).or_insert(sixel);
@@ -779,14 +815,20 @@ impl App {
         if self.image.image_mode == "none" {
             return drained;
         }
-        let Some(ref id) = self.active_conversation else { return drained };
+        let Some(ref id) = self.active_conversation else {
+            return drained;
+        };
         let id = id.clone();
-        let Some(conv) = self.store.conversations.get(&id) else { return drained };
+        let Some(conv) = self.store.conversations.get(&id) else {
+            return drained;
+        };
         let len = conv.messages.len();
         if len == 0 {
             return drained;
         }
-        let end = len.saturating_sub(self.scroll_offset.saturating_sub(5)).min(len);
+        let end = len
+            .saturating_sub(self.scroll_offset.saturating_sub(5))
+            .min(len);
         let start = end.saturating_sub(60);
 
         // Collect work items to avoid borrow conflicts: (timestamp, path, max_width, is_preview)
@@ -820,7 +862,8 @@ impl App {
         let is_sixel = self.image.image_protocol == image_render::ImageProtocol::Sixel;
         let cell_px = self.image.cell_px;
         for (ts, path, max_width, is_preview) in work {
-            self.image.image_render_in_flight
+            self.image
+                .image_render_in_flight
                 .insert((id.clone(), ts, is_preview));
             let tx = self.image.image_render_tx.clone();
             let cid = id.clone();
@@ -831,20 +874,21 @@ impl App {
                 // so caches are populated before the image first appears in the viewport.
                 // Without this, Kitty/iTerm2 would encode synchronously on first scroll-in.
                 let (pre_native_png, pre_sixel) = if is_native {
-                    let cell_w = lines.as_ref()
+                    let cell_w = lines
+                        .as_ref()
                         .and_then(|l| l.first())
                         .map(|l| l.width().saturating_sub(2) as u32)
                         .unwrap_or(0);
                     let cell_h = lines.as_ref().map(|l| l.len() as u32).unwrap_or(0);
                     if cell_w > 0 && cell_h > 0 {
-                        let png = image_render::encode_native_png(
-                            Path::new(&path), cell_w, cell_h,
-                        );
+                        let png = image_render::encode_native_png(Path::new(&path), cell_w, cell_h);
                         let sixel = if is_sixel {
                             png.as_ref().and_then(|p| {
                                 image_render::encode_sixel(
                                     &p.0,
-                                    cell_w as u16, cell_h as u16, cell_px,
+                                    cell_w as u16,
+                                    cell_h as u16,
+                                    cell_px,
                                 )
                             })
                         } else {
@@ -884,26 +928,26 @@ impl App {
         let customize_index = SETTINGS.len() + 2;
 
         // Find current position in visual order
-        let visual_pos = SETTINGS_VISUAL_ORDER.iter()
+        let visual_pos = SETTINGS_VISUAL_ORDER
+            .iter()
             .position(|&i| i == self.settings_index)
             .unwrap_or(0);
 
         match code {
-            KeyCode::Char('j') | KeyCode::Down
-                if visual_pos + 1 < SETTINGS_VISUAL_ORDER.len() => {
-                    self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
-                }
-            KeyCode::Char('k') | KeyCode::Up
-                if visual_pos > 0 => {
-                    self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
-                }
+            KeyCode::Char('j') | KeyCode::Down if visual_pos + 1 < SETTINGS_VISUAL_ORDER.len() => {
+                self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
+            }
+            KeyCode::Char('k') | KeyCode::Up if visual_pos > 0 => {
+                self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
+            }
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
                 if self.settings_index == preview_index {
-                    self.notifications.notification_preview = match self.notifications.notification_preview.as_str() {
-                        "full" => "sender".to_string(),
-                        "sender" => "minimal".to_string(),
-                        _ => "full".to_string(),
-                    };
+                    self.notifications.notification_preview =
+                        match self.notifications.notification_preview.as_str() {
+                            "full" => "sender".to_string(),
+                            "sender" => "minimal".to_string(),
+                            _ => "full".to_string(),
+                        };
                 } else if self.settings_index == image_mode_index {
                     self.image.image_mode = match self.image.image_mode.as_str() {
                         "native" => "halfblock".to_string(),
@@ -930,10 +974,9 @@ impl App {
     pub fn handle_customize_key(&mut self, code: KeyCode) {
         const ITEMS: usize = 3; // Theme, Keybindings, Profile
         match code {
-            KeyCode::Char('j') | KeyCode::Down
-                if self.customize_index + 1 < ITEMS => {
-                    self.customize_index += 1;
-                }
+            KeyCode::Char('j') | KeyCode::Down if self.customize_index + 1 < ITEMS => {
+                self.customize_index += 1;
+            }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.customize_index = self.customize_index.saturating_sub(1);
             }
@@ -944,7 +987,10 @@ impl App {
                 match self.customize_index {
                     0 => {
                         self.theme_picker.show = true;
-                        self.theme_picker.index = self.theme_picker.available_themes.iter()
+                        self.theme_picker.index = self
+                            .theme_picker
+                            .available_themes
+                            .iter()
                             .position(|t| t.name == self.theme.name)
                             .unwrap_or(0);
                     }
@@ -967,7 +1013,10 @@ impl App {
 
     /// Apply a profile without firing expensive hooks (image re-rendering).
     /// Hooks fire when the overlay closes (settings or profile manager Esc handler).
-    fn apply_settings_profile_deferred(&mut self, profile: &crate::settings_profile::SettingsProfile) {
+    fn apply_settings_profile_deferred(
+        &mut self,
+        profile: &crate::settings_profile::SettingsProfile,
+    ) {
         profile.apply_to(self);
         self.settings_profiles.name = profile.name.clone();
     }
@@ -982,7 +1031,10 @@ impl App {
     /// Open the settings profile manager overlay.
     fn open_settings_profile_manager(&mut self) {
         self.settings_profiles.available = crate::settings_profile::all_settings_profiles();
-        self.settings_profiles.index = self.settings_profiles.available.iter()
+        self.settings_profiles.index = self
+            .settings_profiles
+            .available
+            .iter()
             .position(|p| p.name == self.settings_profiles.name)
             .unwrap_or(0);
         self.settings_profiles.show = true;
@@ -1003,12 +1055,17 @@ impl App {
                     } else if crate::settings_profile::is_builtin(&name) {
                         self.status_message = "Cannot overwrite built-in profile".to_string();
                     } else {
-                        let profile = crate::settings_profile::SettingsProfile::from_app(self, name.clone());
+                        let profile =
+                            crate::settings_profile::SettingsProfile::from_app(self, name.clone());
                         match crate::settings_profile::save_custom_profile(&profile) {
                             Ok(()) => {
                                 self.settings_profiles.name = name;
-                                self.settings_profiles.available = crate::settings_profile::all_settings_profiles();
-                                self.settings_profiles.index = self.settings_profiles.available.iter()
+                                self.settings_profiles.available =
+                                    crate::settings_profile::all_settings_profiles();
+                                self.settings_profiles.index = self
+                                    .settings_profiles
+                                    .available
+                                    .iter()
                                     .position(|p| p.name == self.settings_profiles.name)
                                     .unwrap_or(0);
                                 self.save_settings();
@@ -1027,10 +1084,9 @@ impl App {
                 KeyCode::Backspace => {
                     self.settings_profiles.save_as_input.pop();
                 }
-                KeyCode::Char(c)
-                    if self.settings_profiles.save_as_input.len() < 30 => {
-                        self.settings_profiles.save_as_input.push(c);
-                    }
+                KeyCode::Char(c) if self.settings_profiles.save_as_input.len() < 30 => {
+                    self.settings_profiles.save_as_input.push(c);
+                }
                 _ => {}
             }
             return;
@@ -1039,15 +1095,22 @@ impl App {
         // List navigation mode
         match code {
             KeyCode::Char('j') | KeyCode::Down
-                if self.settings_profiles.index < self.settings_profiles.available.len().saturating_sub(1) => {
-                    self.settings_profiles.index += 1;
-                }
+                if self.settings_profiles.index
+                    < self.settings_profiles.available.len().saturating_sub(1) =>
+            {
+                self.settings_profiles.index += 1;
+            }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.settings_profiles.index = self.settings_profiles.index.saturating_sub(1);
             }
             KeyCode::Enter => {
                 // Load the selected profile (stay open for preview)
-                if let Some(profile) = self.settings_profiles.available.get(self.settings_profiles.index).cloned() {
+                if let Some(profile) = self
+                    .settings_profiles
+                    .available
+                    .get(self.settings_profiles.index)
+                    .cloned()
+                {
                     self.apply_settings_profile_deferred(&profile);
                     self.save_settings();
                     self.status_message = format!("Loaded profile: {}", profile.name);
@@ -1055,19 +1118,30 @@ impl App {
             }
             KeyCode::Char('s') => {
                 // Save over current custom profile (only if custom and settings differ)
-                if let Some(profile) = self.settings_profiles.available.get(self.settings_profiles.index) {
+                if let Some(profile) = self
+                    .settings_profiles
+                    .available
+                    .get(self.settings_profiles.index)
+                {
                     if crate::settings_profile::is_builtin(&profile.name) {
                         return;
                     }
                     if profile.matches_app(self) {
                         return;
                     }
-                    let updated = crate::settings_profile::SettingsProfile::from_app(self, profile.name.clone());
+                    let updated = crate::settings_profile::SettingsProfile::from_app(
+                        self,
+                        profile.name.clone(),
+                    );
                     match crate::settings_profile::save_custom_profile(&updated) {
                         Ok(()) => {
                             self.settings_profiles.name = updated.name.clone();
-                            self.settings_profiles.available = crate::settings_profile::all_settings_profiles();
-                            self.settings_profiles.index = self.settings_profiles.available.iter()
+                            self.settings_profiles.available =
+                                crate::settings_profile::all_settings_profiles();
+                            self.settings_profiles.index = self
+                                .settings_profiles
+                                .available
+                                .iter()
                                 .position(|p| p.name == self.settings_profiles.name)
                                 .unwrap_or(0);
                             self.save_settings();
@@ -1081,7 +1155,10 @@ impl App {
             }
             KeyCode::Char('S') => {
                 // Save-as: open name input
-                let has_changes = !self.settings_profiles.available.iter()
+                let has_changes = !self
+                    .settings_profiles
+                    .available
+                    .iter()
                     .any(|p| p.name == self.settings_profiles.name && p.matches_app(self));
                 if has_changes {
                     self.settings_profiles.save_as = true;
@@ -1090,7 +1167,11 @@ impl App {
             }
             KeyCode::Char('d') => {
                 // Delete custom profile
-                if let Some(profile) = self.settings_profiles.available.get(self.settings_profiles.index) {
+                if let Some(profile) = self
+                    .settings_profiles
+                    .available
+                    .get(self.settings_profiles.index)
+                {
                     if crate::settings_profile::is_builtin(&profile.name) {
                         return;
                     }
@@ -1100,9 +1181,13 @@ impl App {
                             if self.settings_profiles.name == name {
                                 self.settings_profiles.name = "Default".to_string();
                             }
-                            self.settings_profiles.available = crate::settings_profile::all_settings_profiles();
-                            if self.settings_profiles.index >= self.settings_profiles.available.len() {
-                                self.settings_profiles.index = self.settings_profiles.available.len().saturating_sub(1);
+                            self.settings_profiles.available =
+                                crate::settings_profile::all_settings_profiles();
+                            if self.settings_profiles.index
+                                >= self.settings_profiles.available.len()
+                            {
+                                self.settings_profiles.index =
+                                    self.settings_profiles.available.len().saturating_sub(1);
                             }
                             self.save_settings();
                             self.status_message = format!("Deleted profile: {name}");
@@ -1131,14 +1216,20 @@ impl App {
         };
         match classify_list_key(code, false) {
             ListKeyAction::Down
-                if self.theme_picker.index < self.theme_picker.available_themes.len().saturating_sub(1) => {
-                    self.theme_picker.index += 1;
-                }
+                if self.theme_picker.index
+                    < self.theme_picker.available_themes.len().saturating_sub(1) =>
+            {
+                self.theme_picker.index += 1;
+            }
             ListKeyAction::Up => {
                 self.theme_picker.index = self.theme_picker.index.saturating_sub(1);
             }
             ListKeyAction::Select => {
-                if let Some(selected) = self.theme_picker.available_themes.get(self.theme_picker.index) {
+                if let Some(selected) = self
+                    .theme_picker
+                    .available_themes
+                    .get(self.theme_picker.index)
+                {
                     self.theme = selected.clone();
                     self.save_settings();
                 }
@@ -1156,14 +1247,25 @@ impl App {
         if self.keybindings_overlay.profile_picker {
             match code {
                 KeyCode::Char('j') | KeyCode::Down
-                    if self.keybindings_overlay.profile_index < self.keybindings_overlay.available_profiles.len().saturating_sub(1) => {
-                        self.keybindings_overlay.profile_index += 1;
-                    }
+                    if self.keybindings_overlay.profile_index
+                        < self
+                            .keybindings_overlay
+                            .available_profiles
+                            .len()
+                            .saturating_sub(1) =>
+                {
+                    self.keybindings_overlay.profile_index += 1;
+                }
                 KeyCode::Char('k') | KeyCode::Up => {
-                    self.keybindings_overlay.profile_index = self.keybindings_overlay.profile_index.saturating_sub(1);
+                    self.keybindings_overlay.profile_index =
+                        self.keybindings_overlay.profile_index.saturating_sub(1);
                 }
                 KeyCode::Char(' ') | KeyCode::Enter => {
-                    if let Some(name) = self.keybindings_overlay.available_profiles.get(self.keybindings_overlay.profile_index) {
+                    if let Some(name) = self
+                        .keybindings_overlay
+                        .available_profiles
+                        .get(self.keybindings_overlay.profile_index)
+                    {
                         let mut kb = keybindings::find_profile(name);
                         let overrides = keybindings::load_overrides();
                         kb.apply_overrides(&overrides);
@@ -1184,11 +1286,15 @@ impl App {
             match code {
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     // Accept: the displaced action loses its binding
-                    self.status_message = format!("{} is now unbound", keybindings::action_label(displaced_action));
+                    self.status_message = format!(
+                        "{} is now unbound",
+                        keybindings::action_label(displaced_action)
+                    );
                 }
                 _ => {
                     // Undo the rebind — restore both
-                    let (mode, action) = self.keybindings_overlay_item(self.keybindings_overlay.index);
+                    let (mode, action) =
+                        self.keybindings_overlay_item(self.keybindings_overlay.index);
                     if let Some(action) = action {
                         self.keybindings.reset_action(mode, action);
                         self.keybindings.reset_action(mode, displaced_action);
@@ -1206,22 +1312,36 @@ impl App {
                     self.keybindings_overlay.index += 1;
                 }
                 // Skip section headers
-                while self.keybindings_overlay.index < total && self.keybindings_overlay_item(self.keybindings_overlay.index).1.is_none() {
+                while self.keybindings_overlay.index < total
+                    && self
+                        .keybindings_overlay_item(self.keybindings_overlay.index)
+                        .1
+                        .is_none()
+                {
                     self.keybindings_overlay.index += 1;
                 }
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.keybindings_overlay.index = self.keybindings_overlay.index.saturating_sub(1);
                 // Skip section headers (index 0 is the profile row — always selectable)
-                while self.keybindings_overlay.index > 0 && self.keybindings_overlay_item(self.keybindings_overlay.index).1.is_none() {
-                    self.keybindings_overlay.index = self.keybindings_overlay.index.saturating_sub(1);
+                while self.keybindings_overlay.index > 0
+                    && self
+                        .keybindings_overlay_item(self.keybindings_overlay.index)
+                        .1
+                        .is_none()
+                {
+                    self.keybindings_overlay.index =
+                        self.keybindings_overlay.index.saturating_sub(1);
                 }
             }
             KeyCode::Enter => {
                 if self.keybindings_overlay.index == 0 {
                     // Profile row → open profile picker
                     self.keybindings_overlay.profile_picker = true;
-                    self.keybindings_overlay.profile_index = self.keybindings_overlay.available_profiles.iter()
+                    self.keybindings_overlay.profile_index = self
+                        .keybindings_overlay
+                        .available_profiles
+                        .iter()
                         .position(|n| *n == self.keybindings.profile_name)
                         .unwrap_or(0);
                 } else {
@@ -1293,9 +1413,12 @@ impl App {
     /// Total number of rows in the keybindings overlay (profile + sections + actions).
     pub fn keybindings_overlay_total(&self) -> usize {
         // profile row + 3 section headers + action counts
-        1 + 1 + keybindings::GLOBAL_ACTIONS.len()
-          + 1 + keybindings::NORMAL_ACTIONS.len()
-          + 1 + keybindings::INSERT_ACTIONS.len()
+        1 + 1
+            + keybindings::GLOBAL_ACTIONS.len()
+            + 1
+            + keybindings::NORMAL_ACTIONS.len()
+            + 1
+            + keybindings::INSERT_ACTIONS.len()
     }
 
     /// Get the (mode, action) for a keybindings overlay row index.
@@ -1306,24 +1429,39 @@ impl App {
         }
         let mut i = 1;
         // Global section header
-        if index == i { return (BindingMode::Global, None); }
+        if index == i {
+            return (BindingMode::Global, None);
+        }
         i += 1;
         if index < i + keybindings::GLOBAL_ACTIONS.len() {
-            return (BindingMode::Global, Some(keybindings::GLOBAL_ACTIONS[index - i]));
+            return (
+                BindingMode::Global,
+                Some(keybindings::GLOBAL_ACTIONS[index - i]),
+            );
         }
         i += keybindings::GLOBAL_ACTIONS.len();
         // Normal section header
-        if index == i { return (BindingMode::Normal, None); }
+        if index == i {
+            return (BindingMode::Normal, None);
+        }
         i += 1;
         if index < i + keybindings::NORMAL_ACTIONS.len() {
-            return (BindingMode::Normal, Some(keybindings::NORMAL_ACTIONS[index - i]));
+            return (
+                BindingMode::Normal,
+                Some(keybindings::NORMAL_ACTIONS[index - i]),
+            );
         }
         i += keybindings::NORMAL_ACTIONS.len();
         // Insert section header
-        if index == i { return (BindingMode::Insert, None); }
+        if index == i {
+            return (BindingMode::Insert, None);
+        }
         i += 1;
         if index < i + keybindings::INSERT_ACTIONS.len() {
-            return (BindingMode::Insert, Some(keybindings::INSERT_ACTIONS[index - i]));
+            return (
+                BindingMode::Insert,
+                Some(keybindings::INSERT_ACTIONS[index - i]),
+            );
         }
         (BindingMode::Insert, None)
     }
@@ -1332,7 +1470,8 @@ impl App {
     pub fn refresh_contacts_filter(&mut self) {
         let filter_lower = self.contacts_overlay.filter.to_lowercase();
         let mut contacts: Vec<(String, String)> = self
-            .store.contact_names
+            .store
+            .contact_names
             .iter()
             .filter(|(_, name)| !name.is_empty())
             .filter(|(number, name)| {
@@ -1346,38 +1485,68 @@ impl App {
             .collect();
         contacts.sort_by_key(|a| a.1.to_lowercase());
         self.contacts_overlay.filtered = contacts;
-        list_overlay::clamp_index(&mut self.contacts_overlay.index, self.contacts_overlay.filtered.len());
+        list_overlay::clamp_index(
+            &mut self.contacts_overlay.index,
+            self.contacts_overlay.filtered.len(),
+        );
     }
 
     /// Build the list of available group menu actions (context-dependent).
     pub fn group_menu_items(&self) -> Vec<MenuAction> {
-        let is_group = self.active_conversation.as_ref()
+        let is_group = self
+            .active_conversation
+            .as_ref()
             .and_then(|id| self.store.conversations.get(id))
             .is_some_and(|c| c.is_group);
         if is_group {
             vec![
-                MenuAction { label: "Members",       key_hint: "m", nerd_icon: "\u{f0849}" },
-                MenuAction { label: "Add member",    key_hint: "a", nerd_icon: "\u{f0234}" },
-                MenuAction { label: "Remove member", key_hint: "r", nerd_icon: "\u{f0235}" },
-                MenuAction { label: "Rename",        key_hint: "n", nerd_icon: "\u{f03eb}" },
-                MenuAction { label: "Leave",         key_hint: "l", nerd_icon: "\u{f0a79}" },
+                MenuAction {
+                    label: "Members",
+                    key_hint: "m",
+                    nerd_icon: "\u{f0849}",
+                },
+                MenuAction {
+                    label: "Add member",
+                    key_hint: "a",
+                    nerd_icon: "\u{f0234}",
+                },
+                MenuAction {
+                    label: "Remove member",
+                    key_hint: "r",
+                    nerd_icon: "\u{f0235}",
+                },
+                MenuAction {
+                    label: "Rename",
+                    key_hint: "n",
+                    nerd_icon: "\u{f03eb}",
+                },
+                MenuAction {
+                    label: "Leave",
+                    key_hint: "l",
+                    nerd_icon: "\u{f0a79}",
+                },
             ]
         } else {
-            vec![
-                MenuAction { label: "Create group",  key_hint: "c", nerd_icon: "\u{f0234}" },
-            ]
+            vec![MenuAction {
+                label: "Create group",
+                key_hint: "c",
+                nerd_icon: "\u{f0234}",
+            }]
         }
     }
 
     /// Build filtered contacts list for the "Add member" picker (excludes existing group members).
     pub fn refresh_group_add_filter(&mut self) {
         let filter_lower = self.group_menu.filter.to_lowercase();
-        let existing_members: HashSet<&str> = self.active_conversation.as_ref()
+        let existing_members: HashSet<&str> = self
+            .active_conversation
+            .as_ref()
             .and_then(|id| self.store.groups.get(id))
             .map(|g| g.members.iter().map(|s| s.as_str()).collect())
             .unwrap_or_default();
         let mut contacts: Vec<(String, String)> = self
-            .store.contact_names
+            .store
+            .contact_names
             .iter()
             .filter(|(_, name)| !name.is_empty())
             .filter(|(number, _)| !existing_members.contains(number.as_str()))
@@ -1402,7 +1571,9 @@ impl App {
     /// Build filtered member list for the "Remove member" picker (excludes self).
     pub fn refresh_group_remove_filter(&mut self) {
         let filter_lower = self.group_menu.filter.to_lowercase();
-        let members: Vec<String> = self.active_conversation.as_ref()
+        let members: Vec<String> = self
+            .active_conversation
+            .as_ref()
             .and_then(|id| self.store.groups.get(id))
             .map(|g| g.members.clone())
             .unwrap_or_default();
@@ -1410,7 +1581,10 @@ impl App {
             .into_iter()
             .filter(|phone| *phone != self.account)
             .map(|phone| {
-                let name = self.store.contact_names.get(&phone)
+                let name = self
+                    .store
+                    .contact_names
+                    .get(&phone)
                     .cloned()
                     .unwrap_or_else(|| phone.clone());
                 (phone, name)
@@ -1441,9 +1615,10 @@ impl App {
                 let item_count = items.len();
                 match code {
                     KeyCode::Char('j') | KeyCode::Down
-                        if self.group_menu.index < item_count.saturating_sub(1) => {
-                            self.group_menu.index += 1;
-                        }
+                        if self.group_menu.index < item_count.saturating_sub(1) =>
+                    {
+                        self.group_menu.index += 1;
+                    }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.group_menu.index = self.group_menu.index.saturating_sub(1);
                     }
@@ -1454,8 +1629,12 @@ impl App {
                     }
                     KeyCode::Char(c) => {
                         let hint = match c {
-                            'm' => "m", 'a' => "a", 'r' => "r",
-                            'n' => "n", 'l' => "l", 'c' => "c",
+                            'm' => "m",
+                            'a' => "a",
+                            'r' => "r",
+                            'n' => "n",
+                            'l' => "l",
+                            'c' => "c",
                             _ => "",
                         };
                         if !hint.is_empty() && items.iter().any(|a| a.key_hint == hint) {
@@ -1473,9 +1652,10 @@ impl App {
                 let member_count = self.group_menu.filtered.len();
                 match code {
                     KeyCode::Char('j') | KeyCode::Down
-                        if self.group_menu.index < member_count.saturating_sub(1) => {
-                            self.group_menu.index += 1;
-                        }
+                        if self.group_menu.index < member_count.saturating_sub(1) =>
+                    {
+                        self.group_menu.index += 1;
+                    }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.group_menu.index = self.group_menu.index.saturating_sub(1);
                     }
@@ -1491,15 +1671,17 @@ impl App {
                 match code {
                     KeyCode::Char('j') | KeyCode::Down
                         if !self.group_menu.filtered.is_empty()
-                            && self.group_menu.index < self.group_menu.filtered.len() - 1
-                        => {
-                            self.group_menu.index += 1;
-                        }
+                            && self.group_menu.index < self.group_menu.filtered.len() - 1 =>
+                    {
+                        self.group_menu.index += 1;
+                    }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.group_menu.index = self.group_menu.index.saturating_sub(1);
                     }
                     KeyCode::Enter => {
-                        if let Some((phone, _)) = self.group_menu.filtered.get(self.group_menu.index) {
+                        if let Some((phone, _)) =
+                            self.group_menu.filtered.get(self.group_menu.index)
+                        {
                             let phone = phone.clone();
                             let group_id = self.active_conversation.clone()?;
                             self.group_menu.state = None;
@@ -1533,15 +1715,17 @@ impl App {
                 match code {
                     KeyCode::Char('j') | KeyCode::Down
                         if !self.group_menu.filtered.is_empty()
-                            && self.group_menu.index < self.group_menu.filtered.len() - 1
-                        => {
-                            self.group_menu.index += 1;
-                        }
+                            && self.group_menu.index < self.group_menu.filtered.len() - 1 =>
+                    {
+                        self.group_menu.index += 1;
+                    }
                     KeyCode::Char('k') | KeyCode::Up => {
                         self.group_menu.index = self.group_menu.index.saturating_sub(1);
                     }
                     KeyCode::Enter => {
-                        if let Some((phone, _)) = self.group_menu.filtered.get(self.group_menu.index) {
+                        if let Some((phone, _)) =
+                            self.group_menu.filtered.get(self.group_menu.index)
+                        {
                             let phone = phone.clone();
                             let group_id = self.active_conversation.clone()?;
                             self.group_menu.state = None;
@@ -1647,14 +1831,24 @@ impl App {
         match hint {
             "m" => {
                 // Populate member list for display
-                let members: Vec<(String, String)> = self.active_conversation.as_ref()
+                let members: Vec<(String, String)> = self
+                    .active_conversation
+                    .as_ref()
                     .and_then(|id| self.store.groups.get(id))
-                    .map(|g| g.members.iter().map(|phone| {
-                        let name = self.store.contact_names.get(phone)
-                            .cloned()
-                            .unwrap_or_else(|| phone.clone());
-                        (phone.clone(), name)
-                    }).collect())
+                    .map(|g| {
+                        g.members
+                            .iter()
+                            .map(|phone| {
+                                let name = self
+                                    .store
+                                    .contact_names
+                                    .get(phone)
+                                    .cloned()
+                                    .unwrap_or_else(|| phone.clone());
+                                (phone.clone(), name)
+                            })
+                            .collect()
+                    })
                     .unwrap_or_default();
                 self.group_menu.filtered = members;
                 self.group_menu.state = Some(GroupMenuState::Members);
@@ -1669,7 +1863,9 @@ impl App {
             }
             "n" => {
                 // Pre-fill with current group name
-                let name = self.active_conversation.as_ref()
+                let name = self
+                    .active_conversation
+                    .as_ref()
                     .and_then(|id| self.store.conversations.get(id))
                     .map(|c| c.name.clone())
                     .unwrap_or_default();
@@ -1697,7 +1893,12 @@ impl App {
         };
         match code {
             KeyCode::Char('a') => {
-                let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                let is_group = self
+                    .store
+                    .conversations
+                    .get(&conv_id)
+                    .map(|c| c.is_group)
+                    .unwrap_or(false);
                 if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
                     conv.accepted = true;
                 }
@@ -1710,7 +1911,12 @@ impl App {
                 })
             }
             KeyCode::Char('d') => {
-                let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                let is_group = self
+                    .store
+                    .conversations
+                    .get(&conv_id)
+                    .map(|c| c.is_group)
+                    .unwrap_or(false);
                 self.store.conversations.remove(&conv_id);
                 self.store.conversation_order.retain(|id| id != &conv_id);
                 self.scroll_positions.remove(&conv_id);
@@ -1775,7 +1981,9 @@ impl App {
     /// Build a SendRequest::Reaction from the current picker selection and focused message.
     /// If the user already reacted with the same emoji, removes it instead (toggle behavior).
     fn prepare_reaction_send(&mut self) -> Option<SendRequest> {
-        let emoji = QUICK_REACTIONS.get(self.reactions.picker_index)?.to_string();
+        let emoji = QUICK_REACTIONS
+            .get(self.reactions.picker_index)?
+            .to_string();
         self.prepare_reaction_send_emoji(&emoji)
     }
 
@@ -1786,9 +1994,9 @@ impl App {
         let conv = self.store.conversations.get(&conv_id)?;
         let is_group = conv.is_group;
 
-        let index = self.focused_msg_index.unwrap_or_else(|| {
-            conv.messages.len().saturating_sub(1)
-        });
+        let index = self
+            .focused_msg_index
+            .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
         let msg = conv.messages.get(index)?;
 
         let target_timestamp = msg.timestamp_ms;
@@ -1796,7 +2004,8 @@ impl App {
             self.account.clone()
         } else {
             // Reverse lookup: find the phone number for this display name
-            self.store.contact_names
+            self.store
+                .contact_names
                 .iter()
                 .find(|(_, name)| name.as_str() == msg.sender)
                 .map(|(num, _)| num.clone())
@@ -1804,13 +2013,17 @@ impl App {
         };
 
         // Check if user already reacted with the same emoji (toggle → remove)
-        let is_remove = msg.reactions.iter().any(|r| r.sender == "you" && r.emoji == emoji);
+        let is_remove = msg
+            .reactions
+            .iter()
+            .any(|r| r.sender == "you" && r.emoji == emoji);
 
         // Optimistic local update
         if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
             if let Some(msg) = conv.messages.get_mut(index) {
                 if is_remove {
-                    msg.reactions.retain(|r| !(r.sender == "you" && r.emoji == emoji));
+                    msg.reactions
+                        .retain(|r| !(r.sender == "you" && r.emoji == emoji));
                 } else {
                     // One reaction per user — replace or push
                     if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == "you") {
@@ -1828,12 +2041,14 @@ impl App {
         // Persist to DB
         if is_remove {
             self.db_warn_visible(
-                self.db.remove_reaction(&conv_id, target_timestamp, &target_author, "you"),
+                self.db
+                    .remove_reaction(&conv_id, target_timestamp, &target_author, "you"),
                 "remove_reaction",
             );
         } else {
             self.db_warn_visible(
-                self.db.upsert_reaction(&conv_id, target_timestamp, &target_author, "you", emoji),
+                self.db
+                    .upsert_reaction(&conv_id, target_timestamp, &target_author, "you", emoji),
                 "upsert_reaction",
             );
         }
@@ -2088,8 +2303,14 @@ impl App {
                     if let Some(ref poll) = msg.poll_data {
                         if !poll.closed {
                             let conv_id = self.active_conversation.clone().unwrap_or_default();
-                            let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
-                            let poll_author = if msg.sender_id.is_empty() || msg.sender_id == "you" {
+                            let is_group = self
+                                .store
+                                .conversations
+                                .get(&conv_id)
+                                .map(|c| c.is_group)
+                                .unwrap_or(false);
+                            let poll_author = if msg.sender_id.is_empty() || msg.sender_id == "you"
+                            {
                                 self.account.clone()
                             } else {
                                 msg.sender_id.clone()
@@ -2119,7 +2340,12 @@ impl App {
                 if let Some(msg) = self.selected_message() {
                     if msg.sender == "you" && msg.poll_data.as_ref().is_some_and(|p| !p.closed) {
                         let conv_id = self.active_conversation.clone()?;
-                        let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                        let is_group = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.is_group)
+                            .unwrap_or(false);
                         let poll_timestamp = msg.timestamp_ms;
                         // Optimistic close
                         if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
@@ -2129,7 +2355,10 @@ impl App {
                                 }
                             }
                         }
-                        self.db_warn_visible(self.db.close_poll(&conv_id, poll_timestamp), "close_poll");
+                        self.db_warn_visible(
+                            self.db.close_poll(&conv_id, poll_timestamp),
+                            "close_poll",
+                        );
                         return Some(SendRequest::PollTerminate {
                             recipient: conv_id,
                             is_group,
@@ -2181,7 +2410,8 @@ impl App {
             KeyCode::Char('v') | KeyCode::Enter => {
                 if let Some(id) = self.verify.identities.get(self.verify.index) {
                     if id.safety_number.is_empty() {
-                        self.status_message = "Safety number not available — cannot verify".to_string();
+                        self.status_message =
+                            "Safety number not available — cannot verify".to_string();
                         return None;
                     }
                     if self.verify.confirming {
@@ -2190,7 +2420,10 @@ impl App {
                             let recipient = number.clone();
                             let safety_number = id.safety_number.clone();
                             self.verify.confirming = false;
-                            return Some(SendRequest::TrustIdentity { recipient, safety_number });
+                            return Some(SendRequest::TrustIdentity {
+                                recipient,
+                                safety_number,
+                            });
                         }
                     } else {
                         // First press: ask for confirmation
@@ -2218,12 +2451,19 @@ impl App {
 
     fn update_forward_filter(&mut self) {
         let filter = self.forward.filter.to_lowercase();
-        self.forward.filtered = self.store.conversation_order.iter()
+        self.forward.filtered = self
+            .store
+            .conversation_order
+            .iter()
             .filter_map(|id| {
                 let conv = self.store.conversations.get(id)?;
-                if !conv.accepted { return None; }
+                if !conv.accepted {
+                    return None;
+                }
                 // Exclude the current conversation
-                if self.active_conversation.as_deref() == Some(id.as_str()) { return None; }
+                if self.active_conversation.as_deref() == Some(id.as_str()) {
+                    return None;
+                }
                 let name = &conv.name;
                 if filter.is_empty() || name.to_lowercase().contains(&filter) {
                     Some((id.clone(), name.clone()))
@@ -2248,8 +2488,15 @@ impl App {
                 self.forward.index = self.forward.index.saturating_sub(1);
             }
             ListKeyAction::Select => {
-                if let Some((conv_id, name)) = self.forward.filtered.get(self.forward.index).cloned() {
-                    let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                if let Some((conv_id, name)) =
+                    self.forward.filtered.get(self.forward.index).cloned()
+                {
+                    let is_group = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.is_group)
+                        .unwrap_or(false);
                     let body = format!("[Forwarded]\n{}", self.forward.body);
                     let local_ts_ms = chrono::Utc::now().timestamp_millis();
                     self.forward.show = false;
@@ -2301,7 +2548,11 @@ impl App {
                 self.contacts_overlay.index = self.contacts_overlay.index.saturating_sub(1);
             }
             ListKeyAction::Select => {
-                if let Some((number, _)) = self.contacts_overlay.filtered.get(self.contacts_overlay.index) {
+                if let Some((number, _)) = self
+                    .contacts_overlay
+                    .filtered
+                    .get(self.contacts_overlay.index)
+                {
                     let number = number.clone();
                     self.contacts_overlay.show = false;
                     self.contacts_overlay.filter.clear();
@@ -2373,14 +2624,18 @@ impl App {
         };
 
         // Save current position for jump-back
-        self.jump_stack.push((self.scroll_offset, self.focused_msg_index));
+        self.jump_stack
+            .push((self.scroll_offset, self.focused_msg_index));
 
         // Try to find the quoted message
         let conv_id = match self.active_conversation.as_ref() {
             Some(id) => id.clone(),
             None => return,
         };
-        let found = self.store.conversations.get(&conv_id)
+        let found = self
+            .store
+            .conversations
+            .get(&conv_id)
             .and_then(|c| c.find_msg_idx(quote_ts))
             .is_some();
 
@@ -2411,7 +2666,11 @@ impl App {
     /// Dispatch a `SearchAction` returned by `SearchState` methods.
     fn dispatch_search_action(&mut self, action: SearchAction) {
         match action {
-            SearchAction::Select { conv_id, timestamp_ms, status } => {
+            SearchAction::Select {
+                conv_id,
+                timestamp_ms,
+                status,
+            } => {
                 self.join_conversation(&conv_id);
                 self.jump_to_message_timestamp(timestamp_ms);
                 if let Some(msg) = status {
@@ -2550,7 +2809,11 @@ impl App {
             paste_temp_path: {
                 static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
                 let unique = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                let dir = std::env::temp_dir().join(format!("siggy-paste-{}-{}", std::process::id(), unique));
+                let dir = std::env::temp_dir().join(format!(
+                    "siggy-paste-{}-{}",
+                    std::process::id(),
+                    unique
+                ));
                 // Best-effort: clean any stale files from a previous run with the same PID,
                 // then recreate. Errors here are non-fatal; handle_clipboard_image re-checks.
                 let _ = std::fs::remove_dir_all(&dir);
@@ -2661,11 +2924,19 @@ impl App {
         for conv in self.store.conversations.values_mut() {
             if !conv.is_group && conv.name == conv.id && conv.name.starts_with('+') {
                 // Find the most recent non-"you" sender with a real name
-                if let Some(name) = conv.messages.iter().rev()
-                    .find(|m| m.sender != "you" && m.sender != conv.id && !m.sender.starts_with('+'))
+                if let Some(name) = conv
+                    .messages
+                    .iter()
+                    .rev()
+                    .find(|m| {
+                        m.sender != "you" && m.sender != conv.id && !m.sender.starts_with('+')
+                    })
                     .map(|m| m.sender.clone())
                 {
-                    db_warn(self.db.upsert_conversation(&conv.id, &name, false), "upsert_conversation");
+                    db_warn(
+                        self.db.upsert_conversation(&conv.id, &name, false),
+                        "upsert_conversation",
+                    );
                     conv.name = name;
                 }
             }
@@ -2682,10 +2953,17 @@ impl App {
             _ => return,
         };
 
-        let already_loaded = self.store.conversations.get(&conv_id)
-            .map(|c| c.messages.len()).unwrap_or(0);
+        let already_loaded = self
+            .store
+            .conversations
+            .get(&conv_id)
+            .map(|c| c.messages.len())
+            .unwrap_or(0);
 
-        let new_msgs = match self.db.load_messages_page(&conv_id, Self::PAGE_SIZE, already_loaded) {
+        let new_msgs = match self
+            .db
+            .load_messages_page(&conv_id, Self::PAGE_SIZE, already_loaded)
+        {
             Ok(msgs) => msgs,
             Err(_) => return,
         };
@@ -2701,27 +2979,30 @@ impl App {
         let prepend_count = new_msgs.len();
 
         // Post-process: promote stale Sending → Sent, resolve image paths
-        let mut processed: Vec<DisplayMessage> = new_msgs.into_iter().map(|mut msg| {
-            if msg.status == Some(MessageStatus::Sending) {
-                msg.status = Some(MessageStatus::Sent);
-            }
-            if msg.body.starts_with("[image:") {
-                let path_str = if let Some(uri_pos) = msg.body.find("file:///") {
-                    let uri_slice = msg.body[uri_pos..].trim_end_matches(')');
-                    Some(file_uri_to_path(uri_slice))
-                } else if let Some(arrow_pos) = msg.body.find(" -> ") {
-                    Some(msg.body[arrow_pos + 4..].trim_end_matches(']').to_string())
-                } else {
-                    None
-                };
-                if let Some(p) = path_str {
-                    if Path::new(&p).exists() {
-                        msg.image_path = Some(p);
+        let mut processed: Vec<DisplayMessage> = new_msgs
+            .into_iter()
+            .map(|mut msg| {
+                if msg.status == Some(MessageStatus::Sending) {
+                    msg.status = Some(MessageStatus::Sent);
+                }
+                if msg.body.starts_with("[image:") {
+                    let path_str = if let Some(uri_pos) = msg.body.find("file:///") {
+                        let uri_slice = msg.body[uri_pos..].trim_end_matches(')');
+                        Some(file_uri_to_path(uri_slice))
+                    } else if let Some(arrow_pos) = msg.body.find(" -> ") {
+                        Some(msg.body[arrow_pos + 4..].trim_end_matches(']').to_string())
+                    } else {
+                        None
+                    };
+                    if let Some(p) = path_str {
+                        if Path::new(&p).exists() {
+                            msg.image_path = Some(p);
+                        }
                     }
                 }
-            }
-            msg
-        }).collect();
+                msg
+            })
+            .collect();
 
         // Prepend to conversation
         if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
@@ -2751,10 +3032,12 @@ impl App {
     pub(crate) fn refresh_sidebar_filter(&mut self) {
         let query = self.sidebar_filter.to_lowercase();
         self.sidebar_filtered = self
-            .store.conversation_order
+            .store
+            .conversation_order
             .iter()
             .filter(|id| {
-                self.store.conversations
+                self.store
+                    .conversations
                     .get(*id)
                     .is_some_and(|c| c.name.to_lowercase().contains(&query))
             })
@@ -2807,13 +3090,17 @@ impl App {
     pub fn mark_read(&mut self) {
         if let Some(ref conv_id) = self.active_conversation {
             if let Some(conv) = self.store.conversations.get(conv_id) {
-                self.store.last_read_index
+                self.store
+                    .last_read_index
                     .insert(conv_id.clone(), conv.messages.len());
             }
             // Persist read marker
             let conv_id = conv_id.clone();
             if let Ok(Some(rowid)) = self.db.last_message_rowid(&conv_id) {
-                db_warn(self.db.save_read_marker(&conv_id, rowid), "save_read_marker");
+                db_warn(
+                    self.db.save_read_marker(&conv_id, rowid),
+                    "save_read_marker",
+                );
             }
         }
     }
@@ -2834,7 +3121,11 @@ impl App {
         if total > 0 {
             self.notifications.pending_bell = true;
             if self.notifications.desktop_notifications {
-                let conv_word = if conv_count == 1 { "conversation" } else { "conversations" };
+                let conv_word = if conv_count == 1 {
+                    "conversation"
+                } else {
+                    "conversations"
+                };
                 let body = format!("{total} new messages in {conv_count} {conv_word}");
                 show_desktop_notification("siggy", &body, false, None, "full");
             }
@@ -2843,7 +3134,12 @@ impl App {
 
         // Send read receipts for messages that arrived during sync, then mark read
         if let Some(conv_id) = self.active_conversation.clone() {
-            let read_from = self.store.last_read_index.get(&conv_id).copied().unwrap_or(0);
+            let read_from = self
+                .store
+                .last_read_index
+                .get(&conv_id)
+                .copied()
+                .unwrap_or(0);
             self.queue_read_receipts_for_conv(&conv_id, read_from);
         }
         self.mark_read();
@@ -2912,7 +3208,8 @@ impl App {
     fn build_typing_request(&self, stop: bool) -> Option<SendRequest> {
         let conv_id = self.active_conversation.as_ref()?;
         let is_group = self
-            .store.conversations
+            .store
+            .conversations
             .get(conv_id)
             .map(|c| c.is_group)
             .unwrap_or(false);
@@ -2967,7 +3264,9 @@ impl App {
     /// Handle global keys that work in both Normal and Insert mode.
     /// Returns true if the key was consumed.
     pub fn handle_global_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> bool {
-        let action = self.keybindings.resolve(modifiers, code, BindingMode::Global);
+        let action = self
+            .keybindings
+            .resolve(modifiers, code, BindingMode::Global);
         if self.quit_confirm && !matches!(action, Some(KeyAction::Quit)) {
             self.quit_confirm = false;
             self.update_status();
@@ -3145,7 +3444,11 @@ impl App {
     }
 
     /// Handle Normal mode key. Dispatches to scroll, edit, or action sub-handlers.
-    pub fn handle_normal_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> Option<SendRequest> {
+    pub fn handle_normal_key(
+        &mut self,
+        modifiers: KeyModifiers,
+        code: KeyCode,
+    ) -> Option<SendRequest> {
         // Handle pending prefix key (gg, dd sequences)
         if let Some(prev) = self.pending_normal_key.take() {
             match (prev, code) {
@@ -3178,24 +3481,71 @@ impl App {
             }
         }
 
-        match self.keybindings.resolve(modifiers, code, BindingMode::Normal) {
+        match self
+            .keybindings
+            .resolve(modifiers, code, BindingMode::Normal)
+        {
             // Scroll
-            Some(KeyAction::ScrollDown) => { self.sync.user_scrolled = true; self.scroll_offset = self.scroll_offset.saturating_sub(1); self.focused_msg_index = None; None }
-            Some(KeyAction::ScrollUp) => { self.sync.user_scrolled = true; self.scroll_offset = self.scroll_offset.saturating_add(1); self.focused_msg_index = None; None }
-            Some(KeyAction::FocusNextMessage) => { self.sync.user_scrolled = true; self.jump_to_adjacent_message(false); None }
-            Some(KeyAction::FocusPrevMessage) => { self.sync.user_scrolled = true; self.jump_to_adjacent_message(true); None }
-            Some(KeyAction::HalfPageDown) => { self.sync.user_scrolled = true; self.scroll_offset = self.scroll_offset.saturating_sub(10); self.focused_msg_index = None; None }
-            Some(KeyAction::HalfPageUp) => { self.sync.user_scrolled = true; self.scroll_offset = self.scroll_offset.saturating_add(10); self.focused_msg_index = None; None }
-            Some(KeyAction::ScrollToBottom) => { self.sync.user_scrolled = true; self.scroll_offset = 0; self.focused_msg_index = None; None }
+            Some(KeyAction::ScrollDown) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                self.focused_msg_index = None;
+                None
+            }
+            Some(KeyAction::ScrollUp) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_add(1);
+                self.focused_msg_index = None;
+                None
+            }
+            Some(KeyAction::FocusNextMessage) => {
+                self.sync.user_scrolled = true;
+                self.jump_to_adjacent_message(false);
+                None
+            }
+            Some(KeyAction::FocusPrevMessage) => {
+                self.sync.user_scrolled = true;
+                self.jump_to_adjacent_message(true);
+                None
+            }
+            Some(KeyAction::HalfPageDown) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_sub(10);
+                self.focused_msg_index = None;
+                None
+            }
+            Some(KeyAction::HalfPageUp) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_add(10);
+                self.focused_msg_index = None;
+                None
+            }
+            Some(KeyAction::ScrollToBottom) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = 0;
+                self.focused_msg_index = None;
+                None
+            }
             // Edit/mode-switch
-            Some(KeyAction::InsertAtCursor) => { self.mode = InputMode::Insert; None }
+            Some(KeyAction::InsertAtCursor) => {
+                self.mode = InputMode::Insert;
+                None
+            }
             Some(KeyAction::InsertAfterCursor) => {
                 self.input_cursor = next_char_pos(&self.input_buffer, self.input_cursor);
                 self.mode = InputMode::Insert;
                 None
             }
-            Some(KeyAction::InsertLineStart) => { self.input_cursor = self.current_line_start(); self.mode = InputMode::Insert; None }
-            Some(KeyAction::InsertLineEnd) => { self.input_cursor = self.current_line_end(); self.mode = InputMode::Insert; None }
+            Some(KeyAction::InsertLineStart) => {
+                self.input_cursor = self.current_line_start();
+                self.mode = InputMode::Insert;
+                None
+            }
+            Some(KeyAction::InsertLineEnd) => {
+                self.input_cursor = self.current_line_end();
+                self.mode = InputMode::Insert;
+                None
+            }
             Some(KeyAction::OpenLineBelow) => {
                 let line_end = self.current_line_end();
                 self.input_cursor = line_end;
@@ -3204,24 +3554,37 @@ impl App {
                 self.mode = InputMode::Insert;
                 None
             }
-            Some(KeyAction::CursorLeft) => { self.input_cursor = prev_char_pos(&self.input_buffer, self.input_cursor); None }
+            Some(KeyAction::CursorLeft) => {
+                self.input_cursor = prev_char_pos(&self.input_buffer, self.input_cursor);
+                None
+            }
             Some(KeyAction::CursorRight) => {
                 self.input_cursor = next_char_pos(&self.input_buffer, self.input_cursor);
                 None
             }
-            Some(KeyAction::LineStart) => { self.input_cursor = self.current_line_start(); None }
-            Some(KeyAction::LineEnd) => { self.input_cursor = self.current_line_end(); None }
+            Some(KeyAction::LineStart) => {
+                self.input_cursor = self.current_line_start();
+                None
+            }
+            Some(KeyAction::LineEnd) => {
+                self.input_cursor = self.current_line_end();
+                None
+            }
             Some(KeyAction::WordForward) => {
                 let buf = &self.input_buffer;
                 let mut pos = self.input_cursor;
                 while pos < buf.len() {
                     let c = buf[pos..].chars().next().unwrap();
-                    if c.is_whitespace() { break; }
+                    if c.is_whitespace() {
+                        break;
+                    }
                     pos += c.len_utf8();
                 }
                 while pos < buf.len() {
                     let c = buf[pos..].chars().next().unwrap();
-                    if !c.is_whitespace() { break; }
+                    if !c.is_whitespace() {
+                        break;
+                    }
                     pos += c.len_utf8();
                 }
                 self.input_cursor = pos;
@@ -3232,12 +3595,16 @@ impl App {
                 let mut pos = self.input_cursor;
                 while pos > 0 {
                     let prev = buf[..pos].chars().next_back().unwrap();
-                    if !prev.is_whitespace() { break; }
+                    if !prev.is_whitespace() {
+                        break;
+                    }
                     pos -= prev.len_utf8();
                 }
                 while pos > 0 {
                     let prev = buf[..pos].chars().next_back().unwrap();
-                    if prev.is_whitespace() { break; }
+                    if prev.is_whitespace() {
+                        break;
+                    }
                     pos -= prev.len_utf8();
                 }
                 self.input_cursor = pos;
@@ -3247,7 +3614,8 @@ impl App {
                 if self.input_cursor < self.input_buffer.len() {
                     self.input_buffer.remove(self.input_cursor);
                     if self.input_cursor > 0 && self.input_cursor >= self.input_buffer.len() {
-                        self.input_cursor = prev_char_pos(&self.input_buffer, self.input_buffer.len());
+                        self.input_cursor =
+                            prev_char_pos(&self.input_buffer, self.input_buffer.len());
                     }
                 }
                 None
@@ -3280,8 +3648,14 @@ impl App {
                 None
             }
             // Actions
-            Some(KeyAction::CopyMessage) => { self.copy_selected_message(false); None }
-            Some(KeyAction::CopyAllMessages) => { self.copy_selected_message(true); None }
+            Some(KeyAction::CopyMessage) => {
+                self.copy_selected_message(false);
+                None
+            }
+            Some(KeyAction::CopyAllMessages) => {
+                self.copy_selected_message(true);
+                None
+            }
             Some(KeyAction::React) => {
                 if self.selected_message().is_some_and(|m| !m.is_system) {
                     self.reactions.show_picker = true;
@@ -3336,11 +3710,15 @@ impl App {
                 None
             }
             Some(KeyAction::NextSearchResult) => {
-                if !self.search.results.is_empty() { self.jump_to_search_result(true); }
+                if !self.search.results.is_empty() {
+                    self.jump_to_search_result(true);
+                }
                 None
             }
             Some(KeyAction::PrevSearchResult) => {
-                if !self.search.results.is_empty() { self.jump_to_search_result(false); }
+                if !self.search.results.is_empty() {
+                    self.jump_to_search_result(false);
+                }
                 None
             }
             Some(KeyAction::OpenActionMenu) => {
@@ -3351,8 +3729,14 @@ impl App {
                 None
             }
             Some(KeyAction::PinMessage) => self.execute_pin_toggle(),
-            Some(KeyAction::JumpToQuote) => { self.jump_to_quote(); None }
-            Some(KeyAction::JumpBack) => { self.jump_back(); None }
+            Some(KeyAction::JumpToQuote) => {
+                self.jump_to_quote();
+                None
+            }
+            Some(KeyAction::JumpBack) => {
+                self.jump_back();
+                None
+            }
             _ => {
                 // Handle prefix keys that aren't in the binding map
                 if let KeyCode::Char(c @ ('g' | 'd')) = code {
@@ -3367,8 +3751,15 @@ impl App {
 
     /// Handle Insert mode key.
     /// Returns `Some(SendRequest)` if a message send or typing indicator should be dispatched.
-    pub fn handle_insert_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> Option<SendRequest> {
-        match self.keybindings.resolve(modifiers, code, BindingMode::Insert) {
+    pub fn handle_insert_key(
+        &mut self,
+        modifiers: KeyModifiers,
+        code: KeyCode,
+    ) -> Option<SendRequest> {
+        match self
+            .keybindings
+            .resolve(modifiers, code, BindingMode::Insert)
+        {
             Some(KeyAction::ExitInsert) => {
                 self.mode = InputMode::Normal;
                 self.pending_normal_key = None; // defensive reset
@@ -3387,7 +3778,10 @@ impl App {
                 self.typing.last_keypress = Some(Instant::now());
                 if !self.typing.sent
                     && !self.input_buffer.starts_with('/')
-                    && self.active_conversation.as_ref().is_some_and(|id| !self.blocked_conversations.contains(id))
+                    && self
+                        .active_conversation
+                        .as_ref()
+                        .is_some_and(|id| !self.blocked_conversations.contains(id))
                 {
                     self.typing.sent = true;
                     return self.build_typing_request(false);
@@ -3410,15 +3804,34 @@ impl App {
                 None
             }
             // Actions that alternative profiles (Emacs/Minimal) may bind in Insert mode
-            Some(KeyAction::ScrollDown) => { self.sync.user_scrolled = true; self.scroll_offset = self.scroll_offset.saturating_sub(1); self.focused_msg_index = None; None }
-            Some(KeyAction::ScrollUp) => { self.sync.user_scrolled = true; self.scroll_offset = self.scroll_offset.saturating_add(1); self.focused_msg_index = None; None }
-            Some(KeyAction::CursorLeft) => { self.input_cursor = prev_char_pos(&self.input_buffer, self.input_cursor); None }
+            Some(KeyAction::ScrollDown) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_sub(1);
+                self.focused_msg_index = None;
+                None
+            }
+            Some(KeyAction::ScrollUp) => {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_add(1);
+                self.focused_msg_index = None;
+                None
+            }
+            Some(KeyAction::CursorLeft) => {
+                self.input_cursor = prev_char_pos(&self.input_buffer, self.input_cursor);
+                None
+            }
             Some(KeyAction::CursorRight) => {
                 self.input_cursor = next_char_pos(&self.input_buffer, self.input_cursor);
                 None
             }
-            Some(KeyAction::LineStart) => { self.input_cursor = self.current_line_start(); None }
-            Some(KeyAction::LineEnd) => { self.input_cursor = self.current_line_end(); None }
+            Some(KeyAction::LineStart) => {
+                self.input_cursor = self.current_line_start();
+                None
+            }
+            Some(KeyAction::LineEnd) => {
+                self.input_cursor = self.current_line_end();
+                None
+            }
             Some(KeyAction::DeleteChar) => {
                 if self.input_cursor < self.input_buffer.len() {
                     self.input_buffer.remove(self.input_cursor);
@@ -3430,8 +3843,14 @@ impl App {
                 self.input_buffer.drain(self.input_cursor..line_end);
                 None
             }
-            Some(KeyAction::CopyMessage) => { self.copy_selected_message(false); None }
-            Some(KeyAction::CopyAllMessages) => { self.copy_selected_message(true); None }
+            Some(KeyAction::CopyMessage) => {
+                self.copy_selected_message(false);
+                None
+            }
+            Some(KeyAction::CopyAllMessages) => {
+                self.copy_selected_message(true);
+                None
+            }
             Some(KeyAction::React) => {
                 if self.selected_message().is_some_and(|m| !m.is_system) {
                     self.reactions.show_picker = true;
@@ -3492,11 +3911,15 @@ impl App {
                 None
             }
             Some(KeyAction::NextSearchResult) => {
-                if !self.search.results.is_empty() { self.jump_to_search_result(true); }
+                if !self.search.results.is_empty() {
+                    self.jump_to_search_result(true);
+                }
                 None
             }
             Some(KeyAction::PrevSearchResult) => {
-                if !self.search.results.is_empty() { self.jump_to_search_result(false); }
+                if !self.search.results.is_empty() {
+                    self.jump_to_search_result(false);
+                }
                 None
             }
             Some(KeyAction::OpenActionMenu) => {
@@ -3507,8 +3930,14 @@ impl App {
                 None
             }
             Some(KeyAction::PinMessage) => self.execute_pin_toggle(),
-            Some(KeyAction::JumpToQuote) => { self.jump_to_quote(); None }
-            Some(KeyAction::JumpBack) => { self.jump_back(); None }
+            Some(KeyAction::JumpToQuote) => {
+                self.jump_to_quote();
+                None
+            }
+            Some(KeyAction::JumpBack) => {
+                self.jump_back();
+                None
+            }
             _ => {
                 let needs_ac_update = matches!(
                     code,
@@ -3518,7 +3947,10 @@ impl App {
                 if needs_ac_update {
                     self.update_autocomplete();
                 }
-                if matches!(code, KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete) {
+                if matches!(
+                    code,
+                    KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
+                ) {
                     self.typing.last_keypress = Some(Instant::now());
                     if self.input_buffer.is_empty() && self.typing.sent {
                         self.typing.sent = false;
@@ -3528,7 +3960,10 @@ impl App {
                     if !self.typing.sent
                         && !self.input_buffer.is_empty()
                         && !self.input_buffer.starts_with('/')
-                        && self.active_conversation.as_ref().is_some_and(|id| !self.blocked_conversations.contains(id))
+                        && self
+                            .active_conversation
+                            .as_ref()
+                            .is_some_and(|id| !self.blocked_conversations.contains(id))
                     {
                         self.typing.sent = true;
                         return self.build_typing_request(false);
@@ -3543,7 +3978,11 @@ impl App {
     pub fn handle_signal_event(&mut self, event: SignalEvent) {
         match event {
             SignalEvent::MessageReceived(msg) => self.handle_message(msg),
-            SignalEvent::ReceiptReceived { sender, receipt_type, timestamps } => {
+            SignalEvent::ReceiptReceived {
+                sender,
+                receipt_type,
+                timestamps,
+            } => {
                 self.handle_receipt(&sender, &receipt_type, &timestamps);
             }
             SignalEvent::SendTimestamp { rpc_id, server_ts } => {
@@ -3553,15 +3992,24 @@ impl App {
                 self.status_message = "send failed".to_string();
                 self.handle_send_failed(&rpc_id);
             }
-            SignalEvent::TypingIndicator { sender, sender_name, is_typing, group_id } => {
+            SignalEvent::TypingIndicator {
+                sender,
+                sender_name,
+                is_typing,
+                group_id,
+            } => {
                 // Store name in contact lookup if we learned it from this event
                 if let Some(ref name) = sender_name {
-                    self.store.contact_names.entry(sender.clone()).or_insert_with(|| name.clone());
+                    self.store
+                        .contact_names
+                        .entry(sender.clone())
+                        .or_insert_with(|| name.clone());
                 }
                 // Key by group ID for group messages, sender phone for 1:1
                 let conv_key = group_id.as_ref().unwrap_or(&sender).clone();
                 if is_typing {
-                    self.typing.indicators
+                    self.typing
+                        .indicators
                         .entry(conv_key)
                         .or_default()
                         .insert(sender.clone(), Instant::now());
@@ -3573,65 +4021,150 @@ impl App {
                 }
             }
             SignalEvent::ReactionReceived {
-                conv_id, emoji, sender, sender_name, target_author, target_timestamp, is_remove,
+                conv_id,
+                emoji,
+                sender,
+                sender_name,
+                target_author,
+                target_timestamp,
+                is_remove,
             } => {
                 if let Some(ref name) = sender_name {
-                    self.store.contact_names.entry(sender.clone()).or_insert_with(|| name.clone());
+                    self.store
+                        .contact_names
+                        .entry(sender.clone())
+                        .or_insert_with(|| name.clone());
                 }
-                self.handle_reaction(&conv_id, &emoji, &sender, &target_author, target_timestamp, is_remove);
+                self.handle_reaction(
+                    &conv_id,
+                    &emoji,
+                    &sender,
+                    &target_author,
+                    target_timestamp,
+                    is_remove,
+                );
             }
             SignalEvent::EditReceived {
-                conv_id, sender: _, sender_name: _, target_timestamp, new_body, new_timestamp: _, is_outgoing: _,
+                conv_id,
+                sender: _,
+                sender_name: _,
+                target_timestamp,
+                new_body,
+                new_timestamp: _,
+                is_outgoing: _,
             } => {
                 self.handle_edit_received(&conv_id, target_timestamp, &new_body);
             }
             SignalEvent::RemoteDeleteReceived {
-                conv_id, sender: _, target_timestamp,
+                conv_id,
+                sender: _,
+                target_timestamp,
             } => {
                 self.handle_remote_delete(&conv_id, target_timestamp);
             }
             SignalEvent::PinReceived {
-                conv_id, sender, sender_name, target_author: _, target_timestamp,
+                conv_id,
+                sender,
+                sender_name,
+                target_author: _,
+                target_timestamp,
             } => {
                 if let Some(ref name) = sender_name {
-                    self.store.contact_names.entry(sender.clone()).or_insert_with(|| name.clone());
+                    self.store
+                        .contact_names
+                        .entry(sender.clone())
+                        .or_insert_with(|| name.clone());
                 }
                 self.handle_pin_received(&conv_id, &sender, target_timestamp, true);
             }
             SignalEvent::UnpinReceived {
-                conv_id, sender, sender_name, target_author: _, target_timestamp,
+                conv_id,
+                sender,
+                sender_name,
+                target_author: _,
+                target_timestamp,
             } => {
                 if let Some(ref name) = sender_name {
-                    self.store.contact_names.entry(sender.clone()).or_insert_with(|| name.clone());
+                    self.store
+                        .contact_names
+                        .entry(sender.clone())
+                        .or_insert_with(|| name.clone());
                 }
                 self.handle_pin_received(&conv_id, &sender, target_timestamp, false);
             }
-            SignalEvent::PollCreated { conv_id, timestamp, poll_data } => {
+            SignalEvent::PollCreated {
+                conv_id,
+                timestamp,
+                poll_data,
+            } => {
                 self.handle_poll_created(&conv_id, timestamp, poll_data);
             }
             SignalEvent::PollVoteReceived {
-                conv_id, target_timestamp, voter, voter_name, option_indexes, vote_count,
+                conv_id,
+                target_timestamp,
+                voter,
+                voter_name,
+                option_indexes,
+                vote_count,
             } => {
                 if let Some(ref name) = voter_name {
-                    self.store.contact_names.entry(voter.clone()).or_insert_with(|| name.clone());
+                    self.store
+                        .contact_names
+                        .entry(voter.clone())
+                        .or_insert_with(|| name.clone());
                 }
-                self.handle_poll_vote(&conv_id, target_timestamp, &voter, voter_name.as_deref(), &option_indexes, vote_count);
+                self.handle_poll_vote(
+                    &conv_id,
+                    target_timestamp,
+                    &voter,
+                    voter_name.as_deref(),
+                    &option_indexes,
+                    vote_count,
+                );
             }
-            SignalEvent::PollTerminated { conv_id, target_timestamp } => {
+            SignalEvent::PollTerminated {
+                conv_id,
+                target_timestamp,
+            } => {
                 self.handle_poll_terminated(&conv_id, target_timestamp);
             }
-            SignalEvent::SystemMessage { conv_id, body, timestamp, timestamp_ms } => {
+            SignalEvent::SystemMessage {
+                conv_id,
+                body,
+                timestamp,
+                timestamp_ms,
+            } => {
                 self.handle_system_message(&conv_id, &body, timestamp, timestamp_ms);
             }
-            SignalEvent::ExpirationTimerChanged { conv_id, seconds, body, timestamp, timestamp_ms } => {
+            SignalEvent::ExpirationTimerChanged {
+                conv_id,
+                seconds,
+                body,
+                timestamp,
+                timestamp_ms,
+            } => {
                 // Update conversation timer
-                let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
-                let conv_name = self.store.contact_names.get(&conv_id).cloned().unwrap_or_else(|| conv_id.to_string());
-                self.store.get_or_create_conversation(&conv_id, &conv_name, is_group, &self.db);
+                let is_group = self
+                    .store
+                    .conversations
+                    .get(&conv_id)
+                    .map(|c| c.is_group)
+                    .unwrap_or(false);
+                let conv_name = self
+                    .store
+                    .contact_names
+                    .get(&conv_id)
+                    .cloned()
+                    .unwrap_or_else(|| conv_id.to_string());
+                self.store
+                    .get_or_create_conversation(&conv_id, &conv_name, is_group, &self.db);
                 if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
                     conv.expiration_timer = seconds;
                 }
-                self.db_warn_visible(self.db.update_expiration_timer(&conv_id, seconds), "update_expiration_timer");
+                self.db_warn_visible(
+                    self.db.update_expiration_timer(&conv_id, seconds),
+                    "update_expiration_timer",
+                );
                 // Insert system message
                 self.handle_system_message(&conv_id, &body, timestamp, timestamp_ms);
             }
@@ -3662,27 +4195,32 @@ impl App {
         };
 
         if self.store.move_conversation_to_top(&conv_id) && self.sidebar_filter_active {
-
             self.refresh_sidebar_filter();
-
         }
 
         // Track sync burst progress
         if self.sync.active {
             self.sync.message_count += 1;
             self.sync.last_message_time = Some(Instant::now());
-            self.status_message = format!("Syncing... ({} messages received)", self.sync.message_count);
+            self.status_message =
+                format!("Syncing... ({} messages received)", self.sync.message_count);
         }
 
         // Store source_name in contact lookup for future resolution (typing indicators, etc.)
         if !msg.is_outgoing {
             if let Some(ref name) = msg.source_name {
-                self.store.contact_names.entry(msg.source.clone()).or_insert_with(|| name.clone());
+                self.store
+                    .contact_names
+                    .entry(msg.source.clone())
+                    .or_insert_with(|| name.clone());
             }
             // Populate UUID->name for @mention resolution
             if let (Some(ref uuid), Some(ref name)) = (&msg.source_uuid, &msg.source_name) {
                 if !name.is_empty() {
-                    self.store.uuid_to_name.entry(uuid.clone()).or_insert_with(|| name.clone());
+                    self.store
+                        .uuid_to_name
+                        .entry(uuid.clone())
+                        .or_insert_with(|| name.clone());
                 }
             }
         }
@@ -3693,9 +4231,17 @@ impl App {
         let conv_name = msg
             .group_name
             .as_deref()
-            .or(if is_group { None } else { msg.source_name.as_deref() })
+            .or(if is_group {
+                None
+            } else {
+                msg.source_name.as_deref()
+            })
             .unwrap_or_else(|| {
-                self.store.contact_names.get(&conv_id).map(|s| s.as_str()).unwrap_or(&conv_id)
+                self.store
+                    .contact_names
+                    .get(&conv_id)
+                    .map(|s| s.as_str())
+                    .unwrap_or(&conv_id)
             })
             .to_string();
 
@@ -3716,8 +4262,13 @@ impl App {
 
         // Ensure conversation exists; detect message requests for new 1:1 from unknown senders
         let is_new = !self.store.conversations.contains_key(&conv_id);
-        self.store.get_or_create_conversation(&conv_id, &conv_name, is_group, &self.db);
-        if is_new && !msg.is_outgoing && !is_group && !self.store.contact_names.contains_key(&conv_id) {
+        self.store
+            .get_or_create_conversation(&conv_id, &conv_name, is_group, &self.db);
+        if is_new
+            && !msg.is_outgoing
+            && !is_group
+            && !self.store.contact_names.contains_key(&conv_id)
+        {
             if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
                 conv.accepted = false;
             }
@@ -3727,13 +4278,21 @@ impl App {
         let ts_rfc3339 = msg.timestamp.to_rfc3339();
         let msg_ts_ms = msg.timestamp.timestamp_millis();
         // Outgoing synced messages already have a server timestamp; incoming messages have no status
-        let msg_status = if msg.is_outgoing { Some(MessageStatus::Sent) } else { None };
+        let msg_status = if msg.is_outgoing {
+            Some(MessageStatus::Sent)
+        } else {
+            None
+        };
 
         // Disappearing messages: extract expiration metadata
         let msg_expires_in = msg.expires_in_seconds;
         let msg_expiration_start = if msg_expires_in > 0 {
             // For received messages, start countdown now; for sent sync, use message timestamp
-            if msg.is_outgoing { msg_ts_ms } else { Utc::now().timestamp_millis() }
+            if msg.is_outgoing {
+                msg_ts_ms
+            } else {
+                Utc::now().timestamp_millis()
+            }
         } else {
             0
         };
@@ -3742,26 +4301,53 @@ impl App {
         if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
             if conv.expiration_timer != msg_expires_in {
                 conv.expiration_timer = msg_expires_in;
-                db_warn(self.db.update_expiration_timer(&conv_id, msg_expires_in), "update_expiration_timer");
+                db_warn(
+                    self.db.update_expiration_timer(&conv_id, msg_expires_in),
+                    "update_expiration_timer",
+                );
             }
         }
 
         // Resolve @mentions before the push closure borrows self mutably
-        let resolved_body = msg.body.as_ref().map(|body| {
-            self.store.resolve_mentions(body, &msg.mentions)
-        });
+        let resolved_body = msg
+            .body
+            .as_ref()
+            .map(|body| self.store.resolve_mentions(body, &msg.mentions));
 
         // Resolve text styles (UTF-16 → byte offsets, accounting for mention replacements)
-        let resolved_styles = resolved_body.as_ref().map(|(resolved, _)| {
-            self.store.resolve_text_styles(resolved, &msg.text_styles, &msg.mentions)
-        }).unwrap_or_default();
+        let resolved_styles = resolved_body
+            .as_ref()
+            .map(|(resolved, _)| {
+                self.store
+                    .resolve_text_styles(resolved, &msg.text_styles, &msg.mentions)
+            })
+            .unwrap_or_default();
 
         // Resolve quote from wire format
         let msg_quote = msg.quote.as_ref().map(|(ts, author_phone, body)| {
-            let author_display = self.store.contact_names.get(author_phone)
+            let author_display = self
+                .store
+                .contact_names
+                .get(author_phone)
                 .cloned()
-                .unwrap_or_else(|| if *author_phone == self.account { "you".to_string() } else { author_phone.clone() });
-            (Quote { author: author_display, body: body.clone(), timestamp_ms: *ts, author_id: author_phone.clone() }, author_phone.clone(), body.clone(), *ts)
+                .unwrap_or_else(|| {
+                    if *author_phone == self.account {
+                        "you".to_string()
+                    } else {
+                        author_phone.clone()
+                    }
+                });
+            (
+                Quote {
+                    author: author_display,
+                    body: body.clone(),
+                    timestamp_ms: *ts,
+                    author_id: author_phone.clone(),
+                },
+                author_phone.clone(),
+                body.clone(),
+                *ts,
+            )
         });
         let display_quote = msg_quote.as_ref().map(|(q, _, _, _)| q.clone());
         let wire_quote_author = msg_quote.as_ref().map(|(_, a, _, _)| a.clone());
@@ -3776,34 +4362,42 @@ impl App {
                             style_ranges: Vec<(usize, usize, StyleType)>,
                             quote: Option<Quote>| {
             // Check for buffered poll data from a race condition (poll event arrived first)
-            let deferred_poll = self.poll_vote.pending_polls.remove(&(conv_id.clone(), msg_ts_ms));
+            let deferred_poll = self
+                .poll_vote
+                .pending_polls
+                .remove(&(conv_id.clone(), msg_ts_ms));
             if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                let pos = conv.messages.partition_point(|m| m.timestamp_ms <= msg_ts_ms);
-                conv.messages.insert(pos, DisplayMessage {
-                    sender: sender_display.clone(),
-                    timestamp: msg.timestamp,
-                    body: body.clone(),
-                    is_system: false,
-                    image_lines,
-                    image_path,
-                    status: msg_status,
-                    timestamp_ms: msg_ts_ms,
-                    reactions: Vec::new(),
-                    mention_ranges,
-                    style_ranges,
-                    quote,
-                    is_edited: false,
-                    is_deleted: false,
-                    is_pinned: false,
-                    sender_id: sender_id.clone(),
-                    expires_in_seconds: msg_expires_in,
-                    expiration_start_ms: msg_expiration_start,
-                    poll_data: deferred_poll,
-                    poll_votes: Vec::new(),
-                    preview: None,
-                    preview_image_lines: None,
-                    preview_image_path: None,
-                });
+                let pos = conv
+                    .messages
+                    .partition_point(|m| m.timestamp_ms <= msg_ts_ms);
+                conv.messages.insert(
+                    pos,
+                    DisplayMessage {
+                        sender: sender_display.clone(),
+                        timestamp: msg.timestamp,
+                        body: body.clone(),
+                        is_system: false,
+                        image_lines,
+                        image_path,
+                        status: msg_status,
+                        timestamp_ms: msg_ts_ms,
+                        reactions: Vec::new(),
+                        mention_ranges,
+                        style_ranges,
+                        quote,
+                        is_edited: false,
+                        is_deleted: false,
+                        is_pinned: false,
+                        sender_id: sender_id.clone(),
+                        expires_in_seconds: msg_expires_in,
+                        expiration_start_ms: msg_expiration_start,
+                        poll_data: deferred_poll,
+                        poll_votes: Vec::new(),
+                        preview: None,
+                        preview_image_lines: None,
+                        preview_image_path: None,
+                    },
+                );
                 // Bump last_read_index if we inserted before the read marker
                 if let Some(read_idx) = self.store.last_read_index.get_mut(&conv_id) {
                     if pos <= *read_idx {
@@ -3816,7 +4410,13 @@ impl App {
             }
             db_warn(
                 self.db.insert_message_full(
-                    &conv_id, &sender_display, &ts_rfc3339, &body, false, msg_status, msg_ts_ms,
+                    &conv_id,
+                    &sender_display,
+                    &ts_rfc3339,
+                    &body,
+                    false,
+                    msg_status,
+                    msg_ts_ms,
                     &sender_id,
                     wire_quote_author.as_deref(),
                     wire_quote_body.as_deref(),
@@ -3848,7 +4448,8 @@ impl App {
                 .unwrap_or_default();
 
             if is_image {
-                let rendered = att.local_path
+                let rendered = att
+                    .local_path
                     .as_deref()
                     .and_then(|p| image_render::render_image(Path::new(p), 40));
                 push_msg(
@@ -3860,31 +4461,48 @@ impl App {
                     None,
                 );
             } else {
-                push_msg(format!("[attachment: {label}]{path_info}"), None, None, Vec::new(), Vec::new(), None);
+                push_msg(
+                    format!("[attachment: {label}]{path_info}"),
+                    None,
+                    None,
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                );
             }
         }
 
         // Attach first link preview to the body message (not attachment messages)
         if let Some(preview) = msg.previews.into_iter().next() {
             if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                if let Some(dm) = conv.messages.iter_mut().rev()
+                if let Some(dm) = conv
+                    .messages
+                    .iter_mut()
+                    .rev()
                     .find(|m| m.timestamp_ms == msg_ts_ms && !m.body.starts_with('['))
                 {
-                    let (img_lines, img_path) = if self.image.show_link_previews && self.image.image_mode != "none" {
-                        if let Some(ref p) = preview.image_path {
-                            (image_render::render_image(Path::new(p), 30), Some(p.clone()))
+                    let (img_lines, img_path) =
+                        if self.image.show_link_previews && self.image.image_mode != "none" {
+                            if let Some(ref p) = preview.image_path {
+                                (
+                                    image_render::render_image(Path::new(p), 30),
+                                    Some(p.clone()),
+                                )
+                            } else {
+                                (None, None)
+                            }
                         } else {
                             (None, None)
-                        }
-                    } else {
-                        (None, None)
-                    };
+                        };
                     dm.preview = Some(preview.clone());
                     dm.preview_image_lines = img_lines;
                     dm.preview_image_path = img_path;
                 }
             }
-            db_warn(self.db.upsert_link_preview(&conv_id, msg_ts_ms, &preview), "upsert_link_preview");
+            db_warn(
+                self.db.upsert_link_preview(&conv_id, msg_ts_ms, &preview),
+                "upsert_link_preview",
+            );
         }
 
         let is_active = self
@@ -3897,14 +4515,27 @@ impl App {
             if let Some(c) = self.store.conversations.get_mut(&conv_id) {
                 c.unread += 1;
             }
-            let conv_accepted = self.store.conversations.get(&conv_id).map(|c| c.accepted).unwrap_or(true);
+            let conv_accepted = self
+                .store
+                .conversations
+                .get(&conv_id)
+                .map(|c| c.accepted)
+                .unwrap_or(true);
             let not_muted_or_blocked = conv_accepted
                 && !self.muted_conversations.contains(&conv_id)
                 && !self.blocked_conversations.contains(&conv_id);
-            let type_enabled = if is_group { self.notifications.notify_group } else { self.notifications.notify_direct };
+            let type_enabled = if is_group {
+                self.notifications.notify_group
+            } else {
+                self.notifications.notify_direct
+            };
             if self.sync.active {
                 if type_enabled && not_muted_or_blocked {
-                    *self.sync.suppressed_notifications.entry(conv_id.clone()).or_insert(0) += 1;
+                    *self
+                        .sync
+                        .suppressed_notifications
+                        .entry(conv_id.clone())
+                        .or_insert(0) += 1;
                 }
             } else {
                 if type_enabled && not_muted_or_blocked {
@@ -3913,7 +4544,10 @@ impl App {
                 if self.notifications.desktop_notifications && not_muted_or_blocked {
                     let notif_body = msg.body.as_deref().unwrap_or("");
                     let notif_group = if is_group {
-                        self.store.conversations.get(&conv_id).map(|c| c.name.clone())
+                        self.store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.clone())
                     } else {
                         None
                     };
@@ -3930,25 +4564,39 @@ impl App {
 
         // Viewport stabilization: keep scroll offset pinned during sync so newly
         // arriving messages don't jump the viewport.
-        if self.sync.active && !self.sync.user_scrolled
+        if self.sync.active
+            && !self.sync.user_scrolled
             && self.active_conversation.as_ref() == Some(&conv_id)
         {
             self.scroll_offset = self.scroll_offset.saturating_add(1);
         }
 
         // Active conversation: send read receipt and advance read marker
-        let conv_accepted = self.store.conversations.get(&conv_id).map(|c| c.accepted).unwrap_or(true);
+        let conv_accepted = self
+            .store
+            .conversations
+            .get(&conv_id)
+            .map(|c| c.accepted)
+            .unwrap_or(true);
         if is_active {
             if !self.sync.active {
-                if !msg.is_outgoing && conv_accepted && !self.blocked_conversations.contains(&conv_id) {
+                if !msg.is_outgoing
+                    && conv_accepted
+                    && !self.blocked_conversations.contains(&conv_id)
+                {
                     self.queue_single_read_receipt(&sender_id, msg_ts_ms);
                 }
                 if let Some(conv) = self.store.conversations.get(&conv_id) {
-                    self.store.last_read_index.insert(conv_id.clone(), conv.messages.len());
+                    self.store
+                        .last_read_index
+                        .insert(conv_id.clone(), conv.messages.len());
                 }
             }
             if let Ok(Some(rowid)) = self.db.last_message_rowid(&conv_id) {
-                db_warn(self.db.save_read_marker(&conv_id, rowid), "save_read_marker");
+                db_warn(
+                    self.db.save_read_marker(&conv_id, rowid),
+                    "save_read_marker",
+                );
             }
         }
     }
@@ -3960,36 +4608,52 @@ impl App {
         timestamp: DateTime<Utc>,
         timestamp_ms: i64,
     ) {
-        let is_group = self.store.conversations.get(conv_id).map(|c| c.is_group).unwrap_or(false);
-        let conv_name = self.store.contact_names.get(conv_id).cloned().unwrap_or_else(|| conv_id.to_string());
-        self.store.get_or_create_conversation(conv_id, &conv_name, is_group, &self.db);
+        let is_group = self
+            .store
+            .conversations
+            .get(conv_id)
+            .map(|c| c.is_group)
+            .unwrap_or(false);
+        let conv_name = self
+            .store
+            .contact_names
+            .get(conv_id)
+            .cloned()
+            .unwrap_or_else(|| conv_id.to_string());
+        self.store
+            .get_or_create_conversation(conv_id, &conv_name, is_group, &self.db);
         if let Some(conv) = self.store.conversations.get_mut(conv_id) {
-            let pos = conv.messages.partition_point(|m| m.timestamp_ms <= timestamp_ms);
-            conv.messages.insert(pos, DisplayMessage {
-                sender: String::new(),
-                timestamp,
-                body: body.to_string(),
-                is_system: true,
-                image_lines: None,
-                image_path: None,
-                status: None,
-                timestamp_ms,
-                reactions: Vec::new(),
-                mention_ranges: Vec::new(),
-                style_ranges: Vec::new(),
-                quote: None,
-                is_edited: false,
-                is_deleted: false,
-                is_pinned: false,
-                sender_id: String::new(),
-                expires_in_seconds: 0,
-                expiration_start_ms: 0,
-                poll_data: None,
-                poll_votes: Vec::new(),
-                preview: None,
-                preview_image_lines: None,
-                preview_image_path: None,
-            });
+            let pos = conv
+                .messages
+                .partition_point(|m| m.timestamp_ms <= timestamp_ms);
+            conv.messages.insert(
+                pos,
+                DisplayMessage {
+                    sender: String::new(),
+                    timestamp,
+                    body: body.to_string(),
+                    is_system: true,
+                    image_lines: None,
+                    image_path: None,
+                    status: None,
+                    timestamp_ms,
+                    reactions: Vec::new(),
+                    mention_ranges: Vec::new(),
+                    style_ranges: Vec::new(),
+                    quote: None,
+                    is_edited: false,
+                    is_deleted: false,
+                    is_pinned: false,
+                    sender_id: String::new(),
+                    expires_in_seconds: 0,
+                    expiration_start_ms: 0,
+                    poll_data: None,
+                    poll_votes: Vec::new(),
+                    preview: None,
+                    preview_image_lines: None,
+                    preview_image_path: None,
+                },
+            );
             // Bump last_read_index if we inserted before the read marker
             if let Some(read_idx) = self.store.last_read_index.get_mut(conv_id) {
                 if pos <= *read_idx {
@@ -3999,7 +4663,8 @@ impl App {
         }
         let ts_rfc3339 = timestamp.to_rfc3339();
         self.db_warn_visible(
-            self.db.insert_message(conv_id, "", &ts_rfc3339, body, true, None, timestamp_ms),
+            self.db
+                .insert_message(conv_id, "", &ts_rfc3339, body, true, None, timestamp_ms),
             "insert_system_message",
         );
     }
@@ -4058,7 +4723,8 @@ impl App {
         let sender_display = if is_self {
             "you".to_string()
         } else {
-            self.store.contact_names
+            self.store
+                .contact_names
                 .get(sender)
                 .cloned()
                 .unwrap_or_else(|| sender.to_string())
@@ -4072,7 +4738,11 @@ impl App {
                     m.sender == target_author
                         || target_display.as_deref() == Some(m.sender.as_str())
                 };
-                if matches { Some(idx) } else { None }
+                if matches {
+                    Some(idx)
+                } else {
+                    None
+                }
             });
             if let Some(msg) = found.map(|idx| &mut conv.messages[idx]) {
                 if is_remove {
@@ -4080,7 +4750,11 @@ impl App {
                     msg.reactions.retain(|r| r.sender != sender_display);
                 } else {
                     // One reaction per user — replace or push
-                    if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == sender_display) {
+                    if let Some(existing) = msg
+                        .reactions
+                        .iter_mut()
+                        .find(|r| r.sender == sender_display)
+                    {
                         existing.emoji = emoji.to_string();
                     } else {
                         msg.reactions.push(Reaction {
@@ -4095,12 +4769,14 @@ impl App {
         // Persist to DB regardless of whether message is in memory
         if is_remove {
             self.db_warn_visible(
-                self.db.remove_reaction(conv_id, target_timestamp, target_author, sender),
+                self.db
+                    .remove_reaction(conv_id, target_timestamp, target_author, sender),
                 "remove_reaction",
             );
         } else {
             self.db_warn_visible(
-                self.db.upsert_reaction(conv_id, target_timestamp, target_author, sender, emoji),
+                self.db
+                    .upsert_reaction(conv_id, target_timestamp, target_author, sender, emoji),
                 "upsert_reaction",
             );
         }
@@ -4115,9 +4791,9 @@ impl App {
                 let conv_id = self.active_conversation.clone()?;
                 let conv = self.store.conversations.get(&conv_id)?;
                 let is_group = conv.is_group;
-                let index = self.focused_msg_index.unwrap_or_else(|| {
-                    conv.messages.len().saturating_sub(1)
-                });
+                let index = self
+                    .focused_msg_index
+                    .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
                 let msg = conv.messages.get(index)?;
                 let is_outgoing = msg.sender == "you";
                 let target_timestamp = msg.timestamp_ms;
@@ -4148,9 +4824,9 @@ impl App {
                 self.show_delete_confirm = false;
                 let conv_id = self.active_conversation.clone()?;
                 let conv = self.store.conversations.get(&conv_id)?;
-                let index = self.focused_msg_index.unwrap_or_else(|| {
-                    conv.messages.len().saturating_sub(1)
-                });
+                let index = self
+                    .focused_msg_index
+                    .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
                 let msg = conv.messages.get(index)?;
                 let target_timestamp = msg.timestamp_ms;
 
@@ -4181,7 +4857,8 @@ impl App {
             }
         }
         self.db_warn_visible(
-            self.db.update_message_body(conv_id, target_timestamp, new_body),
+            self.db
+                .update_message_body(conv_id, target_timestamp, new_body),
             "update_message_body",
         );
     }
@@ -4200,21 +4877,32 @@ impl App {
         );
     }
 
-    fn handle_pin_received(&mut self, conv_id: &str, sender: &str, target_timestamp: i64, pinned: bool) {
+    fn handle_pin_received(
+        &mut self,
+        conv_id: &str,
+        sender: &str,
+        target_timestamp: i64,
+        pinned: bool,
+    ) {
         if let Some(conv) = self.store.conversations.get_mut(conv_id) {
             if let Some(idx) = conv.find_msg_idx(target_timestamp) {
                 conv.messages[idx].is_pinned = pinned;
             }
         }
         self.db_warn_visible(
-            self.db.set_message_pinned(conv_id, target_timestamp, pinned),
+            self.db
+                .set_message_pinned(conv_id, target_timestamp, pinned),
             "set_message_pinned",
         );
         // Insert system message — resolve sender to display name
         let sender_display = if sender == self.account {
             "you".to_string()
         } else {
-            self.store.contact_names.get(sender).cloned().unwrap_or_else(|| sender.to_string())
+            self.store
+                .contact_names
+                .get(sender)
+                .cloned()
+                .unwrap_or_else(|| sender.to_string())
         };
         let action = if pinned { "pinned" } else { "unpinned" };
         let body = format!("{sender_display} {action} a message");
@@ -4231,7 +4919,9 @@ impl App {
             if let Some(idx) = conv.find_msg_idx(timestamp) {
                 conv.messages[idx].poll_data = Some(poll_data.clone());
             } else {
-                self.poll_vote.pending_polls.insert((conv_id.to_string(), timestamp), poll_data.clone());
+                self.poll_vote
+                    .pending_polls
+                    .insert((conv_id.to_string(), timestamp), poll_data.clone());
             }
         }
         self.db_warn_visible(
@@ -4268,7 +4958,14 @@ impl App {
             }
         }
         self.db_warn_visible(
-            self.db.upsert_poll_vote(conv_id, target_timestamp, voter, voter_name, option_indexes, vote_count),
+            self.db.upsert_poll_vote(
+                conv_id,
+                target_timestamp,
+                voter,
+                voter_name,
+                option_indexes,
+                vote_count,
+            ),
             "upsert_poll_vote",
         );
     }
@@ -4281,10 +4978,7 @@ impl App {
                 }
             }
         }
-        self.db_warn_visible(
-            self.db.close_poll(conv_id, target_timestamp),
-            "close_poll",
-        );
+        self.db_warn_visible(self.db.close_poll(conv_id, target_timestamp), "close_poll");
     }
 
     fn execute_pin_toggle(&mut self) -> Option<SendRequest> {
@@ -4296,7 +4990,12 @@ impl App {
         let target_timestamp = msg.timestamp_ms;
         let author_phone = msg.sender_id.clone();
         let conv_id = self.active_conversation.clone()?;
-        let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+        let is_group = self
+            .store
+            .conversations
+            .get(&conv_id)
+            .map(|c| c.is_group)
+            .unwrap_or(false);
 
         let target_author = if author_phone.is_empty() || author_phone == "you" {
             self.account.clone()
@@ -4312,7 +5011,8 @@ impl App {
                 }
             }
             self.db_warn_visible(
-                self.db.set_message_pinned(&conv_id, target_timestamp, false),
+                self.db
+                    .set_message_pinned(&conv_id, target_timestamp, false),
                 "set_message_pinned",
             );
             self.scroll_offset = 0;
@@ -4366,7 +5066,8 @@ impl App {
                     }
                 }
                 self.db_warn_visible(
-                    self.db.set_message_pinned(&pending.conv_id, pending.target_timestamp, true),
+                    self.db
+                        .set_message_pinned(&pending.conv_id, pending.target_timestamp, true),
                     "set_message_pinned",
                 );
                 self.scroll_offset = 0;
@@ -4423,14 +5124,12 @@ impl App {
 
         // Navigation mode
         match code {
-            KeyCode::Char('j') | KeyCode::Down
-                if self.profile.index < SAVE_INDEX => {
-                    self.profile.index += 1;
-                }
-            KeyCode::Char('k') | KeyCode::Up
-                if self.profile.index > 0 => {
-                    self.profile.index -= 1;
-                }
+            KeyCode::Char('j') | KeyCode::Down if self.profile.index < SAVE_INDEX => {
+                self.profile.index += 1;
+            }
+            KeyCode::Char('k') | KeyCode::Up if self.profile.index > 0 => {
+                self.profile.index -= 1;
+            }
             KeyCode::Enter => {
                 if self.profile.index < FIELD_COUNT {
                     // Start editing the selected field
@@ -4492,7 +5191,9 @@ impl App {
                 None
             }
             KeyCode::Enter => {
-                let selected: Vec<i64> = self.poll_vote.selections
+                let selected: Vec<i64> = self
+                    .poll_vote
+                    .selections
                     .iter()
                     .enumerate()
                     .filter(|(_, &sel)| sel)
@@ -4506,7 +5207,14 @@ impl App {
 
                 // Optimistic local vote
                 let voter = self.account.clone();
-                self.handle_poll_vote(&pending.conv_id, pending.poll_timestamp, &voter, None, &selected, 1);
+                self.handle_poll_vote(
+                    &pending.conv_id,
+                    pending.poll_timestamp,
+                    &voter,
+                    None,
+                    &selected,
+                    1,
+                );
 
                 Some(SendRequest::PollVote {
                     recipient: pending.conv_id,
@@ -4570,9 +5278,16 @@ impl App {
             };
 
             // Only advance, never retreat
-            let current = self.store.last_read_index.get(conv_id).copied().unwrap_or(0);
+            let current = self
+                .store
+                .last_read_index
+                .get(conv_id)
+                .copied()
+                .unwrap_or(0);
             if new_read_idx > current {
-                self.store.last_read_index.insert(conv_id.clone(), new_read_idx);
+                self.store
+                    .last_read_index
+                    .insert(conv_id.clone(), new_read_idx);
 
                 // Recompute unread from remaining messages after the read marker
                 if let Some(conv) = self.store.conversations.get_mut(conv_id) {
@@ -4601,7 +5316,9 @@ impl App {
             // Store name in lookup for future message resolution
             if let Some(ref name) = contact.name {
                 if !name.is_empty() {
-                    self.store.contact_names.insert(contact.number.clone(), name.clone());
+                    self.store
+                        .contact_names
+                        .insert(contact.number.clone(), name.clone());
                 }
             }
             // Build UUID maps for @mention resolution
@@ -4611,21 +5328,32 @@ impl App {
                         self.store.uuid_to_name.insert(uuid.clone(), name.clone());
                     }
                 }
-                self.store.number_to_uuid.insert(contact.number.clone(), uuid.clone());
+                self.store
+                    .number_to_uuid
+                    .insert(contact.number.clone(), uuid.clone());
             }
             // Update name on existing conversations only — don't create new ones
             if let Some(conv) = self.store.conversations.get_mut(&contact.number) {
                 if let Some(ref contact_name) = contact.name {
                     if !contact_name.is_empty() && conv.name != *contact_name {
                         conv.name = contact_name.clone();
-                        db_warn(self.db.upsert_conversation(&contact.number, contact_name, false), "upsert_conversation");
+                        db_warn(
+                            self.db
+                                .upsert_conversation(&contact.number, contact_name, false),
+                            "upsert_conversation",
+                        );
                     }
                 }
             }
         }
         // Auto-accept unaccepted 1:1 conversations whose sender is now a known contact
-        let to_accept: Vec<String> = self.store.conversations.iter()
-            .filter(|(_, c)| !c.accepted && !c.is_group && self.store.contact_names.contains_key(&c.id))
+        let to_accept: Vec<String> = self
+            .store
+            .conversations
+            .iter()
+            .filter(|(_, c)| {
+                !c.accepted && !c.is_group && self.store.contact_names.contains_key(&c.id)
+            })
             .map(|(id, _)| id.clone())
             .collect();
         for id in to_accept {
@@ -4644,27 +5372,40 @@ impl App {
         for group in groups {
             // Store name in lookup for future message resolution
             if !group.name.is_empty() {
-                self.store.contact_names.insert(group.id.clone(), group.name.clone());
+                self.store
+                    .contact_names
+                    .insert(group.id.clone(), group.name.clone());
             }
             // Store UUID↔phone mappings from group members
             for (phone, uuid) in &group.member_uuids {
-                self.store.number_to_uuid.entry(phone.clone()).or_insert_with(|| uuid.clone());
+                self.store
+                    .number_to_uuid
+                    .entry(phone.clone())
+                    .or_insert_with(|| uuid.clone());
             }
             // Populate UUID->name from group members (phone->uuid + phone->name)
             for (phone, uuid) in &group.member_uuids {
                 if let Some(name) = self.store.contact_names.get(phone) {
                     if !name.is_empty() {
-                        self.store.uuid_to_name.entry(uuid.clone()).or_insert_with(|| name.clone());
+                        self.store
+                            .uuid_to_name
+                            .entry(uuid.clone())
+                            .or_insert_with(|| name.clone());
                     }
                 }
             }
             // Store group for @mention member lookup
             self.store.groups.insert(group.id.clone(), group.clone());
             // Groups are always "active" (you're a member), so create conversations
-            let conv = self.store.get_or_create_conversation(&group.id, &group.name, true, &self.db);
+            let conv =
+                self.store
+                    .get_or_create_conversation(&group.id, &group.name, true, &self.db);
             if !group.name.is_empty() && conv.name != group.name {
                 conv.name = group.name.clone();
-                db_warn(self.db.upsert_conversation(&group.id, &group.name, true), "upsert_conversation");
+                db_warn(
+                    self.db.upsert_conversation(&group.id, &group.name, true),
+                    "upsert_conversation",
+                );
             }
         }
         // Re-resolve reaction senders with any new names from group members.
@@ -4683,23 +5424,37 @@ impl App {
         if self.verify.show {
             if let Some(ref conv_id) = self.active_conversation {
                 let conv_id = conv_id.clone();
-                let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                let is_group = self
+                    .store
+                    .conversations
+                    .get(&conv_id)
+                    .map(|c| c.is_group)
+                    .unwrap_or(false);
                 if is_group {
                     if let Some(group) = self.store.groups.get(&conv_id) {
-                        let members: HashSet<&str> = group.members.iter().map(|s| s.as_str()).collect();
-                        self.verify.identities = identities.iter()
-                            .filter(|id| id.number.as_ref().is_some_and(|n| members.contains(n.as_str())))
+                        let members: HashSet<&str> =
+                            group.members.iter().map(|s| s.as_str()).collect();
+                        self.verify.identities = identities
+                            .iter()
+                            .filter(|id| {
+                                id.number
+                                    .as_ref()
+                                    .is_some_and(|n| members.contains(n.as_str()))
+                            })
                             .cloned()
                             .collect();
                     }
                 } else {
-                    self.verify.identities = identities.iter()
+                    self.verify.identities = identities
+                        .iter()
                         .filter(|id| id.number.as_deref() == Some(conv_id.as_str()))
                         .cloned()
                         .collect();
                 }
                 // Clamp index
-                if !self.verify.identities.is_empty() && self.verify.index >= self.verify.identities.len() {
+                if !self.verify.identities.is_empty()
+                    && self.verify.index >= self.verify.identities.len()
+                {
                     self.verify.index = self.verify.identities.len() - 1;
                 }
             }
@@ -4747,7 +5502,10 @@ impl App {
         if let Some((path, _)) = self.pending_paste_cleanups.remove(rpc_id) {
             self.pending_paste_cleanups.insert(
                 rpc_id.to_string(),
-                (path, Instant::now() + std::time::Duration::from_secs(PASTE_CLEANUP_DELAY_SECS)),
+                (
+                    path,
+                    Instant::now() + std::time::Duration::from_secs(PASTE_CLEANUP_DELAY_SECS),
+                ),
             );
         }
         if let Some((conv_id, local_ts)) = self.pending_sends.remove(rpc_id) {
@@ -4759,7 +5517,10 @@ impl App {
             let mut found = false;
             if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
                 // Find the outgoing message with matching local timestamp
-                if let Some(idx) = conv.find_msg_idx(local_ts).filter(|&idx| conv.messages[idx].sender == "you") {
+                if let Some(idx) = conv
+                    .find_msg_idx(local_ts)
+                    .filter(|&idx| conv.messages[idx].sender == "you")
+                {
                     conv.messages[idx].timestamp_ms = effective_ts;
                     conv.messages[idx].status = Some(MessageStatus::Sent);
                     found = true;
@@ -4767,12 +5528,15 @@ impl App {
             }
             if found {
                 // Update the DB row's timestamp_ms from local → server
-                self.db_warn_visible(self.db.update_message_timestamp_ms(
-                    &conv_id,
-                    local_ts,
-                    effective_ts,
-                    MessageStatus::Sent.to_i32(),
-                ), "update_message_timestamp_ms");
+                self.db_warn_visible(
+                    self.db.update_message_timestamp_ms(
+                        &conv_id,
+                        local_ts,
+                        effective_ts,
+                        MessageStatus::Sent.to_i32(),
+                    ),
+                    "update_message_timestamp_ms",
+                );
             }
 
             // Replay any buffered receipts that may have arrived before this SendTimestamp
@@ -4790,23 +5554,32 @@ impl App {
         if let Some((path, _)) = self.pending_paste_cleanups.remove(rpc_id) {
             self.pending_paste_cleanups.insert(
                 rpc_id.to_string(),
-                (path, Instant::now() + std::time::Duration::from_secs(PASTE_CLEANUP_DELAY_SECS)),
+                (
+                    path,
+                    Instant::now() + std::time::Duration::from_secs(PASTE_CLEANUP_DELAY_SECS),
+                ),
             );
         }
         if let Some((conv_id, local_ts)) = self.pending_sends.remove(rpc_id) {
             let mut found = false;
             if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                if let Some(idx) = conv.find_msg_idx(local_ts).filter(|&idx| conv.messages[idx].sender == "you") {
+                if let Some(idx) = conv
+                    .find_msg_idx(local_ts)
+                    .filter(|&idx| conv.messages[idx].sender == "you")
+                {
                     conv.messages[idx].status = Some(MessageStatus::Failed);
                     found = true;
                 }
             }
             if found {
-                self.db_warn_visible(self.db.update_message_status(
-                    &conv_id,
-                    local_ts,
-                    MessageStatus::Failed.to_i32(),
-                ), "update_message_status");
+                self.db_warn_visible(
+                    self.db.update_message_status(
+                        &conv_id,
+                        local_ts,
+                        MessageStatus::Failed.to_i32(),
+                    ),
+                    "update_message_status",
+                );
             }
         }
     }
@@ -4820,7 +5593,10 @@ impl App {
         ts: i64,
         new_status: MessageStatus,
     ) -> bool {
-        if let Some(idx) = conv.find_msg_idx(ts).filter(|&idx| conv.messages[idx].sender == "you") {
+        if let Some(idx) = conv
+            .find_msg_idx(ts)
+            .filter(|&idx| conv.messages[idx].sender == "you")
+        {
             if let Some(current) = conv.messages[idx].status {
                 if new_status > current {
                     conv.messages[idx].status = Some(new_status);
@@ -4904,7 +5680,10 @@ impl App {
         match action {
             InputAction::SendText(raw_text) => {
                 let text = input::replace_shortcodes(&raw_text);
-                if text.is_empty() && self.pending_attachment.is_none() && self.editing_message.is_none() {
+                if text.is_empty()
+                    && self.pending_attachment.is_none()
+                    && self.editing_message.is_none()
+                {
                     return None;
                 }
 
@@ -4912,13 +5691,21 @@ impl App {
                 if let Some((edit_ts, edit_conv_id)) = self.editing_message.take() {
                     if !text.is_empty() {
                         // Extract original quote fields (immutable borrow) before mutating
-                        let original_quote = self.store.conversations.get(&edit_conv_id)
-                            .and_then(|conv| conv.find_msg_idx(edit_ts).map(|idx| &conv.messages[idx]))
+                        let original_quote = self
+                            .store
+                            .conversations
+                            .get(&edit_conv_id)
+                            .and_then(|conv| {
+                                conv.find_msg_idx(edit_ts).map(|idx| &conv.messages[idx])
+                            })
                             .filter(|msg| msg.sender == "you")
                             .and_then(|msg| msg.quote.as_ref())
                             .map(|q| (q.timestamp_ms, q.author_id.clone(), q.body.clone()));
                         if let Some(conv) = self.store.conversations.get_mut(&edit_conv_id) {
-                            if let Some(idx) = conv.find_msg_idx(edit_ts).filter(|&idx| conv.messages[idx].sender == "you") {
+                            if let Some(idx) = conv
+                                .find_msg_idx(edit_ts)
+                                .filter(|&idx| conv.messages[idx].sender == "you")
+                            {
                                 conv.messages[idx].body = text.clone();
                                 conv.messages[idx].is_edited = true;
                             }
@@ -4949,30 +5736,46 @@ impl App {
                 if let Some(ref conv_id) = self.active_conversation {
                     let attachment = self.pending_attachment.take();
                     let is_group = self
-                        .store.conversations
+                        .store
+                        .conversations
                         .get(conv_id)
                         .map(|c| c.is_group)
                         .unwrap_or(false);
                     let conv_id = conv_id.clone();
 
                     // Build display body with attachment prefix; render inline image if applicable
-                    let (display_body, outgoing_image_lines, outgoing_image_path) = if let Some(ref path) = attachment {
-                        let fname = path.file_name()
-                            .map(|f| f.to_string_lossy().to_string())
-                            .unwrap_or_else(|| "file".to_string());
-                        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_lowercase();
-                        let is_image = matches!(ext.as_str(), "png" | "jpg" | "jpeg" | "gif" | "webp");
-                        let prefix = if is_image { "image" } else { "attachment" };
-                        let body = if text.is_empty() { format!("[{prefix}: {fname}]") } else { format!("[{prefix}: {fname}] {text}") };
-                        let (img_lines, img_path) = if is_image && self.image.image_mode != "none" {
-                            (image_render::render_image(path, 40), Some(path.to_string_lossy().into_owned()))
+                    let (display_body, outgoing_image_lines, outgoing_image_path) =
+                        if let Some(ref path) = attachment {
+                            let fname = path
+                                .file_name()
+                                .map(|f| f.to_string_lossy().to_string())
+                                .unwrap_or_else(|| "file".to_string());
+                            let ext = path
+                                .extension()
+                                .and_then(|e| e.to_str())
+                                .unwrap_or("")
+                                .to_lowercase();
+                            let is_image =
+                                matches!(ext.as_str(), "png" | "jpg" | "jpeg" | "gif" | "webp");
+                            let prefix = if is_image { "image" } else { "attachment" };
+                            let body = if text.is_empty() {
+                                format!("[{prefix}: {fname}]")
+                            } else {
+                                format!("[{prefix}: {fname}] {text}")
+                            };
+                            let (img_lines, img_path) =
+                                if is_image && self.image.image_mode != "none" {
+                                    (
+                                        image_render::render_image(path, 40),
+                                        Some(path.to_string_lossy().into_owned()),
+                                    )
+                                } else {
+                                    (None, None)
+                                };
+                            (body, img_lines, img_path)
                         } else {
-                            (None, None)
+                            (text.clone(), None, None)
                         };
-                        (body, img_lines, img_path)
-                    } else {
-                        (text.clone(), None, None)
-                    };
 
                     // Compute mention byte ranges for display styling
                     let mut mention_ranges = Vec::new();
@@ -4992,18 +5795,39 @@ impl App {
                     let local_ts_ms = now.timestamp_millis();
                     // Build quote for display if replying
                     let quote = self.reply_target.as_ref().map(|(author_phone, body, ts)| {
-                        let author_display = self.store.contact_names.get(author_phone)
+                        let author_display = self
+                            .store
+                            .contact_names
+                            .get(author_phone)
                             .cloned()
-                            .unwrap_or_else(|| if *author_phone == self.account { "you".to_string() } else { author_phone.clone() });
-                        Quote { author: author_display, body: body.clone(), timestamp_ms: *ts, author_id: author_phone.clone() }
+                            .unwrap_or_else(|| {
+                                if *author_phone == self.account {
+                                    "you".to_string()
+                                } else {
+                                    author_phone.clone()
+                                }
+                            });
+                        Quote {
+                            author: author_display,
+                            body: body.clone(),
+                            timestamp_ms: *ts,
+                            author_id: author_phone.clone(),
+                        }
                     });
                     let quote_timestamp = self.reply_target.as_ref().map(|(_, _, ts)| *ts);
-                    let quote_author = self.reply_target.as_ref().map(|(phone, _, _)| phone.clone());
+                    let quote_author = self
+                        .reply_target
+                        .as_ref()
+                        .map(|(phone, _, _)| phone.clone());
                     let quote_body = self.reply_target.as_ref().map(|(_, body, _)| body.clone());
 
                     // Outgoing messages inherit the conversation's expiration timer
-                    let out_expires = self.store.conversations.get(&conv_id)
-                        .map(|c| c.expiration_timer).unwrap_or(0);
+                    let out_expires = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.expiration_timer)
+                        .unwrap_or(0);
                     let out_expiry_start = if out_expires > 0 { local_ts_ms } else { 0 };
 
                     if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
@@ -5036,21 +5860,24 @@ impl App {
                             self.expiring_msg_count += 1;
                         }
                     }
-                    self.db_warn_visible(self.db.insert_message_full(
-                        &conv_id,
-                        "you",
-                        &now.to_rfc3339(),
-                        &display_body,
-                        false,
-                        Some(MessageStatus::Sending),
-                        local_ts_ms,
-                        &self.account,
-                        quote_author.as_deref(),
-                        quote_body.as_deref(),
-                        quote_timestamp,
-                        out_expires,
-                        out_expiry_start,
-                    ), "insert_message");
+                    self.db_warn_visible(
+                        self.db.insert_message_full(
+                            &conv_id,
+                            "you",
+                            &now.to_rfc3339(),
+                            &display_body,
+                            false,
+                            Some(MessageStatus::Sending),
+                            local_ts_ms,
+                            &self.account,
+                            quote_author.as_deref(),
+                            quote_body.as_deref(),
+                            quote_timestamp,
+                            out_expires,
+                            out_expiry_start,
+                        ),
+                        "insert_message",
+                    );
                     self.scroll_offset = 0;
                     self.focused_msg_index = None;
                     self.reply_target = None;
@@ -5099,7 +5926,8 @@ impl App {
                 match target.as_deref() {
                     None => {
                         // Toggle both together
-                        let new_state = !(self.notifications.notify_direct && self.notifications.notify_group);
+                        let new_state =
+                            !(self.notifications.notify_direct && self.notifications.notify_group);
                         self.notifications.notify_direct = new_state;
                         self.notifications.notify_group = new_state;
                         let state = if new_state { "on" } else { "off" };
@@ -5107,16 +5935,25 @@ impl App {
                     }
                     Some("direct" | "dm" | "1:1") => {
                         self.notifications.notify_direct = !self.notifications.notify_direct;
-                        let state = if self.notifications.notify_direct { "on" } else { "off" };
+                        let state = if self.notifications.notify_direct {
+                            "on"
+                        } else {
+                            "off"
+                        };
                         self.status_message = format!("direct notifications {state}");
                     }
                     Some("group" | "groups") => {
                         self.notifications.notify_group = !self.notifications.notify_group;
-                        let state = if self.notifications.notify_group { "on" } else { "off" };
+                        let state = if self.notifications.notify_group {
+                            "on"
+                        } else {
+                            "off"
+                        };
                         self.status_message = format!("group notifications {state}");
                     }
                     Some(other) => {
-                        self.status_message = format!("unknown bell type: {other} (use direct or group)");
+                        self.status_message =
+                            format!("unknown bell type: {other} (use direct or group)");
                     }
                 }
             }
@@ -5124,13 +5961,21 @@ impl App {
                 if let Some(ref conv_id) = self.active_conversation {
                     let conv_id = conv_id.clone();
                     if self.muted_conversations.remove(&conv_id) {
-                        let name = self.store.conversations.get(&conv_id)
-                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        let name = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.as_str())
+                            .unwrap_or(&conv_id);
                         self.status_message = format!("unmuted {name}");
                         db_warn(self.db.set_muted(&conv_id, false), "set_muted");
                     } else {
-                        let name = self.store.conversations.get(&conv_id)
-                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        let name = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.as_str())
+                            .unwrap_or(&conv_id);
                         self.status_message = format!("muted {name}");
                         self.muted_conversations.insert(conv_id.clone());
                         db_warn(self.db.set_muted(&conv_id, true), "set_muted");
@@ -5142,18 +5987,34 @@ impl App {
             InputAction::Block => {
                 if let Some(ref conv_id) = self.active_conversation {
                     let conv_id = conv_id.clone();
-                    let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                    let is_group = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.is_group)
+                        .unwrap_or(false);
                     if self.blocked_conversations.contains(&conv_id) {
-                        let name = self.store.conversations.get(&conv_id)
-                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        let name = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.as_str())
+                            .unwrap_or(&conv_id);
                         self.status_message = format!("{name} is already blocked");
                     } else {
-                        let name = self.store.conversations.get(&conv_id)
-                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        let name = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.as_str())
+                            .unwrap_or(&conv_id);
                         self.status_message = format!("blocked {name}");
                         self.blocked_conversations.insert(conv_id.clone());
                         db_warn(self.db.set_blocked(&conv_id, true), "set_blocked");
-                        return Some(SendRequest::Block { recipient: conv_id, is_group });
+                        return Some(SendRequest::Block {
+                            recipient: conv_id,
+                            is_group,
+                        });
                     }
                 } else {
                     self.status_message = "no active conversation to block".to_string();
@@ -5162,16 +6023,32 @@ impl App {
             InputAction::Unblock => {
                 if let Some(ref conv_id) = self.active_conversation {
                     let conv_id = conv_id.clone();
-                    let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                    let is_group = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.is_group)
+                        .unwrap_or(false);
                     if self.blocked_conversations.remove(&conv_id) {
-                        let name = self.store.conversations.get(&conv_id)
-                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        let name = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.as_str())
+                            .unwrap_or(&conv_id);
                         self.status_message = format!("unblocked {name}");
                         db_warn(self.db.set_blocked(&conv_id, false), "set_blocked");
-                        return Some(SendRequest::Unblock { recipient: conv_id, is_group });
+                        return Some(SendRequest::Unblock {
+                            recipient: conv_id,
+                            is_group,
+                        });
                     } else {
-                        let name = self.store.conversations.get(&conv_id)
-                            .map(|c| c.name.as_str()).unwrap_or(&conv_id);
+                        let name = self
+                            .store
+                            .conversations
+                            .get(&conv_id)
+                            .map(|c| c.name.as_str())
+                            .unwrap_or(&conv_id);
                         self.status_message = format!("{name} is not blocked");
                     }
                 } else {
@@ -5187,7 +6064,8 @@ impl App {
                 self.open_file_browser();
             }
             InputAction::Search(query) => {
-                self.search.open(query, self.active_conversation.as_deref(), &self.db);
+                self.search
+                    .open(query, self.active_conversation.as_deref(), &self.db);
             }
             InputAction::Contacts => {
                 self.contacts_overlay.show = true;
@@ -5201,7 +6079,10 @@ impl App {
             }
             InputAction::Theme => {
                 self.theme_picker.show = true;
-                self.theme_picker.index = self.theme_picker.available_themes.iter()
+                self.theme_picker.index = self
+                    .theme_picker
+                    .available_themes
+                    .iter()
                     .position(|t| t.name == self.theme.name)
                     .unwrap_or(0);
             }
@@ -5219,8 +6100,11 @@ impl App {
                     if conv.is_group {
                         // For groups, show identities for all members
                         if let Some(group) = self.store.groups.get(&conv_id) {
-                            let members: HashSet<&str> = group.members.iter().map(|s| s.as_str()).collect();
-                            self.verify.identities = self.identity_trust.keys()
+                            let members: HashSet<&str> =
+                                group.members.iter().map(|s| s.as_str()).collect();
+                            self.verify.identities = self
+                                .identity_trust
+                                .keys()
                                 .filter(|num| members.contains(num.as_str()))
                                 .filter_map(|num| {
                                     // Find matching identity info from cached data
@@ -5240,15 +6124,19 @@ impl App {
                         }
                     } else {
                         // 1:1 — show single identity
-                        self.verify.identities = self.identity_trust.get(&conv_id)
-                            .map(|tl| vec![IdentityInfo {
-                                number: Some(conv_id.clone()),
-                                uuid: None,
-                                fingerprint: String::new(),
-                                safety_number: String::new(),
-                                trust_level: *tl,
-                                added_timestamp: 0,
-                            }])
+                        self.verify.identities = self
+                            .identity_trust
+                            .get(&conv_id)
+                            .map(|tl| {
+                                vec![IdentityInfo {
+                                    number: Some(conv_id.clone()),
+                                    uuid: None,
+                                    fingerprint: String::new(),
+                                    safety_number: String::new(),
+                                    trust_level: *tl,
+                                    added_timestamp: 0,
+                                }]
+                            })
                             .unwrap_or_default();
                     }
                     self.verify.show = true;
@@ -5279,12 +6167,20 @@ impl App {
                     Ok(seconds) => {
                         if let Some(ref conv_id) = self.active_conversation {
                             let conv_id = conv_id.clone();
-                            let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                            let is_group = self
+                                .store
+                                .conversations
+                                .get(&conv_id)
+                                .map(|c| c.is_group)
+                                .unwrap_or(false);
                             // Update locally immediately
                             if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
                                 conv.expiration_timer = seconds;
                             }
-                            self.db_warn_visible(self.db.update_expiration_timer(&conv_id, seconds), "update_expiration_timer");
+                            self.db_warn_visible(
+                                self.db.update_expiration_timer(&conv_id, seconds),
+                                "update_expiration_timer",
+                            );
                             // Return a SendRequest to trigger the RPC in main.rs
                             return Some(SendRequest::UpdateExpiration {
                                 conv_id,
@@ -5300,15 +6196,29 @@ impl App {
                     }
                 }
             }
-            InputAction::Poll { question, options, allow_multiple } => {
+            InputAction::Poll {
+                question,
+                options,
+                allow_multiple,
+            } => {
                 if let Some(ref conv_id) = self.active_conversation {
                     let conv_id = conv_id.clone();
-                    let is_group = self.store.conversations.get(&conv_id).map(|c| c.is_group).unwrap_or(false);
+                    let is_group = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.is_group)
+                        .unwrap_or(false);
                     let now = Utc::now();
                     let local_ts_ms = now.timestamp_millis();
 
-                    let poll_options: Vec<PollOption> = options.iter().enumerate()
-                        .map(|(i, text)| PollOption { id: i as i64, text: text.clone() })
+                    let poll_options: Vec<PollOption> = options
+                        .iter()
+                        .enumerate()
+                        .map(|(i, text)| PollOption {
+                            id: i as i64,
+                            text: text.clone(),
+                        })
                         .collect();
                     let poll_data = PollData {
                         question: question.clone(),
@@ -5346,13 +6256,29 @@ impl App {
                             preview_image_path: None,
                         });
                     }
-                    self.db_warn_visible(self.db.insert_message_full(
-                        &conv_id, "you", &now.to_rfc3339(),
-                        &format!("\u{1F4CA} {question}"),
-                        false, Some(MessageStatus::Sending), local_ts_ms,
-                        &self.account.clone(), None, None, None, 0, 0,
-                    ), "insert_poll_msg");
-                    self.db_warn_visible(self.db.upsert_poll_data(&conv_id, local_ts_ms, &poll_data_for_db), "upsert_poll_data");
+                    self.db_warn_visible(
+                        self.db.insert_message_full(
+                            &conv_id,
+                            "you",
+                            &now.to_rfc3339(),
+                            &format!("\u{1F4CA} {question}"),
+                            false,
+                            Some(MessageStatus::Sending),
+                            local_ts_ms,
+                            &self.account.clone(),
+                            None,
+                            None,
+                            None,
+                            0,
+                            0,
+                        ),
+                        "insert_poll_msg",
+                    );
+                    self.db_warn_visible(
+                        self.db
+                            .upsert_poll_data(&conv_id, local_ts_ms, &poll_data_for_db),
+                        "upsert_poll_data",
+                    );
 
                     self.scroll_offset = 0;
                     return Some(SendRequest::PollCreate {
@@ -5438,9 +6364,7 @@ impl App {
             // Collect groups
             for group in self.store.groups.values() {
                 let display = format!("#{}", group.name);
-                if filter_lower.is_empty()
-                    || group.name.to_lowercase().contains(&filter_lower)
-                {
+                if filter_lower.is_empty() || group.name.to_lowercase().contains(&filter_lower) {
                     candidates.push((display, group.id.clone()));
                 }
             }
@@ -5448,9 +6372,7 @@ impl App {
             // Also include existing conversations not yet covered
             for conv_id in &self.store.conversation_order {
                 if let Some(conv) = self.store.conversations.get(conv_id) {
-                    let already_listed = candidates.iter().any(|(_, val)| {
-                        val == conv_id
-                    });
+                    let already_listed = candidates.iter().any(|(_, val)| val == conv_id);
                     if !already_listed {
                         let display = if conv.is_group {
                             format!("#{}", conv.name)
@@ -5493,7 +6415,8 @@ impl App {
                         if let Some(group) = self.store.groups.get(conv_id) {
                             for member_phone in &group.members {
                                 let name = self
-                                    .store.contact_names
+                                    .store
+                                    .contact_names
                                     .get(member_phone)
                                     .cloned()
                                     .unwrap_or_else(|| member_phone.clone());
@@ -5509,7 +6432,8 @@ impl App {
                     } else {
                         // 1:1 chat: offer the contact as a mention candidate
                         let name = self
-                            .store.contact_names
+                            .store
+                            .contact_names
                             .get(conv_id)
                             .cloned()
                             .unwrap_or_else(|| conv_id.clone());
@@ -5639,7 +6563,11 @@ impl App {
                     let lines: Vec<&str> = self.input_buffer.split('\n').collect();
                     let target_line = lines[line - 1];
                     let target_chars = target_line.chars().count();
-                    let target_col: usize = target_line.chars().take(col.min(target_chars)).map(|c| c.len_utf8()).sum();
+                    let target_col: usize = target_line
+                        .chars()
+                        .take(col.min(target_chars))
+                        .map(|c| c.len_utf8())
+                        .sum();
                     let offset: usize = lines.iter().take(line - 1).map(|l| l.len() + 1).sum();
                     self.input_cursor = offset + target_col;
                 } else {
@@ -5654,7 +6582,11 @@ impl App {
                     let lines: Vec<&str> = self.input_buffer.split('\n').collect();
                     let target_line = lines[line + 1];
                     let target_chars = target_line.chars().count();
-                    let target_col: usize = target_line.chars().take(col.min(target_chars)).map(|c| c.len_utf8()).sum();
+                    let target_col: usize = target_line
+                        .chars()
+                        .take(col.min(target_chars))
+                        .map(|c| c.len_utf8())
+                        .sum();
                     let offset: usize = lines.iter().take(line + 1).map(|l| l.len() + 1).sum();
                     self.input_cursor = offset + target_col;
                 } else {
@@ -5715,13 +6647,17 @@ impl App {
         // Skip whitespace before cursor
         while pos > 0 {
             let prev = buf[..pos].chars().next_back().unwrap();
-            if !prev.is_whitespace() { break; }
+            if !prev.is_whitespace() {
+                break;
+            }
             pos -= prev.len_utf8();
         }
         // Skip word chars
         while pos > 0 {
             let prev = buf[..pos].chars().next_back().unwrap();
-            if prev.is_whitespace() { break; }
+            if prev.is_whitespace() {
+                break;
+            }
             pos -= prev.len_utf8();
         }
         self.input_buffer.drain(pos..self.input_cursor);
@@ -5744,7 +6680,10 @@ impl App {
         if !self.typing.sent
             && !self.input_buffer.is_empty()
             && !self.input_buffer.starts_with('/')
-            && self.active_conversation.as_ref().is_some_and(|id| !self.blocked_conversations.contains(id))
+            && self
+                .active_conversation
+                .as_ref()
+                .is_some_and(|id| !self.blocked_conversations.contains(id))
         {
             self.typing.sent = true;
             return self.build_typing_request(false);
@@ -5771,7 +6710,8 @@ impl App {
         let width = img_data.width as u32;
         let height = img_data.height as u32;
 
-        let img: RgbaImage = match ImageBuffer::from_raw(width, height, img_data.bytes.into_owned()) {
+        let img: RgbaImage = match ImageBuffer::from_raw(width, height, img_data.bytes.into_owned())
+        {
             Some(img) => img,
             None => {
                 self.status_message = "Failed to decode clipboard image".to_string();
@@ -5835,7 +6775,11 @@ impl App {
     pub fn apply_autocomplete(&mut self) {
         match self.autocomplete.mode {
             AutocompleteMode::Command => {
-                if let Some(&cmd_idx) = self.autocomplete.command_candidates.get(self.autocomplete.index) {
+                if let Some(&cmd_idx) = self
+                    .autocomplete
+                    .command_candidates
+                    .get(self.autocomplete.index)
+                {
                     let cmd = &COMMANDS[cmd_idx];
                     if cmd.args.is_empty() {
                         self.input_buffer = cmd.name.to_string();
@@ -5849,8 +6793,11 @@ impl App {
                 }
             }
             AutocompleteMode::Mention => {
-                if let Some((_phone, name, uuid)) =
-                    self.autocomplete.mention_candidates.get(self.autocomplete.index).cloned()
+                if let Some((_phone, name, uuid)) = self
+                    .autocomplete
+                    .mention_candidates
+                    .get(self.autocomplete.index)
+                    .cloned()
                 {
                     // Replace @partial with @FullName followed by a space
                     let replacement = format!("@{name} ");
@@ -5866,8 +6813,11 @@ impl App {
                 }
             }
             AutocompleteMode::Join => {
-                if let Some((_display, value)) =
-                    self.autocomplete.join_candidates.get(self.autocomplete.index).cloned()
+                if let Some((_display, value)) = self
+                    .autocomplete
+                    .join_candidates
+                    .get(self.autocomplete.index)
+                    .cloned()
                 {
                     self.input_buffer = format!("/join {value}");
                     self.input_cursor = self.input_buffer.len();
@@ -5881,7 +6831,8 @@ impl App {
 
     fn save_scroll_position(&mut self) {
         if let Some(ref id) = self.active_conversation {
-            self.scroll_positions.insert(id.clone(), (self.scroll_offset, self.focused_msg_index));
+            self.scroll_positions
+                .insert(id.clone(), (self.scroll_offset, self.focused_msg_index));
         }
     }
 
@@ -5919,7 +6870,8 @@ impl App {
         // Try matching by name (case-insensitive)
         let target_lower = target.to_lowercase();
         let found_id = self
-            .store.conversations
+            .store
+            .conversations
             .iter()
             .find(|(_, conv)| conv.name.to_lowercase().contains(&target_lower))
             .map(|(id, _)| id.clone());
@@ -5939,7 +6891,8 @@ impl App {
 
         // Create a new 1:1 conversation if target looks like a phone number
         if target.starts_with('+') {
-            self.store.get_or_create_conversation(target, target, false, &self.db);
+            self.store
+                .get_or_create_conversation(target, target, false, &self.db);
             self.active_conversation = Some(target.to_string());
             self.scroll_offset = 0;
             self.focused_msg_index = None;
@@ -5966,7 +6919,12 @@ impl App {
             .map(|i| (i + 1) % self.store.conversation_order.len())
             .unwrap_or(0);
         let new_id = self.store.conversation_order[idx].clone();
-        let read_from = self.store.last_read_index.get(&new_id).copied().unwrap_or(0);
+        let read_from = self
+            .store
+            .last_read_index
+            .get(&new_id)
+            .copied()
+            .unwrap_or(0);
         self.queue_read_receipts_for_conv(&new_id, read_from);
         self.active_conversation = Some(new_id.clone());
         if let Some(conv) = self.store.conversations.get_mut(&new_id) {
@@ -5995,7 +6953,12 @@ impl App {
             .map(|i| if i == 0 { len - 1 } else { i - 1 })
             .unwrap_or(0);
         let new_id = self.store.conversation_order[idx].clone();
-        let read_from = self.store.last_read_index.get(&new_id).copied().unwrap_or(0);
+        let read_from = self
+            .store
+            .last_read_index
+            .get(&new_id)
+            .copied()
+            .unwrap_or(0);
         self.queue_read_receipts_for_conv(&new_id, read_from);
         self.active_conversation = Some(new_id.clone());
         if let Some(conv) = self.store.conversations.get_mut(&new_id) {
@@ -6013,7 +6976,9 @@ impl App {
                 self.status_message = format!("connected | {}{}", prefix, conv.name);
             }
             // Show message request overlay for unaccepted conversations
-            self.show_message_request = self.active_conversation.as_ref()
+            self.show_message_request = self
+                .active_conversation
+                .as_ref()
                 .and_then(|id| self.store.conversations.get(id))
                 .is_some_and(|c| !c.accepted);
         } else {
@@ -6033,9 +6998,9 @@ impl App {
     pub fn selected_message(&self) -> Option<&DisplayMessage> {
         let conv_id = self.active_conversation.as_ref()?;
         let conv = self.store.conversations.get(conv_id)?;
-        let index = self.focused_msg_index.unwrap_or_else(|| {
-            conv.messages.len().saturating_sub(1)
-        });
+        let index = self
+            .focused_msg_index
+            .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
         conv.messages.get(index)
     }
 
@@ -6090,7 +7055,12 @@ impl App {
             Some(msg) if msg.is_system => Some(msg.body.clone()),
             Some(msg) => {
                 if full_line {
-                    Some(format!("[{}] <{}> {}", msg.format_time(), msg.sender, msg.body))
+                    Some(format!(
+                        "[{}] <{}> {}",
+                        msg.format_time(),
+                        msg.sender,
+                        msg.body
+                    ))
                 } else {
                     Some(msg.body.clone())
                 }
@@ -6136,14 +7106,15 @@ impl App {
     /// Delete any paste temp files whose 10s delay has elapsed.
     /// Called each tick from the main event loop.
     pub fn cleanup_paste_files(&mut self) {
-        self.pending_paste_cleanups.retain(|_rpc_id, (path, delete_after)| {
-            if Instant::now() >= *delete_after {
-                let _ = std::fs::remove_file(path);
-                false
-            } else {
-                true
-            }
-        });
+        self.pending_paste_cleanups
+            .retain(|_rpc_id, (path, delete_after)| {
+                if Instant::now() >= *delete_after {
+                    let _ = std::fs::remove_file(path);
+                    false
+                } else {
+                    true
+                }
+            });
     }
 
     // --- Mouse support ---
@@ -6193,17 +7164,19 @@ impl App {
                 self.handle_left_click(event.column, event.row);
             }
             MouseEventKind::ScrollUp
-                if is_in_rect(event.column, event.row, self.mouse_messages_area) => {
-                    self.sync.user_scrolled = true;
-                    self.scroll_offset = self.scroll_offset.saturating_add(3);
-                    self.focused_msg_index = None;
-                }
+                if is_in_rect(event.column, event.row, self.mouse_messages_area) =>
+            {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_add(3);
+                self.focused_msg_index = None;
+            }
             MouseEventKind::ScrollDown
-                if is_in_rect(event.column, event.row, self.mouse_messages_area) => {
-                    self.sync.user_scrolled = true;
-                    self.scroll_offset = self.scroll_offset.saturating_sub(3);
-                    self.focused_msg_index = None;
-                }
+                if is_in_rect(event.column, event.row, self.mouse_messages_area) =>
+            {
+                self.sync.user_scrolled = true;
+                self.scroll_offset = self.scroll_offset.saturating_sub(3);
+                self.focused_msg_index = None;
+            }
             _ => {}
         }
         None
@@ -6223,11 +7196,12 @@ impl App {
         if let Some(inner) = self.mouse_sidebar_inner {
             if is_in_rect(col, row, inner) {
                 let index = (row - inner.y) as usize;
-                let sidebar_list = if self.sidebar_filter_active && !self.sidebar_filtered.is_empty() {
-                    &self.sidebar_filtered
-                } else {
-                    &self.store.conversation_order
-                };
+                let sidebar_list =
+                    if self.sidebar_filter_active && !self.sidebar_filtered.is_empty() {
+                        &self.sidebar_filtered
+                    } else {
+                        &self.store.conversation_order
+                    };
                 if index < sidebar_list.len() {
                     let conv_id = sidebar_list[index].clone();
                     self.clear_sidebar_filter();
@@ -6245,7 +7219,10 @@ impl App {
             if col >= content_start_col {
                 let text_width = (self.mouse_input_area.width.saturating_sub(2)) as usize
                     - self.mouse_input_prefix_len as usize;
-                let input_scroll = floor_char_boundary(&self.input_buffer, self.input_cursor.saturating_sub(text_width));
+                let input_scroll = floor_char_boundary(
+                    &self.input_buffer,
+                    self.input_cursor.saturating_sub(text_width),
+                );
                 let target_col = (col - content_start_col) as usize;
                 // Walk characters to find the byte offset for the target column
                 let mut byte_pos = input_scroll;
@@ -6316,20 +7293,34 @@ impl App {
 
         // Build plain text output
         let mut output = String::new();
-        let safe_name: String = conv.name.chars()
-            .map(|c| if c.is_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        let safe_name: String = conv
+            .name
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() || c == '-' || c == '_' {
+                    c
+                } else {
+                    '_'
+                }
+            })
             .collect();
         let date = chrono::Local::now().format("%Y-%m-%d");
         let filename = format!("siggy-export-{safe_name}-{date}.txt");
 
         output.push_str(&format!("Chat export: {}\n", conv.name));
-        output.push_str(&format!("Exported: {}\n", chrono::Local::now().format("%Y-%m-%d %H:%M")));
+        output.push_str(&format!(
+            "Exported: {}\n",
+            chrono::Local::now().format("%Y-%m-%d %H:%M")
+        ));
         output.push_str(&format!("Messages: {}\n", export_msgs.len()));
         output.push_str(&"-".repeat(60));
         output.push('\n');
 
         for msg in export_msgs {
-            let time = msg.timestamp.with_timezone(&chrono::Local).format("%Y-%m-%d %H:%M");
+            let time = msg
+                .timestamp
+                .with_timezone(&chrono::Local)
+                .format("%Y-%m-%d %H:%M");
             if msg.is_system {
                 output.push_str(&format!("[{time}] * {}\n", msg.body));
             } else {
@@ -6349,22 +7340,22 @@ impl App {
 
         match std::fs::write(&path, &output) {
             Ok(()) => {
-                self.status_message = format!("Exported {} messages to {}", export_msgs.len(), path.display());
+                self.status_message = format!(
+                    "Exported {} messages to {}",
+                    export_msgs.len(),
+                    path.display()
+                );
             }
             Err(e) => {
                 self.status_message = format!("Export failed: {e}");
             }
         }
     }
-
 }
 
 /// Simple point-in-rect hit test for mouse coordinates.
 fn is_in_rect(col: u16, row: u16, rect: Rect) -> bool {
-    col >= rect.x
-        && col < rect.x + rect.width
-        && row >= rect.y
-        && row < rect.y + rect.height
+    col >= rect.x && col < rect.x + rect.width && row >= rect.y && row < rect.y + rect.height
 }
 
 /// Convert a local file path to a file:/// URI (forward slashes, for terminal Ctrl+Click).
@@ -6383,9 +7374,13 @@ fn file_uri_to_path(uri: &str) -> String {
     let uri = uri.trim();
     if let Some(rest) = uri.strip_prefix("file:///") {
         #[cfg(windows)]
-        { rest.to_string() }
+        {
+            rest.to_string()
+        }
         #[cfg(not(windows))]
-        { format!("/{rest}")}
+        {
+            format!("/{rest}")
+        }
     } else if let Some(rest) = uri.strip_prefix("file://") {
         rest.to_string()
     } else {
@@ -6427,10 +7422,10 @@ impl App {
     /// Populate the app with demo conversations for `--demo` mode and snapshot tests.
     /// `base_date` is used for deterministic timestamps instead of `Utc::now()`.
     pub(crate) fn populate_demo_data(&mut self, base_date: chrono::NaiveDate) {
-        use chrono::{Local, TimeZone};
         use crate::signal::types::{
             Group, LinkPreview, MessageStatus, PollData, PollOption, PollVote, Reaction, StyleType,
         };
+        use chrono::{Local, TimeZone};
 
         let today = base_date;
         // Build timestamps via the local timezone so that format_time() (which
@@ -6456,7 +7451,11 @@ impl App {
                 is_system: false,
                 image_lines: None,
                 image_path: None,
-                status: if is_outgoing { Some(MessageStatus::Sent) } else { None },
+                status: if is_outgoing {
+                    Some(MessageStatus::Sent)
+                } else {
+                    None
+                },
                 timestamp_ms: time.timestamp_millis(),
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
@@ -6482,15 +7481,35 @@ impl App {
         let mut alice_msgs = vec![
             dm("Alice", ts(8, 0), "Good morning! How's your day going?"),
             dm("you", ts(8, 5), "Just getting started, coffee in hand"),
-            dm("Alice", ts(8, 10), "Nice! I've been up since 6, went for a run"),
-            dm("you", ts(8, 15), "Impressive. I can barely get out of bed before 7"),
-            dm("Alice", ts(8, 20), "Ha! It gets easier once you build the habit"),
+            dm(
+                "Alice",
+                ts(8, 10),
+                "Nice! I've been up since 6, went for a run",
+            ),
+            dm(
+                "you",
+                ts(8, 15),
+                "Impressive. I can barely get out of bed before 7",
+            ),
+            dm(
+                "Alice",
+                ts(8, 20),
+                "Ha! It gets easier once you build the habit",
+            ),
             dm("you", ts(8, 25), "That's what everyone says..."),
-            dm("Alice", ts(8, 30), "Trust me, after a week it becomes automatic"),
+            dm(
+                "Alice",
+                ts(8, 30),
+                "Trust me, after a week it becomes automatic",
+            ),
         ];
 
         // Quote reply: Alice replies to "coffee in hand"
-        let mut alice_reply = dm("Alice", ts(8, 35), "Honestly same, I need my coffee first too");
+        let mut alice_reply = dm(
+            "Alice",
+            ts(8, 35),
+            "Honestly same, I need my coffee first too",
+        );
         alice_reply.quote = Some(Quote {
             author: "you".to_string(),
             body: "Just getting started, coffee in hand".to_string(),
@@ -6503,34 +7522,48 @@ impl App {
         alice_msgs.push(dm("Alice", ts(8, 42), "Yeah! What did you have in mind?"));
 
         // Link preview
-        let mut link_msg = dm("Alice", ts(8, 45), "There's this farmers market: https://localmarket.example.com");
+        let mut link_msg = dm(
+            "Alice",
+            ts(8, 45),
+            "There's this farmers market: https://localmarket.example.com",
+        );
         link_msg.preview = Some(LinkPreview {
             url: "https://localmarket.example.com".to_string(),
             title: Some("Downtown Farmers Market".to_string()),
-            description: Some("Fresh produce, artisan goods, and live music every Saturday 8am-1pm".to_string()),
+            description: Some(
+                "Fresh produce, artisan goods, and live music every Saturday 8am-1pm".to_string(),
+            ),
             image_path: None,
         });
         alice_msgs.push(link_msg);
 
         alice_msgs.push(dm("you", ts(8, 47), "Oh nice, what time should we go?"));
-        alice_msgs.push(dm("Alice", ts(8, 48), "Opens at 8, but 9 is fine. Less crowded."));
+        alice_msgs.push(dm(
+            "Alice",
+            ts(8, 48),
+            "Opens at 8, but 9 is fine. Less crowded.",
+        ));
         alice_msgs.push(dm("you", ts(8, 50), "Perfect, let's do 9"));
         alice_msgs.push(dm("Alice", ts(8, 52), "I'll pick you up at 8:45"));
 
         // Edited message
-        let mut edited_msg = dm("you", ts(8, 55), "Actually make it 8:30, I want to browse early");
+        let mut edited_msg = dm(
+            "you",
+            ts(8, 55),
+            "Actually make it 8:30, I want to browse early",
+        );
         edited_msg.is_edited = true;
         alice_msgs.push(edited_msg);
 
         alice_msgs.push(dm("Alice", ts(8, 57), "Even better! See you Saturday"));
 
         // Varied delivery statuses on outgoing messages
-        alice_msgs[1].status = Some(MessageStatus::Read);     // "coffee in hand"
-        alice_msgs[3].status = Some(MessageStatus::Read);     // "barely get out of bed"
-        alice_msgs[5].status = Some(MessageStatus::Read);     // "what everyone says"
+        alice_msgs[1].status = Some(MessageStatus::Read); // "coffee in hand"
+        alice_msgs[3].status = Some(MessageStatus::Read); // "barely get out of bed"
+        alice_msgs[5].status = Some(MessageStatus::Read); // "what everyone says"
         alice_msgs[8].status = Some(MessageStatus::Delivered); // "are you free"
         alice_msgs[12].status = Some(MessageStatus::Delivered); // "let's do 9"
-        alice_msgs[14].status = Some(MessageStatus::Sent);     // edited msg
+        alice_msgs[14].status = Some(MessageStatus::Sent); // edited msg
 
         let alice = Conversation {
             name: "Alice".to_string(),
@@ -6544,15 +7577,27 @@ impl App {
 
         // --- Bob: code review (with styled text) ---
         let bob_id = "+15550002222".to_string();
-        let mut bob_styled = dm("Bob", ts(10, 5), "Can you review my PR? It's the auth refactor");
+        let mut bob_styled = dm(
+            "Bob",
+            ts(10, 5),
+            "Can you review my PR? It's the auth refactor",
+        );
         // "auth refactor" is bold (bytes 33..47)
         bob_styled.style_ranges = vec![(33, 47, StyleType::Bold)];
 
-        let mut bob_code = dm("Bob", ts(10, 8), "The key change is in verify_token() — switched from HMAC to Ed25519");
+        let mut bob_code = dm(
+            "Bob",
+            ts(10, 8),
+            "The key change is in verify_token() — switched from HMAC to Ed25519",
+        );
         // "verify_token()" is monospace (bytes 22..36)
         bob_code.style_ranges = vec![(22, 36, StyleType::Monospace)];
 
-        let mut bob_reply = dm("you", ts(10, 12), "Looks good! Left a few comments on the error handling");
+        let mut bob_reply = dm(
+            "you",
+            ts(10, 12),
+            "Looks good! Left a few comments on the error handling",
+        );
         bob_reply.status = Some(MessageStatus::Read);
 
         let bob_thanks = dm("Bob", ts(10, 15), "Thanks! I'll address those. Also the migration is backwards-compatible so no rush on deploy");
@@ -6575,7 +7620,14 @@ impl App {
         let bob = Conversation {
             name: "Bob".to_string(),
             id: bob_id.clone(),
-            messages: vec![bob_styled, bob_code, bob_reply, bob_thanks, bob_followup, bob_lgtm],
+            messages: vec![
+                bob_styled,
+                bob_code,
+                bob_reply,
+                bob_thanks,
+                bob_followup,
+                bob_lgtm,
+            ],
             unread: 0,
             is_group: false,
             expiration_timer: 0,
@@ -6587,9 +7639,11 @@ impl App {
         let carol = Conversation {
             name: "Carol".to_string(),
             id: carol_id.clone(),
-            messages: vec![
-                dm("Carol", ts(11, 45), "Did you see the announcement about the office move?"),
-            ],
+            messages: vec![dm(
+                "Carol",
+                ts(11, 45),
+                "Did you see the announcement about the office move?",
+            )],
             unread: 1,
             is_group: false,
             expiration_timer: 0,
@@ -6610,7 +7664,11 @@ impl App {
         dave_msg2.expires_in_seconds = 86400;
         dave_msg2.expiration_start_ms = ts(8, 5).timestamp_millis();
 
-        let mut dave_msg3 = dm("Dave", ts(8, 6), "Bring your laptop if you want to hack on stuff");
+        let mut dave_msg3 = dm(
+            "Dave",
+            ts(8, 6),
+            "Bring your laptop if you want to hack on stuff",
+        );
         dave_msg3.expires_in_seconds = 86400;
         dave_msg3.expiration_start_ms = ts(8, 6).timestamp_millis();
 
@@ -6627,10 +7685,18 @@ impl App {
         // --- #Rust Devs: group discussion with @mentions, poll, pinned msg ---
         let rust_id = "group_rustdevs".to_string();
 
-        let mut pinned_msg = dm("Alice", ts(10, 30), "Has anyone tried the new async trait syntax?");
+        let mut pinned_msg = dm(
+            "Alice",
+            ts(10, 30),
+            "Has anyone tried the new async trait syntax?",
+        );
         pinned_msg.is_pinned = true;
 
-        let mut bob_group = dm("Bob", ts(10, 32), "Yeah, it's so much cleaner than the pin-based approach");
+        let mut bob_group = dm(
+            "Bob",
+            ts(10, 32),
+            "Yeah, it's so much cleaner than the pin-based approach",
+        );
         // "so much cleaner" in italic (bytes 9..24)
         bob_group.style_ranges = vec![(9, 24, StyleType::Italic)];
 
@@ -6639,15 +7705,25 @@ impl App {
         let mut you_group = dm("you", ts(10, 40), "The desugaring docs helped me a lot");
         you_group.status = Some(MessageStatus::Read);
 
-        let mut alice_mention = dm("Alice", ts(10, 42), "Can you share the link? @Bob might want it too");
+        let mut alice_mention = dm(
+            "Alice",
+            ts(10, 42),
+            "Can you share the link? @Bob might want it too",
+        );
         alice_mention.mention_ranges = vec![(24, 28)];
 
-        let mut you_link = dm("you", ts(10, 43), "Here you go: https://blog.rust-lang.org/async-traits");
+        let mut you_link = dm(
+            "you",
+            ts(10, 43),
+            "Here you go: https://blog.rust-lang.org/async-traits",
+        );
         you_link.status = Some(MessageStatus::Delivered);
         you_link.preview = Some(LinkPreview {
             url: "https://blog.rust-lang.org/async-traits".to_string(),
             title: Some("Async Trait Methods in Stable Rust".to_string()),
-            description: Some("A deep dive into the stabilization of async fn in traits".to_string()),
+            description: Some(
+                "A deep dive into the stabilization of async fn in traits".to_string(),
+            ),
             image_path: None,
         });
 
@@ -6656,24 +7732,61 @@ impl App {
         poll_msg.poll_data = Some(PollData {
             question: "Which async runtime do you prefer?".to_string(),
             options: vec![
-                PollOption { id: 0, text: "Tokio".to_string() },
-                PollOption { id: 1, text: "async-std".to_string() },
-                PollOption { id: 2, text: "smol".to_string() },
+                PollOption {
+                    id: 0,
+                    text: "Tokio".to_string(),
+                },
+                PollOption {
+                    id: 1,
+                    text: "async-std".to_string(),
+                },
+                PollOption {
+                    id: 2,
+                    text: "smol".to_string(),
+                },
             ],
             allow_multiple: false,
             closed: false,
         });
         poll_msg.poll_votes = vec![
-            PollVote { voter: "+15550001111".to_string(), voter_name: Some("Alice".to_string()), option_indexes: vec![0], vote_count: 1 },
-            PollVote { voter: "+15550002222".to_string(), voter_name: Some("Bob".to_string()), option_indexes: vec![0], vote_count: 1 },
-            PollVote { voter: "+15550004444".to_string(), voter_name: Some("Dave".to_string()), option_indexes: vec![2], vote_count: 1 },
-            PollVote { voter: "you".to_string(), voter_name: Some("you".to_string()), option_indexes: vec![0], vote_count: 1 },
+            PollVote {
+                voter: "+15550001111".to_string(),
+                voter_name: Some("Alice".to_string()),
+                option_indexes: vec![0],
+                vote_count: 1,
+            },
+            PollVote {
+                voter: "+15550002222".to_string(),
+                voter_name: Some("Bob".to_string()),
+                option_indexes: vec![0],
+                vote_count: 1,
+            },
+            PollVote {
+                voter: "+15550004444".to_string(),
+                voter_name: Some("Dave".to_string()),
+                option_indexes: vec![2],
+                vote_count: 1,
+            },
+            PollVote {
+                voter: "you".to_string(),
+                voter_name: Some("you".to_string()),
+                option_indexes: vec![0],
+                vote_count: 1,
+            },
         ];
 
         let rust_group = Conversation {
             name: "#Rust Devs".to_string(),
             id: rust_id.clone(),
-            messages: vec![pinned_msg, bob_group, dave_group, you_group, alice_mention, you_link, poll_msg],
+            messages: vec![
+                pinned_msg,
+                bob_group,
+                dave_group,
+                you_group,
+                alice_mention,
+                you_link,
+                poll_msg,
+            ],
             unread: 0,
             is_group: true,
             expiration_timer: 0,
@@ -6716,9 +7829,11 @@ impl App {
         let eve = Conversation {
             name: "+15550007777".to_string(),
             id: eve_id.clone(),
-            messages: vec![
-                dm("+15550007777", ts(14, 0), "Hey, I got your number from the meetup. Is this the right person?"),
-            ],
+            messages: vec![dm(
+                "+15550007777",
+                ts(14, 0),
+                "Hey, I got your number from the meetup. Is this the right person?",
+            )],
             unread: 1,
             is_group: false,
             expiration_timer: 0,
@@ -6742,7 +7857,8 @@ impl App {
             let unread = conv.unread;
             self.store.conversations.insert(id.clone(), conv);
             if msg_count > 0 {
-                self.store.last_read_index
+                self.store
+                    .last_read_index
                     .insert(id, msg_count.saturating_sub(unread));
             }
         }
@@ -6761,9 +7877,15 @@ impl App {
             (&dad_id, "Dad", "ffff-dad-uuid"),
         ];
         for (phone, name, uuid) in &demo_contacts {
-            self.store.contact_names.insert(phone.to_string(), name.to_string());
-            self.store.uuid_to_name.insert(uuid.to_string(), name.to_string());
-            self.store.number_to_uuid.insert(phone.to_string(), uuid.to_string());
+            self.store
+                .contact_names
+                .insert(phone.to_string(), name.to_string());
+            self.store
+                .uuid_to_name
+                .insert(uuid.to_string(), name.to_string());
+            self.store
+                .number_to_uuid
+                .insert(phone.to_string(), uuid.to_string());
         }
 
         // Populate groups with correct members
@@ -6790,34 +7912,61 @@ impl App {
         if let Some(conv) = self.store.conversations.get_mut(&alice_id) {
             // Alice's first message gets a thumbs up from "you"
             if let Some(msg) = conv.messages.get_mut(0) {
-                msg.reactions.push(Reaction { emoji: "\u{1f44d}".to_string(), sender: "you".to_string() });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{1f44d}".to_string(),
+                    sender: "you".to_string(),
+                });
             }
             // "coffee in hand" gets a heart from Alice
             if let Some(msg) = conv.messages.get_mut(1) {
-                msg.reactions.push(Reaction { emoji: "\u{2764}\u{fe0f}".to_string(), sender: "Alice".to_string() });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{2764}\u{fe0f}".to_string(),
+                    sender: "Alice".to_string(),
+                });
             }
             // "See you Saturday" gets multiple reactions
             if let Some(msg) = conv.messages.last_mut() {
-                msg.reactions.push(Reaction { emoji: "\u{1f389}".to_string(), sender: "you".to_string() });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{1f389}".to_string(),
+                    sender: "you".to_string(),
+                });
             }
         }
         if let Some(conv) = self.store.conversations.get_mut("group_rustdevs") {
             // "desugaring docs" message gets multiple reactions
             if let Some(msg) = conv.messages.get_mut(3) {
-                msg.reactions.push(Reaction { emoji: "\u{1f44d}".to_string(), sender: "Alice".to_string() });
-                msg.reactions.push(Reaction { emoji: "\u{1f44d}".to_string(), sender: "Bob".to_string() });
-                msg.reactions.push(Reaction { emoji: "\u{2764}\u{fe0f}".to_string(), sender: "Dave".to_string() });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{1f44d}".to_string(),
+                    sender: "Alice".to_string(),
+                });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{1f44d}".to_string(),
+                    sender: "Bob".to_string(),
+                });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{2764}\u{fe0f}".to_string(),
+                    sender: "Dave".to_string(),
+                });
             }
             // Pinned msg gets a pushpin reaction
             if let Some(msg) = conv.messages.get_mut(0) {
-                msg.reactions.push(Reaction { emoji: "\u{1f4cc}".to_string(), sender: "Dave".to_string() });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{1f4cc}".to_string(),
+                    sender: "Dave".to_string(),
+                });
             }
         }
         if let Some(conv) = self.store.conversations.get_mut("group_family") {
             // "Count me in!" gets hearts from both parents
             if let Some(msg) = conv.messages.get_mut(2) {
-                msg.reactions.push(Reaction { emoji: "\u{2764}\u{fe0f}".to_string(), sender: "Mom".to_string() });
-                msg.reactions.push(Reaction { emoji: "\u{2764}\u{fe0f}".to_string(), sender: "Dad".to_string() });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{2764}\u{fe0f}".to_string(),
+                    sender: "Mom".to_string(),
+                });
+                msg.reactions.push(Reaction {
+                    emoji: "\u{2764}\u{fe0f}".to_string(),
+                    sender: "Dad".to_string(),
+                });
             }
         }
     }
@@ -6827,7 +7976,9 @@ impl App {
 mod tests {
     use super::*;
     use crate::db::Database;
-    use crate::signal::types::{Attachment, Contact, Group, Mention, SignalEvent, SignalMessage, StyleType, TextStyle};
+    use crate::signal::types::{
+        Attachment, Contact, Group, Mention, SignalEvent, SignalMessage, StyleType, TextStyle,
+    };
     use crossterm::event::{KeyCode, KeyModifiers};
     use rstest::{fixture, rstest};
 
@@ -6846,8 +7997,16 @@ mod tests {
         assert!(app.store.conversations.is_empty());
 
         app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+1".to_string(), name: Some("Alice".to_string()), uuid: None },
-            Contact { number: "+2".to_string(), name: Some("Bob".to_string()), uuid: None },
+            Contact {
+                number: "+1".to_string(),
+                name: Some("Alice".to_string()),
+                uuid: None,
+            },
+            Contact {
+                number: "+2".to_string(),
+                name: Some("Bob".to_string()),
+                uuid: None,
+            },
         ]));
 
         // No conversations created — only name lookup populated
@@ -6859,10 +8018,19 @@ mod tests {
 
     #[rstest]
     fn group_list_creates_conversations(mut app: App) {
-
         app.handle_signal_event(SignalEvent::GroupList(vec![
-            Group { id: "g1".to_string(), name: "Family".to_string(), members: vec![], member_uuids: vec![] },
-            Group { id: "g2".to_string(), name: "Work".to_string(), members: vec![], member_uuids: vec![] },
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec![],
+                member_uuids: vec![],
+            },
+            Group {
+                id: "g2".to_string(),
+                name: "Work".to_string(),
+                members: vec![],
+                member_uuids: vec![],
+            },
         ]));
 
         // Groups always create conversations (you're a member)
@@ -6877,7 +8045,6 @@ mod tests {
 
     #[rstest]
     fn contact_name_updates_existing_conversation(mut app: App) {
-
         // A message arrives first with just a phone number
         let msg = SignalMessage {
             source: "+15551234567".to_string(),
@@ -6900,16 +8067,17 @@ mod tests {
         assert_eq!(app.store.conversations["+15551234567"].name, "+15551234567");
 
         // Contact list arrives with a proper name — updates existing conv
-        app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+15551234567".to_string(), name: Some("Alice".to_string()), uuid: None },
-        ]));
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+15551234567".to_string(),
+            name: Some("Alice".to_string()),
+            uuid: None,
+        }]));
 
         assert_eq!(app.store.conversations["+15551234567"].name, "Alice");
     }
 
     #[rstest]
     fn contact_without_name_does_not_overwrite_existing_name(mut app: App) {
-
         // Create conversation with a name already
         let msg = SignalMessage {
             source: "+1".to_string(),
@@ -6932,9 +8100,11 @@ mod tests {
         assert_eq!(app.store.conversations["+1"].name, "Alice");
 
         // Contact arrives with no name — should NOT overwrite
-        app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+1".to_string(), name: None, uuid: None },
-        ]));
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+1".to_string(),
+            name: None,
+            uuid: None,
+        }]));
 
         assert_eq!(app.store.conversations["+1"].name, "Alice");
     }
@@ -6943,11 +8113,12 @@ mod tests {
 
     #[rstest]
     fn message_uses_contact_name_lookup(mut app: App) {
-
         // Contacts loaded first (no conversations created)
-        app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+1".to_string(), name: Some("Alice".to_string()), uuid: None },
-        ]));
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+1".to_string(),
+            name: Some("Alice".to_string()),
+            uuid: None,
+        }]));
         assert!(app.store.conversations.is_empty());
 
         // Message arrives with no source_name — should use lookup
@@ -6977,11 +8148,13 @@ mod tests {
 
     #[rstest]
     fn message_in_known_group_uses_name_lookup(mut app: App) {
-
         // Groups loaded — conversation created
-        app.handle_signal_event(SignalEvent::GroupList(vec![
-            Group { id: "g1".to_string(), name: "Family".to_string(), members: vec![], member_uuids: vec![] },
-        ]));
+        app.handle_signal_event(SignalEvent::GroupList(vec![Group {
+            id: "g1".to_string(),
+            name: "Family".to_string(),
+            members: vec![],
+            member_uuids: vec![],
+        }]));
         assert_eq!(app.store.conversations.len(), 1);
 
         // Message arrives in that group (no group_name in metadata)
@@ -7014,10 +8187,11 @@ mod tests {
 
     #[rstest]
     fn no_duplicate_on_repeated_messages(mut app: App) {
-
-        app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+1".to_string(), name: Some("Alice".to_string()), uuid: None },
-        ]));
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+1".to_string(),
+            name: Some("Alice".to_string()),
+            uuid: None,
+        }]));
 
         for _ in 0..3 {
             let msg = SignalMessage {
@@ -7061,9 +8235,16 @@ mod tests {
     ) {
         app.input_buffer = input.to_string();
         app.update_autocomplete();
-        assert_eq!(app.autocomplete.visible, expected_visible, "visibility for {input:?}");
+        assert_eq!(
+            app.autocomplete.visible, expected_visible,
+            "visibility for {input:?}"
+        );
         if let Some(count) = expected_count {
-            assert_eq!(app.autocomplete.command_candidates.len(), count, "count for {input:?}");
+            assert_eq!(
+                app.autocomplete.command_candidates.len(),
+                count,
+                "count for {input:?}"
+            );
         }
     }
 
@@ -7101,8 +8282,12 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_shows_contacts(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.contact_names.insert("+2".to_string(), "Bob".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+2".to_string(), "Bob".to_string());
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7112,12 +8297,15 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_shows_groups(mut app: App) {
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Family".to_string(),
-            members: vec![],
-            member_uuids: vec![],
-        });
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec![],
+                member_uuids: vec![],
+            },
+        );
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7128,8 +8316,12 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_filters_by_name(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.contact_names.insert("+2".to_string(), "Bob".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+2".to_string(), "Bob".to_string());
         app.input_buffer = "/join al".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7139,8 +8331,12 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_filters_by_phone(mut app: App) {
-        app.store.contact_names.insert("+1234".to_string(), "Alice".to_string());
-        app.store.contact_names.insert("+5678".to_string(), "Bob".to_string());
+        app.store
+            .contact_names
+            .insert("+1234".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+5678".to_string(), "Bob".to_string());
         app.input_buffer = "/join +123".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7150,7 +8346,9 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_alias(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/j ".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7160,7 +8358,9 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_no_match_hides(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join zzz".to_string();
         app.update_autocomplete();
         assert!(!app.autocomplete.visible);
@@ -7168,7 +8368,9 @@ mod tests {
 
     #[rstest]
     fn apply_join_autocomplete(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join al".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7180,12 +8382,15 @@ mod tests {
 
     #[rstest]
     fn apply_join_autocomplete_group(mut app: App) {
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Family".to_string(),
-            members: vec![],
-            member_uuids: vec![],
-        });
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec![],
+                member_uuids: vec![],
+            },
+        );
         app.input_buffer = "/join fam".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7197,7 +8402,8 @@ mod tests {
     #[rstest]
     fn join_autocomplete_includes_conversations(mut app: App) {
         // Create a conversation that isn't in contact_names
-        app.store.get_or_create_conversation("+9999", "+9999", false, &app.db);
+        app.store
+            .get_or_create_conversation("+9999", "+9999", false, &app.db);
         app.input_buffer = "/join +999".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
@@ -7207,13 +8413,20 @@ mod tests {
     #[rstest]
     fn join_autocomplete_skips_group_ids_in_contacts(mut app: App) {
         // group IDs in contact_names don't start with '+'
-        app.store.contact_names.insert("g1".to_string(), "Family".to_string());
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("g1".to_string(), "Family".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
         assert!(app.autocomplete.visible);
         // Only Alice should appear from contact_names (g1 is skipped as non-phone)
-        let contact_entries: Vec<_> = app.autocomplete.join_candidates.iter()
+        let contact_entries: Vec<_> = app
+            .autocomplete
+            .join_candidates
+            .iter()
             .filter(|(_, v)| v == "+1")
             .collect();
         assert_eq!(contact_entries.len(), 1);
@@ -7221,7 +8434,9 @@ mod tests {
 
     #[rstest]
     fn join_autocomplete_index_clamped(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
         app.autocomplete.index = 100; // way out of bounds
@@ -7294,7 +8509,6 @@ mod tests {
 
     #[rstest]
     fn history_down_without_browsing_is_noop(mut app: App) {
-
         app.input_buffer = "draft".to_string();
         app.history_down();
         assert_eq!(app.input_buffer, "draft");
@@ -7303,7 +8517,6 @@ mod tests {
 
     #[rstest]
     fn history_up_recalls_last_entry(mut app: App) {
-
         app.input_history = vec!["hello".to_string(), "world".to_string()];
         app.input_buffer = "draft".to_string();
         app.input_cursor = 5;
@@ -7317,8 +8530,11 @@ mod tests {
 
     #[rstest]
     fn history_up_walks_to_oldest(mut app: App) {
-
-        app.input_history = vec!["first".to_string(), "second".to_string(), "third".to_string()];
+        app.input_history = vec![
+            "first".to_string(),
+            "second".to_string(),
+            "third".to_string(),
+        ];
         app.input_buffer = String::new();
 
         app.history_up(); // -> "third"
@@ -7341,7 +8557,6 @@ mod tests {
 
     #[rstest]
     fn history_down_walks_forward_and_restores_draft(mut app: App) {
-
         app.input_history = vec!["aaa".to_string(), "bbb".to_string()];
         app.input_buffer = "my draft".to_string();
 
@@ -7364,7 +8579,6 @@ mod tests {
 
     #[rstest]
     fn history_cursor_moves_to_end(mut app: App) {
-
         app.input_history = vec!["short".to_string(), "a longer entry".to_string()];
         app.input_buffer = String::new();
         app.input_cursor = 0;
@@ -7384,9 +8598,9 @@ mod tests {
 
     #[rstest]
     fn handle_input_saves_to_history(mut app: App) {
-
         // Need an active conversation for SendText to work
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
 
         app.input_buffer = "hello".to_string();
@@ -7398,13 +8612,16 @@ mod tests {
         app.input_buffer = "world".to_string();
         app.input_cursor = 5;
         app.handle_input();
-        assert_eq!(app.input_history, vec!["hello".to_string(), "world".to_string()]);
+        assert_eq!(
+            app.input_history,
+            vec!["hello".to_string(), "world".to_string()]
+        );
     }
 
     #[rstest]
     fn handle_input_trims_and_skips_empty(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
 
         // Whitespace-only input should not be saved
@@ -7421,8 +8638,8 @@ mod tests {
 
     #[rstest]
     fn handle_input_resets_history_index(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
 
         app.input_history = vec!["old".to_string()];
@@ -7436,7 +8653,6 @@ mod tests {
 
     #[rstest]
     fn apply_input_edit_up_down_routes_to_history(mut app: App) {
-
         app.input_history = vec!["recalled".to_string()];
         app.input_buffer = "draft".to_string();
 
@@ -7559,7 +8775,8 @@ mod tests {
     #[rstest]
     fn enter_sends_multiline_message(mut app: App) {
         app.mode = InputMode::Insert;
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.input_buffer = "hello\nworld".to_string();
         app.input_cursor = 11;
@@ -7581,14 +8798,21 @@ mod tests {
     fn load_from_db_marks_has_more(mut app: App) {
         // Insert exactly PAGE_SIZE messages
         let conv_id = "+pagination";
-        app.db.upsert_conversation(conv_id, "PagTest", false).unwrap();
+        app.db
+            .upsert_conversation(conv_id, "PagTest", false)
+            .unwrap();
         for i in 0..App::PAGE_SIZE {
-            app.db.insert_message(
-                conv_id, "Alice",
-                &format!("2025-01-01T00:{:02}:{:02}Z", i / 60, i % 60),
-                &format!("msg{i}"),
-                false, None, i as i64 * 1000,
-            ).unwrap();
+            app.db
+                .insert_message(
+                    conv_id,
+                    "Alice",
+                    &format!("2025-01-01T00:{:02}:{:02}Z", i / 60, i % 60),
+                    &format!("msg{i}"),
+                    false,
+                    None,
+                    i as i64 * 1000,
+                )
+                .unwrap();
         }
         app.load_from_db().unwrap();
         assert!(app.store.has_more_messages.contains(conv_id));
@@ -7598,7 +8822,17 @@ mod tests {
     fn load_from_db_no_more_when_under_page_size(mut app: App) {
         let conv_id = "+small";
         app.db.upsert_conversation(conv_id, "Small", false).unwrap();
-        app.db.insert_message(conv_id, "Alice", "2025-01-01T00:00:00Z", "only one", false, None, 0).unwrap();
+        app.db
+            .insert_message(
+                conv_id,
+                "Alice",
+                "2025-01-01T00:00:00Z",
+                "only one",
+                false,
+                None,
+                0,
+            )
+            .unwrap();
         app.load_from_db().unwrap();
         assert!(!app.store.has_more_messages.contains(conv_id));
     }
@@ -7609,12 +8843,17 @@ mod tests {
         app.db.upsert_conversation(conv_id, "Test", false).unwrap();
         // Insert 150 messages (more than PAGE_SIZE=100)
         for i in 0..150 {
-            app.db.insert_message(
-                conv_id, "Alice",
-                &format!("2025-01-01T{:02}:{:02}:00Z", i / 60, i % 60),
-                &format!("msg{i}"),
-                false, None, i as i64 * 1000,
-            ).unwrap();
+            app.db
+                .insert_message(
+                    conv_id,
+                    "Alice",
+                    &format!("2025-01-01T{:02}:{:02}:00Z", i / 60, i % 60),
+                    &format!("msg{i}"),
+                    false,
+                    None,
+                    i as i64 * 1000,
+                )
+                .unwrap();
         }
         app.load_from_db().unwrap();
         app.active_conversation = Some(conv_id.to_string());
@@ -7637,7 +8876,10 @@ mod tests {
         // Should now have 150 messages, oldest first
         assert_eq!(app.store.conversations[conv_id].messages.len(), 150);
         assert_eq!(app.store.conversations[conv_id].messages[0].body, "msg0");
-        assert_eq!(app.store.conversations[conv_id].messages[149].body, "msg149");
+        assert_eq!(
+            app.store.conversations[conv_id].messages[149].body,
+            "msg149"
+        );
 
         // Indexes should have shifted by 50 (the prepend count)
         assert_eq!(app.store.last_read_index[conv_id], 140);
@@ -7651,10 +8893,10 @@ mod tests {
 
     #[rstest]
     fn receipt_upgrades_outgoing_message_status(mut app: App) {
-
         // Create a conversation with an outgoing message
         let conv_id = "+1";
-        app.store.get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
         let ts_ms = 1700000000000_i64;
         if let Some(conv) = app.store.conversations.get_mut(conv_id) {
             conv.messages.push(DisplayMessage {
@@ -7709,9 +8951,9 @@ mod tests {
 
     #[rstest]
     fn receipt_does_not_downgrade_status(mut app: App) {
-
         let conv_id = "+1";
-        app.store.get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
         let ts_ms = 1700000000000_i64;
         if let Some(conv) = app.store.conversations.get_mut(conv_id) {
             conv.messages.push(DisplayMessage {
@@ -7755,9 +8997,9 @@ mod tests {
 
     #[rstest]
     fn send_timestamp_upgrades_sending_to_sent(mut app: App) {
-
         let conv_id = "+1";
-        app.store.get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
         let local_ts = 1700000000000_i64;
         let server_ts = 1700000000123_i64;
 
@@ -7790,7 +9032,8 @@ mod tests {
         }
 
         // Register pending send
-        app.pending_sends.insert("rpc-1".to_string(), (conv_id.to_string(), local_ts));
+        app.pending_sends
+            .insert("rpc-1".to_string(), (conv_id.to_string(), local_ts));
 
         app.handle_signal_event(SignalEvent::SendTimestamp {
             rpc_id: "rpc-1".to_string(),
@@ -7804,9 +9047,9 @@ mod tests {
 
     #[rstest]
     fn send_failed_sets_failed_status(mut app: App) {
-
         let conv_id = "+1";
-        app.store.get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
         let local_ts = 1700000000000_i64;
 
         if let Some(conv) = app.store.conversations.get_mut(conv_id) {
@@ -7837,7 +9080,8 @@ mod tests {
             });
         }
 
-        app.pending_sends.insert("rpc-1".to_string(), (conv_id.to_string(), local_ts));
+        app.pending_sends
+            .insert("rpc-1".to_string(), (conv_id.to_string(), local_ts));
 
         app.handle_signal_event(SignalEvent::SendFailed {
             rpc_id: "rpc-1".to_string(),
@@ -7856,7 +9100,8 @@ mod tests {
         // Set up a sentinel entry (far-future deadline = awaiting confirmation)
         let tmp = std::env::temp_dir().join("test-paste-dummy.png");
         let sentinel = Instant::now() + std::time::Duration::from_secs(PASTE_CLEANUP_SENTINEL_SECS);
-        app.pending_paste_cleanups.insert("rpc-1".to_string(), (tmp.clone(), sentinel));
+        app.pending_paste_cleanups
+            .insert("rpc-1".to_string(), (tmp.clone(), sentinel));
 
         app.handle_signal_event(SignalEvent::SendTimestamp {
             rpc_id: "rpc-1".to_string(),
@@ -7864,7 +9109,10 @@ mod tests {
         });
 
         // Deadline should now be ~10s from now, well under the sentinel
-        let (_, deadline) = app.pending_paste_cleanups.get("rpc-1").expect("entry should still exist");
+        let (_, deadline) = app
+            .pending_paste_cleanups
+            .get("rpc-1")
+            .expect("entry should still exist");
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
             remaining <= std::time::Duration::from_secs(PASTE_CLEANUP_DELAY_SECS),
@@ -7876,13 +9124,17 @@ mod tests {
     fn send_failed_resets_paste_cleanup_deadline(mut app: App) {
         let tmp = std::env::temp_dir().join("test-paste-dummy-fail.png");
         let sentinel = Instant::now() + std::time::Duration::from_secs(PASTE_CLEANUP_SENTINEL_SECS);
-        app.pending_paste_cleanups.insert("rpc-2".to_string(), (tmp.clone(), sentinel));
+        app.pending_paste_cleanups
+            .insert("rpc-2".to_string(), (tmp.clone(), sentinel));
 
         app.handle_signal_event(SignalEvent::SendFailed {
             rpc_id: "rpc-2".to_string(),
         });
 
-        let (_, deadline) = app.pending_paste_cleanups.get("rpc-2").expect("entry should still exist");
+        let (_, deadline) = app
+            .pending_paste_cleanups
+            .get("rpc-2")
+            .expect("entry should still exist");
         let remaining = deadline.saturating_duration_since(Instant::now());
         assert!(
             remaining <= std::time::Duration::from_secs(PASTE_CLEANUP_DELAY_SECS),
@@ -7893,18 +9145,23 @@ mod tests {
     #[rstest]
     fn cleanup_paste_files_removes_file_after_deadline(mut app: App) {
         // Create a real temp file
-        let tmp = std::env::temp_dir().join(format!("test-paste-cleanup-{}.png", std::process::id()));
+        let tmp =
+            std::env::temp_dir().join(format!("test-paste-cleanup-{}.png", std::process::id()));
         std::fs::write(&tmp, b"fake image data").expect("write temp file");
         assert!(tmp.exists());
 
         // Insert with a deadline already in the past
         let past = Instant::now() - std::time::Duration::from_secs(1);
-        app.pending_paste_cleanups.insert("rpc-3".to_string(), (tmp.clone(), past));
+        app.pending_paste_cleanups
+            .insert("rpc-3".to_string(), (tmp.clone(), past));
 
         app.cleanup_paste_files();
 
         assert!(!tmp.exists(), "temp file should have been deleted");
-        assert!(app.pending_paste_cleanups.is_empty(), "entry should be removed");
+        assert!(
+            app.pending_paste_cleanups.is_empty(),
+            "entry should be removed"
+        );
     }
 
     #[rstest]
@@ -7914,19 +9171,22 @@ mod tests {
 
         // Insert with a future deadline
         let future = Instant::now() + std::time::Duration::from_secs(60);
-        app.pending_paste_cleanups.insert("rpc-4".to_string(), (tmp.clone(), future));
+        app.pending_paste_cleanups
+            .insert("rpc-4".to_string(), (tmp.clone(), future));
 
         app.cleanup_paste_files();
 
         // File should still exist; clean it up manually
         assert!(tmp.exists(), "temp file should not have been deleted yet");
         let _ = std::fs::remove_file(&tmp);
-        assert!(!app.pending_paste_cleanups.is_empty(), "entry should still be present");
+        assert!(
+            !app.pending_paste_cleanups.is_empty(),
+            "entry should still be present"
+        );
     }
 
     #[rstest]
     fn incoming_messages_have_no_status(mut app: App) {
-
         let msg = SignalMessage {
             source: "+1".to_string(),
             source_name: Some("Alice".to_string()),
@@ -7951,9 +9211,9 @@ mod tests {
 
     #[rstest]
     fn receipt_before_send_timestamp_is_buffered_and_replayed(mut app: App) {
-
         let conv_id = "+1";
-        app.store.get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
         let local_ts = 1700000000000_i64;
         let server_ts = 1700000000123_i64;
 
@@ -7986,7 +9246,8 @@ mod tests {
             });
         }
 
-        app.pending_sends.insert("rpc-1".to_string(), (conv_id.to_string(), local_ts));
+        app.pending_sends
+            .insert("rpc-1".to_string(), (conv_id.to_string(), local_ts));
 
         // Receipt arrives BEFORE SendTimestamp (references server_ts which we don't know yet)
         app.handle_signal_event(SignalEvent::ReceiptReceived {
@@ -8020,7 +9281,6 @@ mod tests {
 
     #[rstest]
     fn handle_reaction_adds_to_message(mut app: App) {
-
         let msg = SignalMessage {
             source: "+1".to_string(),
             source_name: Some("Alice".to_string()),
@@ -8061,7 +9321,6 @@ mod tests {
 
     #[rstest]
     fn handle_reaction_replaces_existing_from_same_sender(mut app: App) {
-
         let msg = SignalMessage {
             source: "+1".to_string(),
             source_name: Some("Alice".to_string()),
@@ -8110,7 +9369,6 @@ mod tests {
 
     #[rstest]
     fn handle_reaction_remove(mut app: App) {
-
         let msg = SignalMessage {
             source: "+1".to_string(),
             source_name: Some("Alice".to_string()),
@@ -8158,10 +9416,10 @@ mod tests {
 
     #[rstest]
     fn handle_reaction_on_own_message(mut app: App) {
-
         // Send a message (outgoing) — simulate by creating conversation and pushing directly
         let conv_id = "+1";
-        app.store.get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
         let ts_ms = 1700000000000_i64;
         if let Some(conv) = app.store.conversations.get_mut(conv_id) {
             conv.messages.push(DisplayMessage {
@@ -8209,8 +9467,8 @@ mod tests {
 
     #[rstest]
     fn handle_reaction_unknown_message_persists_to_db(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
 
         // Reaction for a message not in memory (timestamp doesn't match any)
         app.handle_signal_event(SignalEvent::ReactionReceived {
@@ -8232,8 +9490,8 @@ mod tests {
 
     #[rstest]
     fn contact_list_resolves_reactions_and_quotes(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "+1", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "+1", false, &app.db);
 
         // Simulate DB-loaded messages: one from a contact (+2=Bob), one from
         // a non-contact (+3=Charlie, known only from sender_id on a message)
@@ -8273,14 +9531,28 @@ mod tests {
             status: None,
             timestamp_ms: 1000,
             reactions: vec![
-                Reaction { emoji: "\u{1f44d}".to_string(), sender: "+2".to_string() },       // contact
-                Reaction { emoji: "\u{2764}".to_string(), sender: "+10000000000".to_string() }, // own account
-                Reaction { emoji: "\u{1f602}".to_string(), sender: "+3".to_string() },        // non-contact
+                Reaction {
+                    emoji: "\u{1f44d}".to_string(),
+                    sender: "+2".to_string(),
+                }, // contact
+                Reaction {
+                    emoji: "\u{2764}".to_string(),
+                    sender: "+10000000000".to_string(),
+                }, // own account
+                Reaction {
+                    emoji: "\u{1f602}".to_string(),
+                    sender: "+3".to_string(),
+                }, // non-contact
             ],
             mention_ranges: Vec::new(),
             style_ranges: Vec::new(),
             // Quote from own account (should become "you")
-            quote: Some(Quote { author: "+10000000000".to_string(), body: "quoted".to_string(), timestamp_ms: 500, author_id: "+10000000000".to_string() }),
+            quote: Some(Quote {
+                author: "+10000000000".to_string(),
+                body: "quoted".to_string(),
+                timestamp_ms: 500,
+                author_id: "+10000000000".to_string(),
+            }),
             is_edited: false,
             is_deleted: false,
             is_pinned: false,
@@ -8306,7 +9578,12 @@ mod tests {
             reactions: Vec::new(),
             mention_ranges: Vec::new(),
             style_ranges: Vec::new(),
-            quote: Some(Quote { author: "+3".to_string(), body: "hey".to_string(), timestamp_ms: 900, author_id: "+3".to_string() }),
+            quote: Some(Quote {
+                author: "+3".to_string(),
+                body: "hey".to_string(),
+                timestamp_ms: 900,
+                author_id: "+3".to_string(),
+            }),
             is_edited: false,
             is_deleted: false,
             is_pinned: false,
@@ -8322,8 +9599,16 @@ mod tests {
 
         // Contact list arrives — only +2 is a formal contact
         app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+1".to_string(), name: Some("Alice".to_string()), uuid: None },
-            Contact { number: "+2".to_string(), name: Some("Bob".to_string()), uuid: None },
+            Contact {
+                number: "+1".to_string(),
+                name: Some("Alice".to_string()),
+                uuid: None,
+            },
+            Contact {
+                number: "+2".to_string(),
+                name: Some("Bob".to_string()),
+                uuid: None,
+            },
         ]));
 
         let msgs = &app.store.conversations["+1"].messages;
@@ -8360,10 +9645,17 @@ mod tests {
         #[case] expected_tags: &[&str],
     ) {
         for (uuid, name) in uuid_names {
-            app.store.uuid_to_name.insert(uuid.to_string(), name.to_string());
+            app.store
+                .uuid_to_name
+                .insert(uuid.to_string(), name.to_string());
         }
-        let mentions: Vec<Mention> = mention_data.iter()
-            .map(|(start, length, uuid)| Mention { start: *start, length: *length, uuid: uuid.to_string() })
+        let mentions: Vec<Mention> = mention_data
+            .iter()
+            .map(|(start, length, uuid)| Mention {
+                start: *start,
+                length: *length,
+                uuid: uuid.to_string(),
+            })
             .collect();
         let (resolved, ranges) = app.store.resolve_mentions(body, &mentions);
         assert_eq!(resolved, expected_body);
@@ -8375,10 +9667,12 @@ mod tests {
 
     #[rstest]
     fn mention_autocomplete_in_direct_chat(mut app: App) {
-
         // Create a 1:1 conversation with a known contact
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.active_conversation = Some("+1".to_string());
         app.input_buffer = "@Al".to_string();
         app.input_cursor = 3;
@@ -8393,17 +9687,24 @@ mod tests {
 
     #[rstest]
     fn mention_autocomplete_in_group(mut app: App) {
-
         // Set up group with members
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Test Group".to_string(),
-            members: vec!["+1".to_string(), "+2".to_string()],
-            member_uuids: vec![],
-        });
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.contact_names.insert("+2".to_string(), "Bob".to_string());
-        app.store.get_or_create_conversation("g1", "Test Group", true, &app.db);
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Test Group".to_string(),
+                members: vec!["+1".to_string(), "+2".to_string()],
+                member_uuids: vec![],
+            },
+        );
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+2".to_string(), "Bob".to_string());
+        app.store
+            .get_or_create_conversation("g1", "Test Group", true, &app.db);
         app.active_conversation = Some("g1".to_string());
 
         app.input_buffer = "@Al".to_string();
@@ -8418,17 +9719,24 @@ mod tests {
 
     #[rstest]
     fn apply_mention_autocomplete(mut app: App) {
-
         // Set up group with members
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Test Group".to_string(),
-            members: vec!["+1".to_string()],
-            member_uuids: vec![],
-        });
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.number_to_uuid.insert("+1".to_string(), "uuid-alice".to_string());
-        app.store.get_or_create_conversation("g1", "Test Group", true, &app.db);
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Test Group".to_string(),
+                members: vec!["+1".to_string()],
+                member_uuids: vec![],
+            },
+        );
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .number_to_uuid
+            .insert("+1".to_string(), "uuid-alice".to_string());
+        app.store
+            .get_or_create_conversation("g1", "Test Group", true, &app.db);
         app.active_conversation = Some("g1".to_string());
 
         app.input_buffer = "Hey @Al".to_string();
@@ -8440,15 +9748,16 @@ mod tests {
         assert_eq!(app.input_buffer, "Hey @Alice ");
         assert_eq!(app.autocomplete.pending_mentions.len(), 1);
         assert_eq!(app.autocomplete.pending_mentions[0].0, "Alice");
-        assert_eq!(app.autocomplete.pending_mentions[0].1.as_deref(), Some("uuid-alice"));
+        assert_eq!(
+            app.autocomplete.pending_mentions[0].1.as_deref(),
+            Some("uuid-alice")
+        );
     }
 
     #[rstest]
     fn prepare_outgoing_mentions(mut app: App) {
-
-        app.autocomplete.pending_mentions = vec![
-            ("Alice".to_string(), Some("uuid-alice".to_string())),
-        ];
+        app.autocomplete.pending_mentions =
+            vec![("Alice".to_string(), Some("uuid-alice".to_string()))];
 
         let (wire, mentions) = app.prepare_outgoing_mentions("Hey @Alice what's up");
         assert_eq!(wire, "Hey \u{FFFC} what's up");
@@ -8459,7 +9768,6 @@ mod tests {
 
     #[rstest]
     fn prepare_outgoing_no_pending_mentions(app: App) {
-
         let (wire, mentions) = app.prepare_outgoing_mentions("Hello world");
         assert_eq!(wire, "Hello world");
         assert!(mentions.is_empty());
@@ -8467,14 +9775,11 @@ mod tests {
 
     #[rstest]
     fn contact_list_builds_uuid_maps(mut app: App) {
-
-        app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact {
-                number: "+1".to_string(),
-                name: Some("Alice".to_string()),
-                uuid: Some("uuid-alice".to_string()),
-            },
-        ]));
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+1".to_string(),
+            name: Some("Alice".to_string()),
+            uuid: Some("uuid-alice".to_string()),
+        }]));
 
         assert_eq!(app.store.uuid_to_name.get("uuid-alice").unwrap(), "Alice");
         assert_eq!(app.store.number_to_uuid.get("+1").unwrap(), "uuid-alice");
@@ -8482,15 +9787,12 @@ mod tests {
 
     #[rstest]
     fn group_list_stores_groups(mut app: App) {
-
-        app.handle_signal_event(SignalEvent::GroupList(vec![
-            Group {
-                id: "g1".to_string(),
-                name: "Test".to_string(),
-                members: vec!["+1".to_string(), "+2".to_string()],
-                member_uuids: vec![],
-            },
-        ]));
+        app.handle_signal_event(SignalEvent::GroupList(vec![Group {
+            id: "g1".to_string(),
+            name: "Test".to_string(),
+            members: vec!["+1".to_string(), "+2".to_string()],
+            member_uuids: vec![],
+        }]));
 
         assert!(app.store.groups.contains_key("g1"));
         assert_eq!(app.store.groups["g1"].members.len(), 2);
@@ -8498,8 +9800,9 @@ mod tests {
 
     #[rstest]
     fn incoming_message_resolves_mentions(mut app: App) {
-
-        app.store.uuid_to_name.insert("uuid-bob".to_string(), "Bob".to_string());
+        app.store
+            .uuid_to_name
+            .insert("uuid-bob".to_string(), "Bob".to_string());
 
         let msg = SignalMessage {
             source: "+1".to_string(),
@@ -8512,7 +9815,11 @@ mod tests {
             group_name: None,
             is_outgoing: false,
             destination: None,
-            mentions: vec![Mention { start: 0, length: 1, uuid: "uuid-bob".to_string() }],
+            mentions: vec![Mention {
+                start: 0,
+                length: 1,
+                uuid: "uuid-bob".to_string(),
+            }],
             text_styles: vec![],
             quote: None,
             expires_in_seconds: 0,
@@ -8527,7 +9834,6 @@ mod tests {
 
     #[rstest]
     fn backspace_at_zero_clears_pending_attachment(mut app: App) {
-
         app.pending_attachment = Some(std::path::PathBuf::from("/tmp/photo.jpg"));
         app.input_cursor = 0;
         app.input_buffer.clear();
@@ -8538,8 +9844,8 @@ mod tests {
 
     #[rstest]
     fn empty_text_with_attachment_sends(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.pending_attachment = Some(std::path::PathBuf::from("/tmp/photo.jpg"));
         app.input_buffer.clear();
@@ -8553,7 +9859,6 @@ mod tests {
 
     #[rstest]
     fn attach_no_conversation_shows_error(mut app: App) {
-
         app.active_conversation = None;
         app.open_file_browser();
         assert!(!app.file_picker.visible);
@@ -8562,17 +9867,20 @@ mod tests {
 
     #[rstest]
     fn clears_attachment_on_next_conversation(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.pending_attachment = Some(std::path::PathBuf::from("/tmp/photo.jpg"));
-        app.store.get_or_create_conversation("+2", "Bob", false, &app.db);
+        app.store
+            .get_or_create_conversation("+2", "Bob", false, &app.db);
         app.next_conversation();
         assert!(app.pending_attachment.is_none());
     }
 
     #[rstest]
     fn clears_attachment_on_part_command(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.pending_attachment = Some(std::path::PathBuf::from("/tmp/photo.jpg"));
         app.input_buffer = "/part".to_string();
@@ -8583,12 +9891,22 @@ mod tests {
 
     #[rstest]
     fn search_opens_overlay(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
 
         // Insert a message into the DB so search has something to find
-        app.db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello world", false, None, 1000).unwrap();
+        app.db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:00:00Z",
+                "hello world",
+                false,
+                None,
+                1000,
+            )
+            .unwrap();
 
         app.input_buffer = "/search hello".to_string();
         app.input_cursor = 13;
@@ -8602,7 +9920,6 @@ mod tests {
 
     #[rstest]
     fn search_without_query_shows_error(mut app: App) {
-
         app.input_buffer = "/search".to_string();
         app.input_cursor = 7;
         app.handle_input();
@@ -8613,7 +9930,6 @@ mod tests {
 
     #[rstest]
     fn search_overlay_esc_closes(mut app: App) {
-
         app.search.visible = true;
         app.search.query = "test".to_string();
 
@@ -8625,11 +9941,31 @@ mod tests {
 
     #[rstest]
     fn search_overlay_typing_refines(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
-        app.db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello world", false, None, 1000).unwrap();
-        app.db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "goodbye world", false, None, 2000).unwrap();
+        app.db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:00:00Z",
+                "hello world",
+                false,
+                None,
+                1000,
+            )
+            .unwrap();
+        app.db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:01:00Z",
+                "goodbye world",
+                false,
+                None,
+                2000,
+            )
+            .unwrap();
 
         app.search.visible = true;
         app.search.query = "hello".to_string();
@@ -8644,7 +9980,6 @@ mod tests {
 
     #[rstest]
     fn system_message_inserted_with_is_system_true(mut app: App) {
-
         let ts = chrono::Utc::now();
         let ts_ms = ts.timestamp_millis();
         app.handle_signal_event(SignalEvent::SystemMessage {
@@ -8688,7 +10023,12 @@ mod tests {
 
         // Conversation exists with 1 message, last_read_index should be 0 (unread)
         assert_eq!(app.store.conversations["+15551234567"].messages.len(), 1);
-        let read_idx = app.store.last_read_index.get("+15551234567").copied().unwrap_or(0);
+        let read_idx = app
+            .store
+            .last_read_index
+            .get("+15551234567")
+            .copied()
+            .unwrap_or(0);
         assert_eq!(read_idx, 0);
 
         // Now make it the active conversation
@@ -8723,7 +10063,6 @@ mod tests {
 
     #[rstest]
     fn read_sync_advances_read_marker_and_clears_unread(mut app: App) {
-
         // Create a conversation with 3 messages (all incoming, unread)
         let msg = |body: &str, ts_ms: i64| SignalMessage {
             source: "+15551234567".to_string(),
@@ -8747,7 +10086,14 @@ mod tests {
         app.handle_signal_event(SignalEvent::MessageReceived(msg("three", 3000)));
 
         assert_eq!(app.store.conversations["+15551234567"].unread, 3);
-        assert_eq!(app.store.last_read_index.get("+15551234567").copied().unwrap_or(0), 0);
+        assert_eq!(
+            app.store
+                .last_read_index
+                .get("+15551234567")
+                .copied()
+                .unwrap_or(0),
+            0
+        );
 
         // Simulate reading through timestamp 2000 on another device
         app.handle_signal_event(SignalEvent::ReadSyncReceived {
@@ -8762,7 +10108,6 @@ mod tests {
 
     #[rstest]
     fn read_sync_does_not_retreat_read_marker(mut app: App) {
-
         let msg = |body: &str, ts_ms: i64| SignalMessage {
             source: "+15551234567".to_string(),
             source_name: Some("Alice".to_string()),
@@ -8803,45 +10148,54 @@ mod tests {
 
     #[rstest]
     fn text_style_ranges_resolved_to_byte_offsets(app: App) {
-
         // ASCII body: "hello bold world"
         // "bold" is at UTF-16 offset 6, length 4
         let body = "hello bold world";
         let styles = vec![
-            TextStyle { start: 6, length: 4, style: StyleType::Bold },
-            TextStyle { start: 11, length: 5, style: StyleType::Italic },
+            TextStyle {
+                start: 6,
+                length: 4,
+                style: StyleType::Bold,
+            },
+            TextStyle {
+                start: 11,
+                length: 5,
+                style: StyleType::Italic,
+            },
         ];
         let resolved = app.store.resolve_text_styles(body, &styles, &[]);
 
         // In pure ASCII, UTF-16 offsets == byte offsets
         assert_eq!(resolved.len(), 2);
-        assert_eq!(resolved[0], (6, 10, StyleType::Bold));      // "bold"
-        assert_eq!(resolved[1], (11, 16, StyleType::Italic));    // "world"
+        assert_eq!(resolved[0], (6, 10, StyleType::Bold)); // "bold"
+        assert_eq!(resolved[1], (11, 16, StyleType::Italic)); // "world"
     }
 
     #[rstest]
     fn text_style_ranges_with_multibyte_chars(app: App) {
-
         // Body with multi-byte chars: "Hi \u{1F600} bold" (emoji is 4 bytes UTF-8, 2 units UTF-16)
         // UTF-16: H(1) i(1) ' '(1) \u{1F600}(2) ' '(1) b(1) o(1) l(1) d(1) = offsets
         // "bold" starts at UTF-16 offset 6, length 4
         let body = "Hi \u{1F600} bold";
-        let styles = vec![
-            TextStyle { start: 6, length: 4, style: StyleType::Bold },
-        ];
+        let styles = vec![TextStyle {
+            start: 6,
+            length: 4,
+            style: StyleType::Bold,
+        }];
         let resolved = app.store.resolve_text_styles(body, &styles, &[]);
 
         // "Hi " = 3 bytes, emoji = 4 bytes, " " = 1 byte => "bold" starts at byte 8
         assert_eq!(resolved.len(), 1);
-        assert_eq!(resolved[0].0, 8);  // byte start of "bold"
+        assert_eq!(resolved[0].0, 8); // byte start of "bold"
         assert_eq!(resolved[0].1, 12); // byte end of "bold"
         assert_eq!(resolved[0].2, StyleType::Bold);
     }
 
     #[rstest]
     fn text_style_ranges_with_mentions(mut app: App) {
-
-        app.store.uuid_to_name.insert("uuid-bob".to_string(), "Bob".to_string());
+        app.store
+            .uuid_to_name
+            .insert("uuid-bob".to_string(), "Bob".to_string());
 
         // Original body: "\u{FFFC} is bold"
         // After mention resolution: "@Bob is bold"
@@ -8849,11 +10203,19 @@ mod tests {
         // "bold" is at original UTF-16 offset 5, length 4
         // After resolution shift: offset 5 + 3 (replacement grew by 3) = 8
         let resolved_body = "@Bob is bold";
-        let mentions = vec![Mention { start: 0, length: 1, uuid: "uuid-bob".to_string() }];
-        let styles = vec![
-            TextStyle { start: 5, length: 4, style: StyleType::Strikethrough },
-        ];
-        let resolved = app.store.resolve_text_styles(resolved_body, &styles, &mentions);
+        let mentions = vec![Mention {
+            start: 0,
+            length: 1,
+            uuid: "uuid-bob".to_string(),
+        }];
+        let styles = vec![TextStyle {
+            start: 5,
+            length: 4,
+            style: StyleType::Strikethrough,
+        }];
+        let resolved = app
+            .store
+            .resolve_text_styles(resolved_body, &styles, &mentions);
 
         assert_eq!(resolved.len(), 1);
         // "bold" in "@Bob is bold" starts at byte 8
@@ -8864,7 +10226,6 @@ mod tests {
 
     #[rstest]
     fn text_style_ranges_empty_styles(app: App) {
-
         let resolved = app.store.resolve_text_styles("hello world", &[], &[]);
         assert!(resolved.is_empty());
     }
@@ -8873,13 +10234,20 @@ mod tests {
 
     #[test]
     fn group_command_parsed() {
-        assert!(matches!(crate::input::parse_input("/group"), crate::input::InputAction::Group));
-        assert!(matches!(crate::input::parse_input("/g"), crate::input::InputAction::Group));
+        assert!(matches!(
+            crate::input::parse_input("/group"),
+            crate::input::InputAction::Group
+        ));
+        assert!(matches!(
+            crate::input::parse_input("/g"),
+            crate::input::InputAction::Group
+        ));
     }
 
     #[rstest]
     fn group_menu_items_in_group(mut app: App) {
-        app.store.get_or_create_conversation("g1", "Family", true, &app.db);
+        app.store
+            .get_or_create_conversation("g1", "Family", true, &app.db);
         app.active_conversation = Some("g1".to_string());
         let items = app.group_menu_items();
         assert_eq!(items.len(), 5);
@@ -8889,7 +10257,8 @@ mod tests {
 
     #[rstest]
     fn group_menu_items_not_in_group(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         let items = app.group_menu_items();
         assert_eq!(items.len(), 1);
@@ -8905,18 +10274,27 @@ mod tests {
 
     #[rstest]
     fn group_add_filter_excludes_existing_members(mut app: App) {
-
-        app.store.get_or_create_conversation("g1", "Family", true, &app.db);
+        app.store
+            .get_or_create_conversation("g1", "Family", true, &app.db);
         app.active_conversation = Some("g1".to_string());
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Family".to_string(),
-            members: vec!["+1".to_string(), "+2".to_string()],
-            member_uuids: vec![],
-        });
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.contact_names.insert("+2".to_string(), "Bob".to_string());
-        app.store.contact_names.insert("+3".to_string(), "Charlie".to_string());
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec!["+1".to_string(), "+2".to_string()],
+                member_uuids: vec![],
+            },
+        );
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+2".to_string(), "Bob".to_string());
+        app.store
+            .contact_names
+            .insert("+3".to_string(), "Charlie".to_string());
 
         app.refresh_group_add_filter();
 
@@ -8927,23 +10305,39 @@ mod tests {
 
     #[rstest]
     fn group_remove_filter_excludes_self(mut app: App) {
-
-        app.store.get_or_create_conversation("g1", "Family", true, &app.db);
+        app.store
+            .get_or_create_conversation("g1", "Family", true, &app.db);
         app.active_conversation = Some("g1".to_string());
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Family".to_string(),
-            members: vec!["+10000000000".to_string(), "+1".to_string(), "+2".to_string()],
-            member_uuids: vec![],
-        });
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.contact_names.insert("+2".to_string(), "Bob".to_string());
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec![
+                    "+10000000000".to_string(),
+                    "+1".to_string(),
+                    "+2".to_string(),
+                ],
+                member_uuids: vec![],
+            },
+        );
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+2".to_string(), "Bob".to_string());
 
         app.refresh_group_remove_filter();
 
         // Self (+10000000000) should be excluded
         assert_eq!(app.group_menu.filtered.len(), 2);
-        let phones: Vec<&str> = app.group_menu.filtered.iter().map(|(p, _)| p.as_str()).collect();
+        let phones: Vec<&str> = app
+            .group_menu
+            .filtered
+            .iter()
+            .map(|(p, _)| p.as_str())
+            .collect();
         assert!(!phones.contains(&"+10000000000"));
         assert!(phones.contains(&"+1"));
         assert!(phones.contains(&"+2"));
@@ -8951,15 +10345,18 @@ mod tests {
 
     #[rstest]
     fn group_menu_state_transitions(mut app: App) {
-
-        app.store.get_or_create_conversation("g1", "Family", true, &app.db);
+        app.store
+            .get_or_create_conversation("g1", "Family", true, &app.db);
         app.active_conversation = Some("g1".to_string());
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Family".to_string(),
-            members: vec!["+1".to_string()],
-            member_uuids: vec![],
-        });
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec!["+1".to_string()],
+                member_uuids: vec![],
+            },
+        );
 
         // Open group menu via handle_input
         app.input_buffer = "/group".to_string();
@@ -8990,15 +10387,18 @@ mod tests {
 
     #[rstest]
     fn group_leave_produces_send_request(mut app: App) {
-
-        app.store.get_or_create_conversation("g1", "Family", true, &app.db);
+        app.store
+            .get_or_create_conversation("g1", "Family", true, &app.db);
         app.active_conversation = Some("g1".to_string());
-        app.store.groups.insert("g1".to_string(), Group {
-            id: "g1".to_string(),
-            name: "Family".to_string(),
-            members: vec![],
-            member_uuids: vec![],
-        });
+        app.store.groups.insert(
+            "g1".to_string(),
+            Group {
+                id: "g1".to_string(),
+                name: "Family".to_string(),
+                members: vec![],
+                member_uuids: vec![],
+            },
+        );
 
         app.group_menu.state = Some(GroupMenuState::LeaveConfirm);
         let req = app.handle_group_menu_key(KeyCode::Char('y'));
@@ -9009,7 +10409,6 @@ mod tests {
 
     #[rstest]
     fn group_create_produces_send_request(mut app: App) {
-
         app.group_menu.state = Some(GroupMenuState::Create);
         app.group_menu.input = "New Group".to_string();
         let req = app.handle_group_menu_key(KeyCode::Enter);
@@ -9020,14 +10419,16 @@ mod tests {
 
     #[rstest]
     fn group_rename_produces_send_request(mut app: App) {
-
-        app.store.get_or_create_conversation("g1", "Old Name", true, &app.db);
+        app.store
+            .get_or_create_conversation("g1", "Old Name", true, &app.db);
         app.active_conversation = Some("g1".to_string());
         app.group_menu.state = Some(GroupMenuState::Rename);
         app.group_menu.input = "New Name".to_string();
         let req = app.handle_group_menu_key(KeyCode::Enter);
         assert!(req.is_some());
-        assert!(matches!(req, Some(SendRequest::RenameGroup { group_id, name }) if group_id == "g1" && name == "New Name"));
+        assert!(
+            matches!(req, Some(SendRequest::RenameGroup { group_id, name }) if group_id == "g1" && name == "New Name")
+        );
         assert_eq!(app.group_menu.state, None);
     }
 
@@ -9061,7 +10462,9 @@ mod tests {
 
     #[rstest]
     fn known_contact_creates_accepted_conversation(mut app: App) {
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         assert!(app.store.conversations["+1"].accepted);
     }
@@ -9091,21 +10494,21 @@ mod tests {
 
     #[rstest]
     fn contact_sync_auto_accepts_matching_conversations(mut app: App) {
-
         // Message from unknown creates unaccepted
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         assert!(!app.store.conversations["+1"].accepted);
 
         // Contact list arrives with +1 → auto-accept
-        app.handle_signal_event(SignalEvent::ContactList(vec![
-            Contact { number: "+1".to_string(), name: Some("Alice".to_string()), uuid: None },
-        ]));
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+1".to_string(),
+            name: Some("Alice".to_string()),
+            uuid: None,
+        }]));
         assert!(app.store.conversations["+1"].accepted);
     }
 
     #[rstest]
     fn accept_key_returns_send_request_and_marks_accepted(mut app: App) {
-
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         app.active_conversation = Some("+1".to_string());
         app.show_message_request = true;
@@ -9122,7 +10525,6 @@ mod tests {
 
     #[rstest]
     fn delete_key_removes_conversation(mut app: App) {
-
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         app.active_conversation = Some("+1".to_string());
         app.show_message_request = true;
@@ -9141,7 +10543,6 @@ mod tests {
 
     #[rstest]
     fn esc_closes_message_request_overlay(mut app: App) {
-
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         app.active_conversation = Some("+1".to_string());
         app.show_message_request = true;
@@ -9160,7 +10561,8 @@ mod tests {
 
     #[rstest]
     fn bell_skipped_for_blocked_conversation(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         if let Some(conv) = app.store.conversations.get_mut("+1") {
             conv.accepted = true;
         }
@@ -9180,7 +10582,8 @@ mod tests {
     #[rstest]
     fn read_receipts_not_sent_for_blocked(mut app: App) {
         app.send_read_receipts = true;
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         if let Some(conv) = app.store.conversations.get_mut("+1") {
             conv.accepted = true;
         }
@@ -9194,26 +10597,30 @@ mod tests {
 
     #[rstest]
     fn block_adds_to_set_and_returns_send_request(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.input_buffer = "/block".to_string();
         let req = app.handle_input();
         assert!(app.blocked_conversations.contains("+1"));
-        assert!(matches!(req, Some(SendRequest::Block { ref recipient, is_group }) if recipient == "+1" && !is_group));
+        assert!(
+            matches!(req, Some(SendRequest::Block { ref recipient, is_group }) if recipient == "+1" && !is_group)
+        );
         assert!(app.status_message.contains("blocked"));
     }
 
     #[rstest]
     fn unblock_removes_from_set_and_returns_send_request(mut app: App) {
-
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.blocked_conversations.insert("+1".to_string());
         app.input_buffer = "/unblock".to_string();
         let req = app.handle_input();
         assert!(!app.blocked_conversations.contains("+1"));
-        assert!(matches!(req, Some(SendRequest::Unblock { ref recipient, is_group }) if recipient == "+1" && !is_group));
+        assert!(
+            matches!(req, Some(SendRequest::Unblock { ref recipient, is_group }) if recipient == "+1" && !is_group)
+        );
         assert!(app.status_message.contains("unblocked"));
     }
 
@@ -9226,7 +10633,8 @@ mod tests {
         #[case] pre_blocked: bool,
         #[case] expected_msg: &str,
     ) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         if pre_blocked {
             app.blocked_conversations.insert("+1".to_string());
@@ -9240,7 +10648,11 @@ mod tests {
     #[rstest]
     #[case("/block", "no active conversation")]
     #[case("/unblock", "no active conversation")]
-    fn block_unblock_no_active_conversation(mut app: App, #[case] cmd: &str, #[case] expected_msg: &str) {
+    fn block_unblock_no_active_conversation(
+        mut app: App,
+        #[case] cmd: &str,
+        #[case] expected_msg: &str,
+    ) {
         app.input_buffer = cmd.to_string();
         let req = app.handle_input();
         assert!(req.is_none());
@@ -9278,7 +10690,6 @@ mod tests {
 
     #[rstest]
     fn mouse_disabled_ignores_events(mut app: App) {
-
         app.mouse_enabled = false;
         app.mouse_messages_area = Rect::new(0, 0, 80, 20);
         let result = app.handle_mouse_event(mouse_scroll_up(10, 10));
@@ -9288,7 +10699,6 @@ mod tests {
 
     #[rstest]
     fn mouse_overlay_scroll_navigates_list(mut app: App) {
-
         app.show_settings = true;
         app.settings_index = 0;
         app.mouse_messages_area = Rect::new(0, 0, 80, 20);
@@ -9321,10 +10731,11 @@ mod tests {
 
     #[rstest]
     fn mouse_sidebar_click_switches_conversation(mut app: App) {
-
         // Create two conversations
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
-        app.store.get_or_create_conversation("+2", "Bob", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+2", "Bob", false, &app.db);
         app.active_conversation = Some("+1".to_string());
 
         // Sidebar inner starts at row 0, so clicking row 1 selects the second conv
@@ -9335,7 +10746,6 @@ mod tests {
 
     #[rstest]
     fn mouse_input_click_positions_cursor(mut app: App) {
-
         app.mode = InputMode::Normal;
         app.input_buffer = "hello world".to_string();
         app.input_cursor = 0;
@@ -9352,7 +10762,6 @@ mod tests {
 
     #[rstest]
     fn mouse_input_click_handles_multibyte(mut app: App) {
-
         app.mode = InputMode::Normal;
         app.input_buffer = "caf\u{e9} ok".to_string(); // "café ok" — é is 2 bytes
         app.input_cursor = 0;
@@ -9367,7 +10776,6 @@ mod tests {
 
     #[rstest]
     fn has_overlay_detects_all_overlays(mut app: App) {
-
         assert!(!app.has_overlay());
 
         app.show_settings = true;
@@ -9566,7 +10974,12 @@ mod tests {
 
     // --- Helper for building a SignalMessage ---
 
-    fn make_msg(source: &str, body: Option<&str>, group_id: Option<&str>, is_outgoing: bool) -> SignalMessage {
+    fn make_msg(
+        source: &str,
+        body: Option<&str>,
+        group_id: Option<&str>,
+        is_outgoing: bool,
+    ) -> SignalMessage {
         SignalMessage {
             source: source.to_string(),
             source_name: None,
@@ -9629,7 +11042,10 @@ mod tests {
         }];
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let conv = &app.store.conversations["+1"];
-        assert!(conv.messages.iter().any(|m| m.body.contains("[image: photo.jpg]")));
+        assert!(conv
+            .messages
+            .iter()
+            .any(|m| m.body.contains("[image: photo.jpg]")));
     }
 
     #[rstest]
@@ -9643,7 +11059,10 @@ mod tests {
         }];
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let conv = &app.store.conversations["+1"];
-        assert!(conv.messages.iter().any(|m| m.body.contains("[attachment: doc.pdf]")));
+        assert!(conv
+            .messages
+            .iter()
+            .any(|m| m.body.contains("[attachment: doc.pdf]")));
     }
 
     #[rstest]
@@ -9674,7 +11093,10 @@ mod tests {
         }];
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let conv = &app.store.conversations["+1"];
-        assert!(conv.messages.iter().any(|m| m.body.contains("[attachment: audio/ogg]")));
+        assert!(conv
+            .messages
+            .iter()
+            .any(|m| m.body.contains("[attachment: audio/ogg]")));
     }
 
     // --- Bell / notification tests ---
@@ -9683,8 +11105,11 @@ mod tests {
     fn bell_rings_for_background_dm(mut app: App) {
         app.sync.active = false;
         // "+1" must be a known contact so conversation is accepted
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.get_or_create_conversation("+other", "Other", false, &app.db);
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .get_or_create_conversation("+other", "Other", false, &app.db);
         app.active_conversation = Some("+other".to_string());
         app.notifications.notify_direct = true;
 
@@ -9695,7 +11120,8 @@ mod tests {
 
     #[rstest]
     fn bell_not_set_for_active_conversation(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.notifications.notify_direct = true;
 
@@ -9706,7 +11132,8 @@ mod tests {
 
     #[rstest]
     fn bell_skipped_when_notify_disabled(mut app: App) {
-        app.store.get_or_create_conversation("+other", "Other", false, &app.db);
+        app.store
+            .get_or_create_conversation("+other", "Other", false, &app.db);
         app.active_conversation = Some("+other".to_string());
         app.notifications.notify_direct = false;
 
@@ -9718,10 +11145,14 @@ mod tests {
     #[rstest]
     fn bell_for_group_respects_setting(mut app: App) {
         app.sync.active = false;
-        app.handle_signal_event(SignalEvent::GroupList(vec![
-            Group { id: "g1".to_string(), name: "Team".to_string(), members: vec![], member_uuids: vec![] },
-        ]));
-        app.store.get_or_create_conversation("+other", "Other", false, &app.db);
+        app.handle_signal_event(SignalEvent::GroupList(vec![Group {
+            id: "g1".to_string(),
+            name: "Team".to_string(),
+            members: vec![],
+            member_uuids: vec![],
+        }]));
+        app.store
+            .get_or_create_conversation("+other", "Other", false, &app.db);
         app.active_conversation = Some("+other".to_string());
 
         // group notifications enabled
@@ -9751,7 +11182,8 @@ mod tests {
 
     #[rstest]
     fn unread_no_increment_for_active(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         let msg = make_msg("+1", Some("hey"), None, false);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
@@ -9763,13 +11195,17 @@ mod tests {
     #[rstest]
     fn active_conv_queues_read_receipt(mut app: App) {
         app.sync.active = false;
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.send_read_receipts = true;
 
         let msg = make_msg("+1", Some("hey"), None, false);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
-        assert!(!app.pending_read_receipts.is_empty(), "expected read receipt to be queued");
+        assert!(
+            !app.pending_read_receipts.is_empty(),
+            "expected read receipt to be queued"
+        );
         let (recipient, _) = &app.pending_read_receipts[0];
         assert_eq!(recipient, "+1");
     }
@@ -9778,7 +11214,8 @@ mod tests {
 
     #[rstest]
     fn handle_message_syncs_expiration_timer(mut app: App) {
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         assert_eq!(app.store.conversations["+1"].expiration_timer, 0);
 
         let mut msg = make_msg("+1", Some("secret"), None, false);
@@ -9824,10 +11261,7 @@ mod tests {
             width: 2,
             height: 2,
             bytes: std::borrow::Cow::Owned(vec![
-                255, 0, 0, 255,
-                0, 255, 0, 255,
-                0, 0, 255, 255,
-                255, 255, 0, 255,
+                255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 0, 255,
             ]),
         };
 
@@ -9864,10 +11298,14 @@ mod tests {
             group_id: Some("group-a".to_string()),
         });
 
-        assert!(app.typing.indicators.contains_key("group-a"),
-            "typing indicator should be keyed by group ID");
-        assert!(!app.typing.indicators.contains_key("+1"),
-            "typing indicator must NOT be keyed by sender phone");
+        assert!(
+            app.typing.indicators.contains_key("group-a"),
+            "typing indicator should be keyed by group ID"
+        );
+        assert!(
+            !app.typing.indicators.contains_key("+1"),
+            "typing indicator must NOT be keyed by sender phone"
+        );
         // Inner map stores the sender phone so we can resolve the display name
         assert!(app.typing.indicators["group-a"].contains_key("+1"));
     }
@@ -9875,8 +11313,10 @@ mod tests {
     #[rstest]
     fn group_typing_does_not_bleed_into_other_group(mut app: App) {
         // Alice types in group-a. Viewing group-b must show no typing indicator.
-        app.store.get_or_create_conversation("group-a", "Group A", true, &app.db);
-        app.store.get_or_create_conversation("group-b", "Group B", true, &app.db);
+        app.store
+            .get_or_create_conversation("group-a", "Group A", true, &app.db);
+        app.store
+            .get_or_create_conversation("group-b", "Group B", true, &app.db);
 
         app.handle_signal_event(SignalEvent::TypingIndicator {
             sender: "+1".to_string(),
@@ -9886,8 +11326,10 @@ mod tests {
         });
 
         // Viewing group-b: no indicator should be visible for it
-        assert!(!app.typing.indicators.contains_key("group-b"),
-            "group-a typing must not bleed into group-b");
+        assert!(
+            !app.typing.indicators.contains_key("group-b"),
+            "group-a typing must not bleed into group-b"
+        );
     }
 
     #[rstest]
@@ -9900,8 +11342,10 @@ mod tests {
             group_id: None,
         });
 
-        assert!(app.typing.indicators.contains_key("+1"),
-            "1:1 typing indicator should be keyed by sender phone");
+        assert!(
+            app.typing.indicators.contains_key("+1"),
+            "1:1 typing indicator should be keyed by sender phone"
+        );
     }
 
     #[rstest]
@@ -9959,7 +11403,10 @@ mod tests {
             expiration_timer: 0,
             accepted: true,
         };
-        assert!(empty_group.is_stale(), "group with no messages and name==id is stale");
+        assert!(
+            empty_group.is_stale(),
+            "group with no messages and name==id is stale"
+        );
 
         let named_group = Conversation {
             name: "Book Club".to_string(),
@@ -9970,7 +11417,10 @@ mod tests {
             expiration_timer: 0,
             accepted: true,
         };
-        assert!(!named_group.is_stale(), "group with a real name is not stale");
+        assert!(
+            !named_group.is_stale(),
+            "group with a real name is not stale"
+        );
 
         let phone_contact = Conversation {
             name: "+15551234567".to_string(),
@@ -9981,7 +11431,10 @@ mod tests {
             expiration_timer: 0,
             accepted: true,
         };
-        assert!(!phone_contact.is_stale(), "contact with phone number is not stale");
+        assert!(
+            !phone_contact.is_stale(),
+            "contact with phone number is not stale"
+        );
 
         let uuid_contact = Conversation {
             name: "8eb3dbda-1234-5678".to_string(),
@@ -9992,7 +11445,10 @@ mod tests {
             expiration_timer: 0,
             accepted: true,
         };
-        assert!(uuid_contact.is_stale(), "contact with UUID-only name is stale");
+        assert!(
+            uuid_contact.is_stale(),
+            "contact with UUID-only name is stale"
+        );
     }
 
     #[test]
@@ -10064,7 +11520,10 @@ mod tests {
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         app.active_conversation = Some("+1".to_string());
         let items = app.action_menu_items();
-        assert!(items.iter().any(|a| a.label == "Open attachment"), "expected Open attachment in menu");
+        assert!(
+            items.iter().any(|a| a.label == "Open attachment"),
+            "expected Open attachment in menu"
+        );
     }
 
     #[rstest]
@@ -10073,7 +11532,10 @@ mod tests {
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         app.active_conversation = Some("+1".to_string());
         let items = app.action_menu_items();
-        assert!(items.iter().any(|a| a.label == "Open link"), "expected Open link in menu");
+        assert!(
+            items.iter().any(|a| a.label == "Open link"),
+            "expected Open link in menu"
+        );
     }
 
     #[rstest]
@@ -10094,11 +11556,17 @@ mod tests {
         // Index 0 is the body message ("see https://example.com")
         app.focused_msg_index = Some(0);
         let items_body = app.action_menu_items();
-        assert!(items_body.iter().any(|a| a.label == "Open link"), "expected Open link for body message");
+        assert!(
+            items_body.iter().any(|a| a.label == "Open link"),
+            "expected Open link for body message"
+        );
         // Index 1 is the attachment message ("[image: photo.png](file:///tmp/photo.png)")
         app.focused_msg_index = Some(1);
         let items_att = app.action_menu_items();
-        assert!(items_att.iter().any(|a| a.label == "Open attachment"), "expected Open attachment for attachment message");
+        assert!(
+            items_att.iter().any(|a| a.label == "Open attachment"),
+            "expected Open attachment for attachment message"
+        );
     }
 
     #[rstest]
@@ -10107,8 +11575,14 @@ mod tests {
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         app.active_conversation = Some("+1".to_string());
         let items = app.action_menu_items();
-        assert!(!items.iter().any(|a| a.label == "Open attachment"), "should not have Open attachment");
-        assert!(!items.iter().any(|a| a.label == "Open link"), "should not have Open link");
+        assert!(
+            !items.iter().any(|a| a.label == "Open attachment"),
+            "should not have Open attachment"
+        );
+        assert!(
+            !items.iter().any(|a| a.label == "Open link"),
+            "should not have Open link"
+        );
     }
 
     #[rstest]
@@ -10123,12 +11597,18 @@ mod tests {
 
         // Without focus, defaults to last message (plain text) — no Open link
         let items = app.action_menu_items();
-        assert!(!items.iter().any(|a| a.label == "Open link"), "last msg has no URL");
+        assert!(
+            !items.iter().any(|a| a.label == "Open link"),
+            "last msg has no URL"
+        );
 
         // Focus the first message (the one with a URL)
         app.focused_msg_index = Some(0);
         let items = app.action_menu_items();
-        assert!(items.iter().any(|a| a.label == "Open link"), "focused msg has URL, should show Open link");
+        assert!(
+            items.iter().any(|a| a.label == "Open link"),
+            "focused msg has URL, should show Open link"
+        );
     }
 
     // --- SyncState tests ---
@@ -10154,22 +11634,35 @@ mod tests {
     #[rstest]
     fn sync_suppresses_notifications(mut app: App) {
         assert!(app.sync.active);
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.get_or_create_conversation("+other", "Other", false, &app.db);
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .get_or_create_conversation("+other", "Other", false, &app.db);
         app.active_conversation = Some("+other".to_string());
         app.notifications.notify_direct = true;
         let msg = make_msg("+1", Some("hello"), None, false);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         assert!(!app.notifications.pending_bell);
-        assert_eq!(app.sync.suppressed_notifications.get("+1").copied().unwrap_or(0), 1);
+        assert_eq!(
+            app.sync
+                .suppressed_notifications
+                .get("+1")
+                .copied()
+                .unwrap_or(0),
+            1
+        );
         assert!(app.sync.message_count > 0);
     }
 
     #[rstest]
     fn notifications_fire_after_sync_ends(mut app: App) {
         app.sync.active = false;
-        app.store.contact_names.insert("+1".to_string(), "Alice".to_string());
-        app.store.get_or_create_conversation("+other", "Other", false, &app.db);
+        app.store
+            .contact_names
+            .insert("+1".to_string(), "Alice".to_string());
+        app.store
+            .get_or_create_conversation("+other", "Other", false, &app.db);
         app.active_conversation = Some("+other".to_string());
         app.notifications.notify_direct = true;
         let msg = make_msg("+1", Some("hello"), None, false);
@@ -10180,18 +11673,23 @@ mod tests {
     #[rstest]
     fn sync_stabilizes_scroll_offset(mut app: App) {
         assert!(app.sync.active);
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.scroll_offset = 0;
         let msg = make_msg("+1", Some("hello from sync"), None, false);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
-        assert!(app.scroll_offset > 0, "scroll_offset should increase during sync");
+        assert!(
+            app.scroll_offset > 0,
+            "scroll_offset should increase during sync"
+        );
     }
 
     #[rstest]
     fn sync_does_not_stabilize_after_user_scroll(mut app: App) {
         assert!(app.sync.active);
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         app.scroll_offset = 0;
         app.sync.user_scrolled = true;
@@ -10203,13 +11701,17 @@ mod tests {
     #[rstest]
     fn sync_does_not_advance_read_index_for_active_conv(mut app: App) {
         assert!(app.sync.active);
-        app.store.get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
         let initial_read = app.store.last_read_index.get("+1").copied().unwrap_or(0);
         let msg = make_msg("+1", Some("hello"), None, false);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let after_read = app.store.last_read_index.get("+1").copied().unwrap_or(0);
-        assert_eq!(initial_read, after_read, "read index should not advance during sync");
+        assert_eq!(
+            initial_read, after_read,
+            "read index should not advance during sync"
+        );
     }
 
     #[rstest]
@@ -10217,8 +11719,12 @@ mod tests {
         app.sync.active = true;
         app.sync.message_count = 50;
         app.scroll_offset = 30;
-        app.sync.suppressed_notifications.insert("+1".to_string(), 10);
-        app.sync.suppressed_notifications.insert("+2".to_string(), 5);
+        app.sync
+            .suppressed_notifications
+            .insert("+1".to_string(), 10);
+        app.sync
+            .suppressed_notifications
+            .insert("+2".to_string(), 5);
         app.end_sync();
         assert!(!app.sync.active);
         assert_eq!(app.scroll_offset, 0);

--- a/src/config.rs
+++ b/src/config.rs
@@ -211,7 +211,8 @@ impl Config {
                         if let Some(parent) = new_path.parent() {
                             let _ = std::fs::create_dir_all(parent);
                         }
-                        let _ = std::fs::rename(old_path.parent().unwrap(), new_path.parent().unwrap());
+                        let _ =
+                            std::fs::rename(old_path.parent().unwrap(), new_path.parent().unwrap());
                     }
                 }
                 new_path
@@ -221,8 +222,9 @@ impl Config {
         if config_path.exists() {
             let contents = std::fs::read_to_string(&config_path)
                 .with_context(|| format!("Failed to read config from {}", config_path.display()))?;
-            let mut config: Config = toml::from_str(&contents)
-                .with_context(|| format!("Failed to parse config from {}", config_path.display()))?;
+            let mut config: Config = toml::from_str(&contents).with_context(|| {
+                format!("Failed to parse config from {}", config_path.display())
+            })?;
             // Migrate legacy inline_images/native_images to image_mode
             if config.image_mode.is_empty() {
                 config.image_mode = if config.native_images {
@@ -243,12 +245,12 @@ impl Config {
     pub fn save(&self) -> Result<()> {
         let config_path = Self::default_config_path();
         if let Some(parent) = config_path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("Failed to create config directory {}", parent.display()))?;
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("Failed to create config directory {}", parent.display())
+            })?;
             Self::set_dir_permissions(parent);
         }
-        let contents = toml::to_string_pretty(self)
-            .context("Failed to serialize config")?;
+        let contents = toml::to_string_pretty(self).context("Failed to serialize config")?;
         std::fs::write(&config_path, contents)
             .with_context(|| format!("Failed to write config to {}", config_path.display()))?;
         Self::set_file_permissions(&config_path);

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -180,7 +180,10 @@ impl ConversationStore {
     ) -> &mut Conversation {
         if !self.conversations.contains_key(id) {
             // New conversation — always persist
-            db_warn(db.upsert_conversation(id, name, is_group), "upsert_conversation");
+            db_warn(
+                db.upsert_conversation(id, name, is_group),
+                "upsert_conversation",
+            );
             self.conversations.insert(
                 id.to_string(),
                 Conversation {
@@ -199,7 +202,10 @@ impl ConversationStore {
             let conv = self.conversations.get_mut(id).unwrap();
             if conv.name != name {
                 conv.name = name.to_string();
-                db_warn(db.upsert_conversation(id, name, is_group), "upsert_conversation");
+                db_warn(
+                    db.upsert_conversation(id, name, is_group),
+                    "upsert_conversation",
+                );
             }
         }
         self.conversations.get_mut(id).unwrap()
@@ -226,7 +232,11 @@ impl ConversationStore {
     /// Resolve U+FFFC placeholders in a message body using bodyRanges mentions.
     /// Returns (resolved_body, mention_byte_ranges) where mention_byte_ranges are
     /// (start, end) byte offsets of each `@Name` in the resolved body.
-    pub fn resolve_mentions(&self, body: &str, mentions: &[Mention]) -> (String, Vec<(usize, usize)>) {
+    pub fn resolve_mentions(
+        &self,
+        body: &str,
+        mentions: &[Mention],
+    ) -> (String, Vec<(usize, usize)>) {
         if mentions.is_empty() {
             return (body.to_string(), Vec::new());
         }
@@ -302,7 +312,10 @@ impl ConversationStore {
                     short.to_string()
                 });
             let replacement_utf16_len = format!("@{name}").encode_utf16().count();
-            let byte_start = utf16_to_byte.get(adjusted_start).copied().unwrap_or(resolved_bytes.len());
+            let byte_start = utf16_to_byte
+                .get(adjusted_start)
+                .copied()
+                .unwrap_or(resolved_bytes.len());
             let byte_end = utf16_to_byte
                 .get(adjusted_start + replacement_utf16_len)
                 .copied()
@@ -335,14 +348,14 @@ impl ConversationStore {
             sorted_mentions.sort_by_key(|m| m.start);
             let mut cumulative: i64 = 0;
             for m in &sorted_mentions {
-                let name = self
-                    .uuid_to_name
-                    .get(&m.uuid)
-                    .cloned()
-                    .unwrap_or_else(|| {
-                        let short = if m.uuid.len() > 8 { &m.uuid[..8] } else { &m.uuid };
-                        short.to_string()
-                    });
+                let name = self.uuid_to_name.get(&m.uuid).cloned().unwrap_or_else(|| {
+                    let short = if m.uuid.len() > 8 {
+                        &m.uuid[..8]
+                    } else {
+                        &m.uuid
+                    };
+                    short.to_string()
+                });
                 let replacement_utf16_len = format!("@{name}").encode_utf16().count() as i64;
                 let original_len = m.length as i64;
                 cumulative += replacement_utf16_len - original_len;
@@ -381,8 +394,14 @@ impl ConversationStore {
             .filter_map(|ts| {
                 let shifted_start = shift_offset(ts.start);
                 let shifted_end = shift_offset(ts.start + ts.length);
-                let byte_start = utf16_to_byte.get(shifted_start).copied().unwrap_or(body_byte_len);
-                let byte_end = utf16_to_byte.get(shifted_end).copied().unwrap_or(body_byte_len);
+                let byte_start = utf16_to_byte
+                    .get(shifted_start)
+                    .copied()
+                    .unwrap_or(body_byte_len);
+                let byte_end = utf16_to_byte
+                    .get(shifted_end)
+                    .copied()
+                    .unwrap_or(body_byte_len);
                 if byte_start < byte_end && byte_end <= body_byte_len {
                     Some((byte_start, byte_end, ts.style))
                 } else {

--- a/src/db.rs
+++ b/src/db.rs
@@ -39,13 +39,11 @@ impl Database {
             "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);",
         )?;
 
-        let version: i32 = self
-            .conn
-            .query_row(
-                "SELECT COALESCE(MAX(version), 0) FROM schema_version",
-                [],
-                |row| row.get(0),
-            )?;
+        let version: i32 = self.conn.query_row(
+            "SELECT COALESCE(MAX(version), 0) FROM schema_version",
+            [],
+            |row| row.get(0),
+        )?;
 
         if version < 1 {
             self.conn.execute_batch(
@@ -252,16 +250,31 @@ impl Database {
     }
 
     pub fn delete_conversation(&self, id: &str) -> Result<()> {
-        self.conn.execute("DELETE FROM reactions WHERE conversation_id = ?1", params![id])?;
-        self.conn.execute("DELETE FROM messages WHERE conversation_id = ?1", params![id])?;
-        self.conn.execute("DELETE FROM read_markers WHERE conversation_id = ?1", params![id])?;
-        self.conn.execute("DELETE FROM conversations WHERE id = ?1", params![id])?;
+        self.conn.execute(
+            "DELETE FROM reactions WHERE conversation_id = ?1",
+            params![id],
+        )?;
+        self.conn.execute(
+            "DELETE FROM messages WHERE conversation_id = ?1",
+            params![id],
+        )?;
+        self.conn.execute(
+            "DELETE FROM read_markers WHERE conversation_id = ?1",
+            params![id],
+        )?;
+        self.conn
+            .execute("DELETE FROM conversations WHERE id = ?1", params![id])?;
         Ok(())
     }
 
     /// Load a page of messages for a conversation, ordered chronologically (oldest first).
     /// `offset` skips the N most recent messages (for pagination).
-    pub fn load_messages_page(&self, conv_id: &str, limit: usize, offset: usize) -> Result<Vec<DisplayMessage>> {
+    pub fn load_messages_page(
+        &self,
+        conv_id: &str,
+        limit: usize,
+        offset: usize,
+    ) -> Result<Vec<DisplayMessage>> {
         let mut msg_stmt = self.conn.prepare(
             "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data, link_preview FROM messages
              WHERE conversation_id = ?1
@@ -287,50 +300,90 @@ impl Database {
                 let is_pinned: bool = row.get::<_, i32>(14)? != 0;
                 let poll_data_json: Option<String> = row.get(15)?;
                 let link_preview_json: Option<String> = row.get(16)?;
-                Ok((sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json))
-            })?
-            .filter_map(|r| r.ok())
-            .filter_map(|(sender, ts_str, body, is_system, status_i32, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, is_pinned, poll_data_json, link_preview_json)| {
-                let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
-                    .ok()?
-                    .with_timezone(&chrono::Utc);
-                let quote = match (quote_author, quote_body, quote_ts_ms) {
-                    (Some(author), Some(body), Some(ts)) => Some(crate::app::Quote {
-                        author_id: author.clone(),
-                        author,
-                        body: body.replace('\u{FFFC}', ""),
-                        timestamp_ms: ts,
-                    }),
-                    _ => None,
-                };
-                let poll_data = poll_data_json.and_then(|j| serde_json::from_str::<PollData>(&j).ok());
-                let preview = link_preview_json.and_then(|j| serde_json::from_str::<LinkPreview>(&j).ok());
-                Some(DisplayMessage {
+                Ok((
                     sender,
-                    timestamp,
+                    ts_str,
                     body,
                     is_system,
-                    image_lines: None,
-                    image_path: None,
-                    status: MessageStatus::from_i32(status_i32),
+                    status_i32,
                     timestamp_ms,
-                    reactions: Vec::new(),
-                    mention_ranges: Vec::new(),
-                    style_ranges: Vec::new(),
-                    quote,
                     is_edited,
                     is_deleted,
-                    is_pinned,
+                    quote_author,
+                    quote_body,
+                    quote_ts_ms,
                     sender_id,
                     expires_in_seconds,
                     expiration_start_ms,
-                    poll_data,
-                    poll_votes: Vec::new(),
-                    preview,
-                    preview_image_lines: None,
-                    preview_image_path: None,
-                })
-            })
+                    is_pinned,
+                    poll_data_json,
+                    link_preview_json,
+                ))
+            })?
+            .filter_map(|r| r.ok())
+            .filter_map(
+                |(
+                    sender,
+                    ts_str,
+                    body,
+                    is_system,
+                    status_i32,
+                    timestamp_ms,
+                    is_edited,
+                    is_deleted,
+                    quote_author,
+                    quote_body,
+                    quote_ts_ms,
+                    sender_id,
+                    expires_in_seconds,
+                    expiration_start_ms,
+                    is_pinned,
+                    poll_data_json,
+                    link_preview_json,
+                )| {
+                    let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
+                        .ok()?
+                        .with_timezone(&chrono::Utc);
+                    let quote = match (quote_author, quote_body, quote_ts_ms) {
+                        (Some(author), Some(body), Some(ts)) => Some(crate::app::Quote {
+                            author_id: author.clone(),
+                            author,
+                            body: body.replace('\u{FFFC}', ""),
+                            timestamp_ms: ts,
+                        }),
+                        _ => None,
+                    };
+                    let poll_data =
+                        poll_data_json.and_then(|j| serde_json::from_str::<PollData>(&j).ok());
+                    let preview = link_preview_json
+                        .and_then(|j| serde_json::from_str::<LinkPreview>(&j).ok());
+                    Some(DisplayMessage {
+                        sender,
+                        timestamp,
+                        body,
+                        is_system,
+                        image_lines: None,
+                        image_path: None,
+                        status: MessageStatus::from_i32(status_i32),
+                        timestamp_ms,
+                        reactions: Vec::new(),
+                        mention_ranges: Vec::new(),
+                        style_ranges: Vec::new(),
+                        quote,
+                        is_edited,
+                        is_deleted,
+                        is_pinned,
+                        sender_id,
+                        expires_in_seconds,
+                        expiration_start_ms,
+                        poll_data,
+                        poll_votes: Vec::new(),
+                        preview,
+                        preview_image_lines: None,
+                        preview_image_path: None,
+                    })
+                },
+            )
             .collect();
 
         // Reverse so oldest first
@@ -344,9 +397,12 @@ impl Database {
         if let Ok(reactions) = self.load_reactions(conv_id) {
             for (target_ts, target_author, emoji, sender) in reactions {
                 let idx = ts_to_idx.get(&target_ts).and_then(|idxs| {
-                    idxs.iter().find(|&&i| {
-                        messages[i].sender == target_author || messages[i].sender == "you"
-                    }).or_else(|| idxs.first()).copied()
+                    idxs.iter()
+                        .find(|&&i| {
+                            messages[i].sender == target_author || messages[i].sender == "you"
+                        })
+                        .or_else(|| idxs.first())
+                        .copied()
                 });
                 if let Some(msg) = idx.and_then(|i| messages.get_mut(i)) {
                     if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == sender) {
@@ -437,7 +493,21 @@ impl Database {
         status: Option<MessageStatus>,
         timestamp_ms: i64,
     ) -> Result<i64> {
-        self.insert_message_full(conv_id, sender, timestamp, body, is_system, status, timestamp_ms, "", None, None, None, 0, 0)
+        self.insert_message_full(
+            conv_id,
+            sender,
+            timestamp,
+            body,
+            is_system,
+            status,
+            timestamp_ms,
+            "",
+            None,
+            None,
+            None,
+            0,
+            0,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -467,7 +537,12 @@ impl Database {
     }
 
     /// Update delivery status for an outgoing message by its ms epoch timestamp.
-    pub fn update_message_status(&self, conv_id: &str, timestamp_ms: i64, status: i32) -> Result<()> {
+    pub fn update_message_status(
+        &self,
+        conv_id: &str,
+        timestamp_ms: i64,
+        status: i32,
+    ) -> Result<()> {
         self.conn.execute(
             "UPDATE messages SET status = ?3
              WHERE conversation_id = ?1 AND timestamp_ms = ?2 AND sender = 'you' AND status < ?3",
@@ -515,16 +590,14 @@ impl Database {
     }
 
     pub fn unread_count(&self, conv_id: &str) -> Result<usize> {
-        let last_read: i64 = self
-            .conn
-            .query_row(
-                "SELECT COALESCE(
+        let last_read: i64 = self.conn.query_row(
+            "SELECT COALESCE(
                     (SELECT last_read_rowid FROM read_markers WHERE conversation_id = ?1),
                     0
                  )",
-                params![conv_id],
-                |row| row.get(0),
-            )?;
+            params![conv_id],
+            |row| row.get(0),
+        )?;
 
         let count: i64 = self.conn.query_row(
             "SELECT COUNT(*) FROM messages
@@ -581,12 +654,7 @@ impl Database {
         )?;
         let rows: Vec<(i64, String, String, String)> = stmt
             .query_map(params![conv_id], |row| {
-                Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                ))
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
@@ -633,7 +701,10 @@ impl Database {
         query: &str,
         limit: usize,
     ) -> Result<Vec<SearchRow>> {
-        let escaped = query.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
+        let escaped = query
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
         let pattern = format!("%{escaped}%");
         let mut stmt = self.conn.prepare(
             "SELECT m.sender, m.body, m.timestamp_ms, c.id, c.name
@@ -663,12 +734,11 @@ impl Database {
     /// Search messages across all conversations using case-insensitive LIKE.
     /// Returns (sender, body, timestamp_ms, conversation_id, conversation_name) tuples,
     /// most recent first, limited to `limit` results.
-    pub fn search_all_messages(
-        &self,
-        query: &str,
-        limit: usize,
-    ) -> Result<Vec<SearchRow>> {
-        let escaped = query.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_");
+    pub fn search_all_messages(&self, query: &str, limit: usize) -> Result<Vec<SearchRow>> {
+        let escaped = query
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
         let pattern = format!("%{escaped}%");
         let mut stmt = self.conn.prepare(
             "SELECT m.sender, m.body, m.timestamp_ms, c.id, c.name
@@ -696,7 +766,11 @@ impl Database {
 
     /// Find the max rowid for messages up to (and including) a given timestamp.
     /// Uses the idx_messages_conv_ts_ms index for efficient lookup.
-    pub fn max_rowid_up_to_timestamp(&self, conv_id: &str, timestamp_ms: i64) -> Result<Option<i64>> {
+    pub fn max_rowid_up_to_timestamp(
+        &self,
+        conv_id: &str,
+        timestamp_ms: i64,
+    ) -> Result<Option<i64>> {
         let result = self.conn.query_row(
             "SELECT MAX(rowid) FROM messages WHERE conversation_id = ?1 AND timestamp_ms <= ?2",
             params![conv_id, timestamp_ms],
@@ -716,9 +790,9 @@ impl Database {
     }
 
     pub fn load_muted(&self) -> Result<std::collections::HashSet<String>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id FROM conversations WHERE muted = 1",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM conversations WHERE muted = 1")?;
         let ids: Vec<String> = stmt
             .query_map([], |row| row.get(0))?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -736,9 +810,9 @@ impl Database {
     }
 
     pub fn load_blocked(&self) -> Result<std::collections::HashSet<String>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT id FROM conversations WHERE blocked = 1",
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id FROM conversations WHERE blocked = 1")?;
         let ids: Vec<String> = stmt
             .query_map([], |row| row.get(0))?
             .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -767,7 +841,12 @@ impl Database {
 
     // --- Polls ---
 
-    pub fn upsert_poll_data(&self, conv_id: &str, timestamp_ms: i64, poll_data: &PollData) -> Result<()> {
+    pub fn upsert_poll_data(
+        &self,
+        conv_id: &str,
+        timestamp_ms: i64,
+        poll_data: &PollData,
+    ) -> Result<()> {
         let json = serde_json::to_string(poll_data)?;
         self.conn.execute(
             "UPDATE messages SET poll_data = ?3
@@ -777,7 +856,12 @@ impl Database {
         Ok(())
     }
 
-    pub fn upsert_link_preview(&self, conv_id: &str, timestamp_ms: i64, preview: &LinkPreview) -> Result<()> {
+    pub fn upsert_link_preview(
+        &self,
+        conv_id: &str,
+        timestamp_ms: i64,
+        preview: &LinkPreview,
+    ) -> Result<()> {
         let json = serde_json::to_string(preview)?;
         self.conn.execute(
             "UPDATE messages SET link_preview = ?3
@@ -818,19 +902,29 @@ impl Database {
                 let voter_name: Option<String> = row.get(1)?;
                 let indexes_json: String = row.get(2)?;
                 let vote_count: i64 = row.get(3)?;
-                let option_indexes: Vec<i64> = serde_json::from_str(&indexes_json).unwrap_or_default();
-                Ok(PollVote { voter, voter_name, option_indexes, vote_count })
+                let option_indexes: Vec<i64> =
+                    serde_json::from_str(&indexes_json).unwrap_or_default();
+                Ok(PollVote {
+                    voter,
+                    voter_name,
+                    option_indexes,
+                    vote_count,
+                })
             })?
             .collect::<std::result::Result<Vec<_>, _>>()?;
         Ok(rows)
     }
 
     pub fn close_poll(&self, conv_id: &str, poll_timestamp: i64) -> Result<()> {
-        let poll_json: Option<String> = self.conn.query_row(
-            "SELECT poll_data FROM messages WHERE conversation_id = ?1 AND timestamp_ms = ?2",
-            params![conv_id, poll_timestamp],
-            |row| row.get(0),
-        ).ok().flatten();
+        let poll_json: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT poll_data FROM messages WHERE conversation_id = ?1 AND timestamp_ms = ?2",
+                params![conv_id, poll_timestamp],
+                |row| row.get(0),
+            )
+            .ok()
+            .flatten();
         if let Some(json_str) = poll_json {
             if let Ok(mut poll_data) = serde_json::from_str::<PollData>(&json_str) {
                 poll_data.closed = true;
@@ -844,7 +938,6 @@ impl Database {
         }
         Ok(())
     }
-
 }
 
 #[cfg(test)]
@@ -860,9 +953,10 @@ mod tests {
     #[rstest]
     fn migration_creates_tables(db: Database) {
         // Should be able to query conversations table
-        let count: i64 = db.conn.query_row(
-            "SELECT COUNT(*) FROM conversations", [], |row| row.get(0),
-        ).unwrap();
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM conversations", [], |row| row.get(0))
+            .unwrap();
         assert_eq!(count, 0);
     }
 
@@ -888,8 +982,18 @@ mod tests {
     #[rstest]
     fn insert_and_load_messages(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello", false, None, 0).unwrap();
-        db.insert_message("+1", "you", "2025-01-01T00:01:00Z", "hi!", false, None, 0).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "hello",
+            false,
+            None,
+            0,
+        )
+        .unwrap();
+        db.insert_message("+1", "you", "2025-01-01T00:01:00Z", "hi!", false, None, 0)
+            .unwrap();
 
         let convs = db.load_conversations(100).unwrap();
         assert_eq!(convs[0].messages.len(), 2);
@@ -900,9 +1004,37 @@ mod tests {
     #[rstest]
     fn unread_count_with_read_markers(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        let r1 = db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "msg1", false, None, 0).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "msg2", false, None, 0).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:02:00Z", "msg3", false, None, 0).unwrap();
+        let r1 = db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:00:00Z",
+                "msg1",
+                false,
+                None,
+                0,
+            )
+            .unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:01:00Z",
+            "msg2",
+            false,
+            None,
+            0,
+        )
+        .unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:02:00Z",
+            "msg3",
+            false,
+            None,
+            0,
+        )
+        .unwrap();
 
         // Mark first message as read
         db.save_read_marker("+1", r1).unwrap();
@@ -912,8 +1044,26 @@ mod tests {
     #[rstest]
     fn system_messages_excluded_from_unread(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "", "2025-01-01T00:00:00Z", "system msg", true, None, 0).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "real msg", false, None, 0).unwrap();
+        db.insert_message(
+            "+1",
+            "",
+            "2025-01-01T00:00:00Z",
+            "system msg",
+            true,
+            None,
+            0,
+        )
+        .unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:01:00Z",
+            "real msg",
+            false,
+            None,
+            0,
+        )
+        .unwrap();
 
         // No read marker → only non-system messages count as unread
         assert_eq!(db.unread_count("+1").unwrap(), 1);
@@ -924,8 +1074,10 @@ mod tests {
         db.upsert_conversation("+1", "Alice", false).unwrap();
         db.upsert_conversation("+2", "Bob", false).unwrap();
         // Alice gets an older message, Bob gets a newer one
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "old", false, None, 0).unwrap();
-        db.insert_message("+2", "Bob", "2025-01-02T00:00:00Z", "new", false, None, 0).unwrap();
+        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "old", false, None, 0)
+            .unwrap();
+        db.insert_message("+2", "Bob", "2025-01-02T00:00:00Z", "new", false, None, 0)
+            .unwrap();
 
         let order = db.load_conversation_order().unwrap();
         // Most recent message first
@@ -969,8 +1121,27 @@ mod tests {
 
         assert_eq!(db.last_message_rowid("+1").unwrap(), None);
 
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "msg1", false, None, 0).unwrap();
-        let r2 = db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "msg2", false, None, 0).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "msg1",
+            false,
+            None,
+            0,
+        )
+        .unwrap();
+        let r2 = db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:01:00Z",
+                "msg2",
+                false,
+                None,
+                0,
+            )
+            .unwrap();
 
         assert_eq!(db.last_message_rowid("+1").unwrap(), Some(r2));
     }
@@ -982,9 +1153,39 @@ mod tests {
         // No messages → None
         assert_eq!(db.max_rowid_up_to_timestamp("+1", 5000).unwrap(), None);
 
-        let r1 = db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "msg1", false, None, 1000).unwrap();
-        let r2 = db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "msg2", false, None, 2000).unwrap();
-        let _r3 = db.insert_message("+1", "Alice", "2025-01-01T00:02:00Z", "msg3", false, None, 3000).unwrap();
+        let r1 = db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:00:00Z",
+                "msg1",
+                false,
+                None,
+                1000,
+            )
+            .unwrap();
+        let r2 = db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:01:00Z",
+                "msg2",
+                false,
+                None,
+                2000,
+            )
+            .unwrap();
+        let _r3 = db
+            .insert_message(
+                "+1",
+                "Alice",
+                "2025-01-01T00:02:00Z",
+                "msg3",
+                false,
+                None,
+                3000,
+            )
+            .unwrap();
 
         // Timestamp before all messages → None
         assert_eq!(db.max_rowid_up_to_timestamp("+1", 500).unwrap(), None);
@@ -1004,11 +1205,15 @@ mod tests {
         db.upsert_conversation("+1", "Alice", false).unwrap();
         for i in 0..5 {
             db.insert_message(
-                "+1", "Alice",
+                "+1",
+                "Alice",
                 &format!("2025-01-01T00:0{i}:00Z"),
                 &format!("msg{i}"),
-                false, None, i * 1000,
-            ).unwrap();
+                false,
+                None,
+                i * 1000,
+            )
+            .unwrap();
         }
 
         // Load first page (most recent 3)
@@ -1031,25 +1236,45 @@ mod tests {
     #[rstest]
     fn migration_v4_creates_reactions_table(db: Database) {
         // Should be able to query reactions table
-        let count: i64 = db.conn.query_row(
-            "SELECT COUNT(*) FROM reactions", [], |row| row.get(0),
-        ).unwrap();
+        let count: i64 = db
+            .conn
+            .query_row("SELECT COUNT(*) FROM reactions", [], |row| row.get(0))
+            .unwrap();
         assert_eq!(count, 0);
     }
 
     #[rstest]
     fn upsert_reaction_insert_and_replace(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello", false, None, 1000).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "hello",
+            false,
+            None,
+            1000,
+        )
+        .unwrap();
 
         // Insert a reaction
-        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍").unwrap();
+        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍")
+            .unwrap();
         let reactions = db.load_reactions("+1").unwrap();
         assert_eq!(reactions.len(), 1);
-        assert_eq!(reactions[0], (1000, "Alice".to_string(), "👍".to_string(), "Bob".to_string()));
+        assert_eq!(
+            reactions[0],
+            (
+                1000,
+                "Alice".to_string(),
+                "👍".to_string(),
+                "Bob".to_string()
+            )
+        );
 
         // Replace: same sender reacts with different emoji
-        db.upsert_reaction("+1", 1000, "Alice", "Bob", "❤️").unwrap();
+        db.upsert_reaction("+1", 1000, "Alice", "Bob", "❤️")
+            .unwrap();
         let reactions = db.load_reactions("+1").unwrap();
         assert_eq!(reactions.len(), 1);
         assert_eq!(reactions[0].2, "❤️");
@@ -1059,7 +1284,8 @@ mod tests {
     fn remove_reaction(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
 
-        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍").unwrap();
+        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍")
+            .unwrap();
         assert_eq!(db.load_reactions("+1").unwrap().len(), 1);
 
         db.remove_reaction("+1", 1000, "Alice", "Bob").unwrap();
@@ -1069,11 +1295,23 @@ mod tests {
     #[rstest]
     fn load_reactions_attaches_to_messages(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello", false, None, 1000).unwrap();
-        db.insert_message("+1", "you", "2025-01-01T00:01:00Z", "hi", false, None, 2000).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "hello",
+            false,
+            None,
+            1000,
+        )
+        .unwrap();
+        db.insert_message("+1", "you", "2025-01-01T00:01:00Z", "hi", false, None, 2000)
+            .unwrap();
 
-        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍").unwrap();
-        db.upsert_reaction("+1", 2000, "you", "Alice", "❤️").unwrap();
+        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍")
+            .unwrap();
+        db.upsert_reaction("+1", 2000, "you", "Alice", "❤️")
+            .unwrap();
 
         let convs = db.load_conversations(100).unwrap();
         assert_eq!(convs[0].messages[0].reactions.len(), 1);
@@ -1085,9 +1323,36 @@ mod tests {
     #[rstest]
     fn search_messages_in_conversation(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello world", false, None, 1000).unwrap();
-        db.insert_message("+1", "you", "2025-01-01T00:01:00Z", "hi there", false, None, 2000).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:02:00Z", "Hello again", false, None, 3000).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "hello world",
+            false,
+            None,
+            1000,
+        )
+        .unwrap();
+        db.insert_message(
+            "+1",
+            "you",
+            "2025-01-01T00:01:00Z",
+            "hi there",
+            false,
+            None,
+            2000,
+        )
+        .unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:02:00Z",
+            "Hello again",
+            false,
+            None,
+            3000,
+        )
+        .unwrap();
 
         // Case-insensitive search for "hello"
         let results = db.search_messages("+1", "hello", 50).unwrap();
@@ -1100,8 +1365,26 @@ mod tests {
     #[rstest]
     fn search_messages_excludes_system_and_deleted(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "", "2025-01-01T00:00:00Z", "system hello", true, None, 1000).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:01:00Z", "real hello", false, None, 2000).unwrap();
+        db.insert_message(
+            "+1",
+            "",
+            "2025-01-01T00:00:00Z",
+            "system hello",
+            true,
+            None,
+            1000,
+        )
+        .unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:01:00Z",
+            "real hello",
+            false,
+            None,
+            2000,
+        )
+        .unwrap();
 
         let results = db.search_messages("+1", "hello", 50).unwrap();
         assert_eq!(results.len(), 1);
@@ -1130,8 +1413,18 @@ mod tests {
     #[rstest]
     fn delete_conversation_removes_all_data(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello", false, None, 1000).unwrap();
-        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍").unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "hello",
+            false,
+            None,
+            1000,
+        )
+        .unwrap();
+        db.upsert_reaction("+1", 1000, "Alice", "Bob", "👍")
+            .unwrap();
         db.save_read_marker("+1", 1).unwrap();
 
         db.delete_conversation("+1").unwrap();
@@ -1152,8 +1445,26 @@ mod tests {
     fn search_all_messages_across_conversations(db: Database) {
         db.upsert_conversation("+1", "Alice", false).unwrap();
         db.upsert_conversation("+2", "Bob", false).unwrap();
-        db.insert_message("+1", "Alice", "2025-01-01T00:00:00Z", "hello from alice", false, None, 1000).unwrap();
-        db.insert_message("+2", "Bob", "2025-01-01T00:01:00Z", "hello from bob", false, None, 2000).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "hello from alice",
+            false,
+            None,
+            1000,
+        )
+        .unwrap();
+        db.insert_message(
+            "+2",
+            "Bob",
+            "2025-01-01T00:01:00Z",
+            "hello from bob",
+            false,
+            None,
+            2000,
+        )
+        .unwrap();
 
         let results = db.search_all_messages("hello", 50).unwrap();
         assert_eq!(results.len(), 2);

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -42,11 +42,7 @@ fn setup_file() {
             }
         }
     }
-    if let Ok(f) = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&path)
-    {
+    if let Ok(f) = OpenOptions::new().create(true).append(true).open(&path) {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;

--- a/src/domain/emoji_picker.rs
+++ b/src/domain/emoji_picker.rs
@@ -285,7 +285,10 @@ mod tests {
         state.refresh_filter();
 
         // Should find smiley emojis even though category is Flags
-        assert!(state.filtered.iter().any(|e| e.name.to_lowercase().contains("smile")));
+        assert!(state
+            .filtered
+            .iter()
+            .any(|e| e.name.to_lowercase().contains("smile")));
     }
 
     #[test]

--- a/src/domain/file_picker.rs
+++ b/src/domain/file_picker.rs
@@ -100,9 +100,10 @@ impl FilePickerState {
     pub fn handle_key(&mut self, code: KeyCode) -> Option<PathBuf> {
         match code {
             KeyCode::Char('j') | KeyCode::Down
-                if !self.filtered.is_empty() && self.index < self.filtered.len() - 1 => {
-                    self.index += 1;
-                }
+                if !self.filtered.is_empty() && self.index < self.filtered.len() - 1 =>
+            {
+                self.index += 1;
+            }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.index = self.index.saturating_sub(1);
             }

--- a/src/domain/search.rs
+++ b/src/domain/search.rs
@@ -53,11 +53,10 @@ impl SearchState {
     ) -> SearchAction {
         match code {
             KeyCode::Char('j') | KeyCode::Down
-                if !self.results.is_empty()
-                    && self.index < self.results.len() - 1
-                => {
-                    self.index += 1;
-                }
+                if !self.results.is_empty() && self.index < self.results.len() - 1 =>
+            {
+                self.index += 1;
+            }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.index = self.index.saturating_sub(1);
             }
@@ -78,11 +77,10 @@ impl SearchState {
                 self.visible = false;
                 self.query.clear();
             }
-            KeyCode::Backspace
-                if !self.query.is_empty() => {
-                    self.query.pop();
-                    self.run(active_conversation, db);
-                }
+            KeyCode::Backspace if !self.query.is_empty() => {
+                self.query.pop();
+                self.run(active_conversation, db);
+            }
             KeyCode::Char(c) => {
                 self.query.push(c);
                 self.run(active_conversation, db);
@@ -108,13 +106,15 @@ impl SearchState {
             Ok(rows) => {
                 self.results = rows
                     .into_iter()
-                    .map(|(sender, body, timestamp_ms, conv_id, conv_name)| SearchResult {
-                        sender,
-                        body,
-                        timestamp_ms,
-                        conv_id,
-                        conv_name,
-                    })
+                    .map(
+                        |(sender, body, timestamp_ms, conv_id, conv_name)| SearchResult {
+                            sender,
+                            body,
+                            timestamp_ms,
+                            conv_id,
+                            conv_name,
+                        },
+                    )
                     .collect();
             }
             Err(e) => {
@@ -132,7 +132,11 @@ impl SearchState {
 
     /// Jump to the next/previous search result in the active conversation.
     /// `forward` = true means next (older), false means previous (newer).
-    pub fn jump_to_result(&mut self, forward: bool, active_conversation: Option<&str>) -> SearchAction {
+    pub fn jump_to_result(
+        &mut self,
+        forward: bool,
+        active_conversation: Option<&str>,
+    ) -> SearchAction {
         let conv_id = match active_conversation {
             Some(id) => id,
             None => return SearchAction::None,
@@ -171,7 +175,11 @@ impl SearchState {
         self.index = next_idx;
         if let Some(result) = self.results.get(next_idx) {
             let ts = result.timestamp_ms;
-            let pos = conv_results.iter().position(|&i| i == next_idx).unwrap_or(0) + 1;
+            let pos = conv_results
+                .iter()
+                .position(|&i| i == next_idx)
+                .unwrap_or(0)
+                + 1;
             let status = format!(
                 "match {}/{} for \"{}\"",
                 pos,

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -42,7 +42,11 @@ pub fn detect_protocol() -> ImageProtocol {
 ///
 /// Returns `(base64_data, pixel_width, pixel_height)` sized to look good at the
 /// given cell dimensions. Assumes ~8px per cell width and ~16px per cell height.
-pub fn encode_native_png(path: &Path, cell_width: u32, cell_height: u32) -> Option<(String, u32, u32)> {
+pub fn encode_native_png(
+    path: &Path,
+    cell_width: u32,
+    cell_height: u32,
+) -> Option<(String, u32, u32)> {
     let img = image::open(path).ok()?;
     let (orig_w, orig_h) = img.dimensions();
     if orig_w == 0 || orig_h == 0 {
@@ -65,14 +69,15 @@ pub fn encode_native_png(path: &Path, cell_width: u32, cell_height: u32) -> Opti
     let resized = img.resize_exact(new_w, new_h, image::imageops::FilterType::Triangle);
 
     let mut buf = Cursor::new(Vec::new());
-    resized
-        .write_to(&mut buf, image::ImageFormat::Png)
-        .ok()?;
+    resized.write_to(&mut buf, image::ImageFormat::Png).ok()?;
 
     use base64::Engine;
-    Some((base64::engine::general_purpose::STANDARD.encode(buf.into_inner()), new_w, new_h))
+    Some((
+        base64::engine::general_purpose::STANDARD.encode(buf.into_inner()),
+        new_w,
+        new_h,
+    ))
 }
-
 
 /// Detect the pixel dimensions of a single terminal cell.
 ///
@@ -103,7 +108,9 @@ pub fn encode_sixel(
     cell_px: (u16, u16),
 ) -> Option<String> {
     use base64::Engine;
-    let bytes = base64::engine::general_purpose::STANDARD.decode(b64_png).ok()?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64_png)
+        .ok()?;
     let img = image::load_from_memory(&bytes).ok()?;
     let (w, h) = img.dimensions();
     if w == 0 || h == 0 {
@@ -267,7 +274,9 @@ pub fn crop_png_vertical(
     visible_height_cells: u16,
 ) -> Option<String> {
     use base64::Engine;
-    let bytes = base64::engine::general_purpose::STANDARD.decode(b64_full).ok()?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64_full)
+        .ok()?;
     let img = image::load_from_memory(&bytes).ok()?;
     let (w, _) = img.dimensions();
 
@@ -344,7 +353,7 @@ const DIACRITICS: [char; 256] = [
     '\u{2DFB}', '\u{2DFC}', '\u{2DFD}', '\u{2DFE}', '\u{2DFF}', // 240-244
     '\u{A66F}', '\u{A67C}', '\u{A67D}', '\u{A6F0}', '\u{A6F1}', // 245-249
     '\u{A8E0}', '\u{A8E1}', '\u{A8E2}', '\u{A8E3}', '\u{A8E4}', // 250-254
-    '\u{A8E5}',                                                    // 255
+    '\u{A8E5}', // 255
 ];
 
 /// Return the placeholder symbol for a specific (row, col) image cell.
@@ -426,10 +435,7 @@ pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
                 Color::Reset
             };
 
-            spans.push(Span::styled(
-                "▀",
-                Style::default().fg(fg).bg(bg),
-            ));
+            spans.push(Span::styled("▀", Style::default().fg(fg).bg(bg)));
         }
 
         lines.push(Line::from(spans));

--- a/src/input.rs
+++ b/src/input.rs
@@ -7,30 +7,150 @@ pub struct CommandInfo {
 }
 
 pub const COMMANDS: &[CommandInfo] = &[
-    CommandInfo { name: "/join",     alias: "/j",  args: "<name>",  description: "Switch to a conversation" },
-    CommandInfo { name: "/part",     alias: "/p",  args: "",        description: "Leave current conversation" },
-    CommandInfo { name: "/sidebar",  alias: "/sb", args: "",        description: "Toggle sidebar" },
-    CommandInfo { name: "/bell",     alias: "",    args: "[type]",  description: "Toggle notifications (direct/group)" },
-    CommandInfo { name: "/mute",     alias: "",    args: "",        description: "Mute/unmute current chat" },
-    CommandInfo { name: "/block",    alias: "",    args: "",        description: "Block current contact/group" },
-    CommandInfo { name: "/unblock",  alias: "",    args: "",        description: "Unblock current contact/group" },
-    CommandInfo { name: "/attach",   alias: "/a",  args: "",        description: "Attach a file" },
-    CommandInfo { name: "/paste",    alias: "/pa", args: "",        description: "Paste from clipboard (text, image, or file)" },
-    CommandInfo { name: "/search",   alias: "/s",  args: "<query>", description: "Search messages" },
-    CommandInfo { name: "/contacts", alias: "/c",  args: "",        description: "Browse contacts" },
-    CommandInfo { name: "/settings", alias: "",    args: "",        description: "Open settings" },
-    CommandInfo { name: "/disappearing", alias: "/dm", args: "<duration>", description: "Set disappearing timer (off/30s/5m/1h/1d/1w)" },
-    CommandInfo { name: "/group",    alias: "/g",  args: "",        description: "Group management" },
-    CommandInfo { name: "/theme",    alias: "/t",  args: "",        description: "Change color theme" },
-    CommandInfo { name: "/poll",     alias: "",    args: "\"question\" \"opt1\" \"opt2\" [--single]", description: "Create a poll" },
-    CommandInfo { name: "/verify",   alias: "/v",  args: "",        description: "Verify contact identity" },
-    CommandInfo { name: "/profile",  alias: "",    args: "",        description: "Edit your Signal profile" },
-    CommandInfo { name: "/about",    alias: "",    args: "",        description: "About siggy" },
-    CommandInfo { name: "/keybindings", alias: "/kb", args: "",    description: "Configure keybindings" },
-    CommandInfo { name: "/emoji",    alias: "/e",  args: "[search]", description: "Open emoji picker" },
-    CommandInfo { name: "/export",   alias: "",    args: "[n]",     description: "Export chat history to text file" },
-    CommandInfo { name: "/help",     alias: "/h",  args: "",        description: "Show help" },
-    CommandInfo { name: "/quit",     alias: "/q",  args: "",        description: "Exit siggy" },
+    CommandInfo {
+        name: "/join",
+        alias: "/j",
+        args: "<name>",
+        description: "Switch to a conversation",
+    },
+    CommandInfo {
+        name: "/part",
+        alias: "/p",
+        args: "",
+        description: "Leave current conversation",
+    },
+    CommandInfo {
+        name: "/sidebar",
+        alias: "/sb",
+        args: "",
+        description: "Toggle sidebar",
+    },
+    CommandInfo {
+        name: "/bell",
+        alias: "",
+        args: "[type]",
+        description: "Toggle notifications (direct/group)",
+    },
+    CommandInfo {
+        name: "/mute",
+        alias: "",
+        args: "",
+        description: "Mute/unmute current chat",
+    },
+    CommandInfo {
+        name: "/block",
+        alias: "",
+        args: "",
+        description: "Block current contact/group",
+    },
+    CommandInfo {
+        name: "/unblock",
+        alias: "",
+        args: "",
+        description: "Unblock current contact/group",
+    },
+    CommandInfo {
+        name: "/attach",
+        alias: "/a",
+        args: "",
+        description: "Attach a file",
+    },
+    CommandInfo {
+        name: "/paste",
+        alias: "/pa",
+        args: "",
+        description: "Paste from clipboard (text, image, or file)",
+    },
+    CommandInfo {
+        name: "/search",
+        alias: "/s",
+        args: "<query>",
+        description: "Search messages",
+    },
+    CommandInfo {
+        name: "/contacts",
+        alias: "/c",
+        args: "",
+        description: "Browse contacts",
+    },
+    CommandInfo {
+        name: "/settings",
+        alias: "",
+        args: "",
+        description: "Open settings",
+    },
+    CommandInfo {
+        name: "/disappearing",
+        alias: "/dm",
+        args: "<duration>",
+        description: "Set disappearing timer (off/30s/5m/1h/1d/1w)",
+    },
+    CommandInfo {
+        name: "/group",
+        alias: "/g",
+        args: "",
+        description: "Group management",
+    },
+    CommandInfo {
+        name: "/theme",
+        alias: "/t",
+        args: "",
+        description: "Change color theme",
+    },
+    CommandInfo {
+        name: "/poll",
+        alias: "",
+        args: "\"question\" \"opt1\" \"opt2\" [--single]",
+        description: "Create a poll",
+    },
+    CommandInfo {
+        name: "/verify",
+        alias: "/v",
+        args: "",
+        description: "Verify contact identity",
+    },
+    CommandInfo {
+        name: "/profile",
+        alias: "",
+        args: "",
+        description: "Edit your Signal profile",
+    },
+    CommandInfo {
+        name: "/about",
+        alias: "",
+        args: "",
+        description: "About siggy",
+    },
+    CommandInfo {
+        name: "/keybindings",
+        alias: "/kb",
+        args: "",
+        description: "Configure keybindings",
+    },
+    CommandInfo {
+        name: "/emoji",
+        alias: "/e",
+        args: "[search]",
+        description: "Open emoji picker",
+    },
+    CommandInfo {
+        name: "/export",
+        alias: "",
+        args: "[n]",
+        description: "Export chat history to text file",
+    },
+    CommandInfo {
+        name: "/help",
+        alias: "/h",
+        args: "",
+        description: "Show help",
+    },
+    CommandInfo {
+        name: "/quit",
+        alias: "/q",
+        args: "",
+        description: "Exit siggy",
+    },
 ];
 
 /// Parsed user input — either a command or plain text to send
@@ -73,7 +193,11 @@ pub enum InputAction {
     /// Open theme picker
     Theme,
     /// Create a poll
-    Poll { question: String, options: Vec<String>, allow_multiple: bool },
+    Poll {
+        question: String,
+        options: Vec<String>,
+        allow_multiple: bool,
+    },
     /// Show identity verification overlay
     Verify,
     /// Edit Signal profile
@@ -143,21 +267,25 @@ pub fn parse_input(input: &str) -> InputAction {
         "/settings" => InputAction::Settings,
         "/disappearing" | "/dm" => {
             if arg.is_empty() {
-                InputAction::Unknown("/disappearing requires a duration (e.g. off, 30s, 5m, 1h, 1d, 1w)".to_string())
+                InputAction::Unknown(
+                    "/disappearing requires a duration (e.g. off, 30s, 5m, 1h, 1d, 1w)".to_string(),
+                )
             } else {
                 InputAction::SetDisappearing(arg)
             }
         }
         "/group" | "/g" => InputAction::Group,
         "/theme" | "/t" => InputAction::Theme,
-        "/poll" => {
-            match parse_poll_args(&arg) {
-                Some((question, options, allow_multiple)) if options.len() >= 2 => {
-                    InputAction::Poll { question, options, allow_multiple }
-                }
-                _ => InputAction::Unknown("Usage: /poll \"question\" \"option1\" \"option2\" [--single]".into()),
-            }
-        }
+        "/poll" => match parse_poll_args(&arg) {
+            Some((question, options, allow_multiple)) if options.len() >= 2 => InputAction::Poll {
+                question,
+                options,
+                allow_multiple,
+            },
+            _ => InputAction::Unknown(
+                "Usage: /poll \"question\" \"option1\" \"option2\" [--single]".into(),
+            ),
+        },
         "/emoji" | "/e" => InputAction::Emoji(arg),
         "/verify" | "/v" => InputAction::Verify,
         "/profile" => InputAction::Profile,
@@ -169,7 +297,9 @@ pub fn parse_input(input: &str) -> InputAction {
             } else {
                 match arg.parse::<usize>() {
                     Ok(n) => InputAction::Export(Some(n)),
-                    Err(_) => InputAction::Unknown("/export takes an optional number (e.g. /export 100)".to_string()),
+                    Err(_) => InputAction::Unknown(
+                        "/export takes an optional number (e.g. /export 100)".to_string(),
+                    ),
                 }
             }
         }
@@ -177,7 +307,6 @@ pub fn parse_input(input: &str) -> InputAction {
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }
 }
-
 
 /// Parse `/poll` arguments: extract quoted strings and `--single` flag.
 /// Returns (question, options, allow_multiple) or None on parse failure.
@@ -378,7 +507,10 @@ mod tests {
         let InputAction::Unknown(s) = parse_input(input) else {
             panic!("expected Unknown for {input}");
         };
-        assert!(s.contains("requires"), "error for {input} should mention 'requires': {s}");
+        assert!(
+            s.contains("requires"),
+            "error for {input} should mention 'requires': {s}"
+        );
     }
 
     // --- SendText variants ---
@@ -399,7 +531,9 @@ mod tests {
 
     #[test]
     fn unknown_command() {
-        let InputAction::Unknown(s) = parse_input("/foo") else { panic!("expected Unknown") };
+        let InputAction::Unknown(s) = parse_input("/foo") else {
+            panic!("expected Unknown")
+        };
         assert!(s.contains("/foo"));
     }
 
@@ -427,7 +561,10 @@ mod tests {
     #[case("0s")]
     #[case("-1h")]
     fn duration_parser_invalid(#[case] input: &str) {
-        assert!(parse_duration_to_seconds(input).is_err(), "expected error for {input:?}");
+        assert!(
+            parse_duration_to_seconds(input).is_err(),
+            "expected error for {input:?}"
+        );
     }
 
     // --- Poll command ---
@@ -436,7 +573,11 @@ mod tests {
     fn poll_command_basic() {
         let result = parse_input(r#"/poll "What for lunch?" "Pizza" "Sushi""#);
         match result {
-            InputAction::Poll { question, options, allow_multiple } => {
+            InputAction::Poll {
+                question,
+                options,
+                allow_multiple,
+            } => {
                 assert_eq!(question, "What for lunch?");
                 assert_eq!(options, vec!["Pizza", "Sushi"]);
                 assert!(allow_multiple);
@@ -449,7 +590,11 @@ mod tests {
     fn poll_command_single_select() {
         let result = parse_input(r#"/poll "Q" "A" "B" --single"#);
         match result {
-            InputAction::Poll { allow_multiple, options, .. } => {
+            InputAction::Poll {
+                allow_multiple,
+                options,
+                ..
+            } => {
                 assert!(!allow_multiple);
                 assert_eq!(options, vec!["A", "B"]);
             }
@@ -485,7 +630,10 @@ mod tests {
 
     #[test]
     fn shortcode_unknown_left_as_is() {
-        assert_eq!(replace_shortcodes(":not_a_real_emoji_xyz:"), ":not_a_real_emoji_xyz:");
+        assert_eq!(
+            replace_shortcodes(":not_a_real_emoji_xyz:"),
+            ":not_a_real_emoji_xyz:"
+        );
     }
 
     #[test]

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -97,7 +97,12 @@ pub struct KeyBindings {
 impl KeyBindings {
     /// Look up the action for a key press in the given mode.
     /// Global bindings are checked first, then mode-specific.
-    pub fn resolve(&self, modifiers: KeyModifiers, code: KeyCode, mode: BindingMode) -> Option<KeyAction> {
+    pub fn resolve(
+        &self,
+        modifiers: KeyModifiers,
+        code: KeyCode,
+        mode: BindingMode,
+    ) -> Option<KeyAction> {
         // For Char keys, strip SHIFT from modifiers since the case is already
         // encoded in the character itself (crossterm sends 'J' with SHIFT).
         let modifiers = if matches!(code, KeyCode::Char(_)) {
@@ -175,12 +180,22 @@ impl KeyBindings {
         for (combo, &global_action) in &self.global {
             if let Some(&normal_action) = self.normal.get(combo) {
                 if global_action != normal_action {
-                    result.push((BindingMode::Normal, combo.clone(), global_action, normal_action));
+                    result.push((
+                        BindingMode::Normal,
+                        combo.clone(),
+                        global_action,
+                        normal_action,
+                    ));
                 }
             }
             if let Some(&insert_action) = self.insert.get(combo) {
                 if global_action != insert_action {
-                    result.push((BindingMode::Insert, combo.clone(), global_action, insert_action));
+                    result.push((
+                        BindingMode::Insert,
+                        combo.clone(),
+                        global_action,
+                        insert_action,
+                    ));
                 }
             }
         }
@@ -213,7 +228,12 @@ impl KeyBindings {
     /// Rebind a single action in a specific mode to a new key combo.
     /// Removes the old binding(s) for this action and inserts the new one.
     /// Returns any action that was previously bound to the new combo (conflict).
-    pub fn rebind(&mut self, mode: BindingMode, action: KeyAction, new_combo: KeyCombo) -> Option<KeyAction> {
+    pub fn rebind(
+        &mut self,
+        mode: BindingMode,
+        action: KeyAction,
+        new_combo: KeyCombo,
+    ) -> Option<KeyAction> {
         let map = match mode {
             BindingMode::Global => &mut self.global,
             BindingMode::Normal => &mut self.normal,
@@ -252,23 +272,32 @@ impl KeyBindings {
             default: &HashMap<KeyCombo, KeyAction>,
         ) -> Vec<(KeyAction, Vec<KeyCombo>)> {
             // Collect all actions that appear in either map
-            let mut all_actions: std::collections::HashSet<KeyAction> = std::collections::HashSet::new();
-            for action in current.values() { all_actions.insert(*action); }
-            for action in default.values() { all_actions.insert(*action); }
+            let mut all_actions: std::collections::HashSet<KeyAction> =
+                std::collections::HashSet::new();
+            for action in current.values() {
+                all_actions.insert(*action);
+            }
+            for action in default.values() {
+                all_actions.insert(*action);
+            }
 
             let mut result = Vec::new();
             for action in &all_actions {
-                let current_combos: Vec<&KeyCombo> = current.iter()
+                let current_combos: Vec<&KeyCombo> = current
+                    .iter()
                     .filter(|(_, a)| *a == action)
                     .map(|(c, _)| c)
                     .collect();
-                let default_combos: Vec<&KeyCombo> = default.iter()
+                let default_combos: Vec<&KeyCombo> = default
+                    .iter()
                     .filter(|(_, a)| *a == action)
                     .map(|(c, _)| c)
                     .collect();
                 // Check if the bindings differ
-                let mut cur_sorted: Vec<_> = current_combos.iter().map(|c| format_key_combo(c)).collect();
-                let mut def_sorted: Vec<_> = default_combos.iter().map(|c| format_key_combo(c)).collect();
+                let mut cur_sorted: Vec<_> =
+                    current_combos.iter().map(|c| format_key_combo(c)).collect();
+                let mut def_sorted: Vec<_> =
+                    default_combos.iter().map(|c| format_key_combo(c)).collect();
                 cur_sorted.sort();
                 def_sorted.sort();
                 if cur_sorted != def_sorted {
@@ -329,8 +358,8 @@ pub fn format_key_combo(combo: &KeyCombo) -> String {
         parts.push("Alt".to_string());
     }
     // Only show Shift for non-character keys or special chars
-    let show_shift = combo.modifiers.contains(KeyModifiers::SHIFT)
-        && !matches!(combo.code, KeyCode::Char(_));
+    let show_shift =
+        combo.modifiers.contains(KeyModifiers::SHIFT) && !matches!(combo.code, KeyCode::Char(_));
     if show_shift {
         parts.push("Shift".to_string());
     }
@@ -542,7 +571,12 @@ pub fn action_label(action: KeyAction) -> &'static str {
 // Built-in profiles
 // ---------------------------------------------------------------------------
 
-fn bind(map: &mut HashMap<KeyCombo, KeyAction>, modifiers: KeyModifiers, code: KeyCode, action: KeyAction) {
+fn bind(
+    map: &mut HashMap<KeyCombo, KeyAction>,
+    modifiers: KeyModifiers,
+    code: KeyCode,
+    action: KeyAction,
+) {
     map.insert(KeyCombo { modifiers, code }, action);
 }
 
@@ -553,61 +587,296 @@ pub fn default_profile() -> KeyBindings {
     let mut insert = HashMap::new();
 
     // --- Global ---
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('c'), KeyAction::Quit);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::Tab, KeyAction::NextConversation);
-    bind(&mut global, KeyModifiers::SHIFT, KeyCode::BackTab, KeyAction::PrevConversation);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Left, KeyAction::ResizeSidebarLeft);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Right, KeyAction::ResizeSidebarRight);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::PageUp, KeyAction::PageScrollUp);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::PageDown, KeyAction::PageScrollDown);
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('c'),
+        KeyAction::Quit,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        KeyAction::NextConversation,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::SHIFT,
+        KeyCode::BackTab,
+        KeyAction::PrevConversation,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Left,
+        KeyAction::ResizeSidebarLeft,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Right,
+        KeyAction::ResizeSidebarRight,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::PageUp,
+        KeyAction::PageScrollUp,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::PageDown,
+        KeyAction::PageScrollDown,
+    );
 
     // --- Normal: scroll ---
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('j'), KeyAction::FocusNextMessage);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('k'), KeyAction::FocusPrevMessage);
-    bind(&mut normal, KeyModifiers::CONTROL, KeyCode::Char('d'), KeyAction::HalfPageDown);
-    bind(&mut normal, KeyModifiers::CONTROL, KeyCode::Char('u'), KeyAction::HalfPageUp);
-    bind(&mut normal, KeyModifiers::CONTROL, KeyCode::Char('e'), KeyAction::ScrollDown);
-    bind(&mut normal, KeyModifiers::CONTROL, KeyCode::Char('y'), KeyAction::ScrollUp);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('G'), KeyAction::ScrollToBottom);
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('j'),
+        KeyAction::FocusNextMessage,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('k'),
+        KeyAction::FocusPrevMessage,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('d'),
+        KeyAction::HalfPageDown,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('u'),
+        KeyAction::HalfPageUp,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('e'),
+        KeyAction::ScrollDown,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('y'),
+        KeyAction::ScrollUp,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('G'),
+        KeyAction::ScrollToBottom,
+    );
 
     // --- Normal: edit/mode-switch ---
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('i'), KeyAction::InsertAtCursor);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('a'), KeyAction::InsertAfterCursor);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('I'), KeyAction::InsertLineStart);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('A'), KeyAction::InsertLineEnd);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('o'), KeyAction::OpenLineBelow);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('h'), KeyAction::CursorLeft);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('l'), KeyAction::CursorRight);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('0'), KeyAction::LineStart);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('$'), KeyAction::LineEnd);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('w'), KeyAction::WordForward);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('b'), KeyAction::WordBack);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('x'), KeyAction::DeleteChar);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('D'), KeyAction::DeleteToEnd);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('/'), KeyAction::StartSearch);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ClearInput);
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('i'),
+        KeyAction::InsertAtCursor,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('a'),
+        KeyAction::InsertAfterCursor,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('I'),
+        KeyAction::InsertLineStart,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('A'),
+        KeyAction::InsertLineEnd,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('o'),
+        KeyAction::OpenLineBelow,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('h'),
+        KeyAction::CursorLeft,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('l'),
+        KeyAction::CursorRight,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('0'),
+        KeyAction::LineStart,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('$'),
+        KeyAction::LineEnd,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('w'),
+        KeyAction::WordForward,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('b'),
+        KeyAction::WordBack,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('x'),
+        KeyAction::DeleteChar,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('D'),
+        KeyAction::DeleteToEnd,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('/'),
+        KeyAction::StartSearch,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Esc,
+        KeyAction::ClearInput,
+    );
 
     // --- Normal: actions ---
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('y'), KeyAction::CopyMessage);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('Y'), KeyAction::CopyAllMessages);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('r'), KeyAction::React);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('q'), KeyAction::Quote);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('e'), KeyAction::EditMessage);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('f'), KeyAction::ForwardMessage);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('n'), KeyAction::NextSearchResult);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('N'), KeyAction::PrevSearchResult);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Enter, KeyAction::OpenActionMenu);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('p'), KeyAction::PinMessage);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('Q'), KeyAction::JumpToQuote);
-    bind(&mut normal, KeyModifiers::CONTROL, KeyCode::Char('o'), KeyAction::JumpBack);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('s'), KeyAction::SidebarSearch);
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('y'),
+        KeyAction::CopyMessage,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('Y'),
+        KeyAction::CopyAllMessages,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('r'),
+        KeyAction::React,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('q'),
+        KeyAction::Quote,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('e'),
+        KeyAction::EditMessage,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('f'),
+        KeyAction::ForwardMessage,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('n'),
+        KeyAction::NextSearchResult,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('N'),
+        KeyAction::PrevSearchResult,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Enter,
+        KeyAction::OpenActionMenu,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('p'),
+        KeyAction::PinMessage,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('Q'),
+        KeyAction::JumpToQuote,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('o'),
+        KeyAction::JumpBack,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('s'),
+        KeyAction::SidebarSearch,
+    );
 
     // --- Insert ---
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ExitInsert);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::Enter, KeyAction::SendMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Enter, KeyAction::InsertNewline);
-    bind(&mut insert, KeyModifiers::SHIFT, KeyCode::Enter, KeyAction::InsertNewline);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('w'), KeyAction::DeleteWordBack);
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::Esc,
+        KeyAction::ExitInsert,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::Enter,
+        KeyAction::SendMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Enter,
+        KeyAction::InsertNewline,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::SHIFT,
+        KeyCode::Enter,
+        KeyAction::InsertNewline,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('w'),
+        KeyAction::DeleteWordBack,
+    );
 
     KeyBindings {
         profile_name: "Default".into(),
@@ -624,47 +893,217 @@ pub fn emacs_profile() -> KeyBindings {
     let mut insert = HashMap::new();
 
     // --- Global ---
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('c'), KeyAction::Quit);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::Tab, KeyAction::NextConversation);
-    bind(&mut global, KeyModifiers::SHIFT, KeyCode::BackTab, KeyAction::PrevConversation);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Left, KeyAction::ResizeSidebarLeft);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Right, KeyAction::ResizeSidebarRight);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::PageUp, KeyAction::PageScrollUp);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::PageDown, KeyAction::PageScrollDown);
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('c'),
+        KeyAction::Quit,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        KeyAction::NextConversation,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::SHIFT,
+        KeyCode::BackTab,
+        KeyAction::PrevConversation,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Left,
+        KeyAction::ResizeSidebarLeft,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Right,
+        KeyAction::ResizeSidebarRight,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::PageUp,
+        KeyAction::PageScrollUp,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::PageDown,
+        KeyAction::PageScrollDown,
+    );
 
     // --- Normal: essentially a stripped-down version ---
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('i'), KeyAction::InsertAtCursor);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ClearInput);
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('i'),
+        KeyAction::InsertAtCursor,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Esc,
+        KeyAction::ClearInput,
+    );
 
     // --- Insert (primary mode) ---
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ExitInsert);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::Enter, KeyAction::SendMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Enter, KeyAction::InsertNewline);
-    bind(&mut insert, KeyModifiers::SHIFT, KeyCode::Enter, KeyAction::InsertNewline);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('w'), KeyAction::DeleteWordBack);
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::Esc,
+        KeyAction::ExitInsert,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::Enter,
+        KeyAction::SendMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Enter,
+        KeyAction::InsertNewline,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::SHIFT,
+        KeyCode::Enter,
+        KeyAction::InsertNewline,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('w'),
+        KeyAction::DeleteWordBack,
+    );
     // Emacs scroll
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('p'), KeyAction::ScrollUp);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('n'), KeyAction::ScrollDown);
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('p'),
+        KeyAction::ScrollUp,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('n'),
+        KeyAction::ScrollDown,
+    );
     // Emacs cursor
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('a'), KeyAction::LineStart);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('e'), KeyAction::LineEnd);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('f'), KeyAction::CursorRight);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('b'), KeyAction::CursorLeft);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('d'), KeyAction::DeleteChar);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('k'), KeyAction::DeleteToEnd);
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('a'),
+        KeyAction::LineStart,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('e'),
+        KeyAction::LineEnd,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('f'),
+        KeyAction::CursorRight,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('b'),
+        KeyAction::CursorLeft,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('d'),
+        KeyAction::DeleteChar,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('k'),
+        KeyAction::DeleteToEnd,
+    );
     // Emacs actions via Alt
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('r'), KeyAction::React);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('q'), KeyAction::Quote);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('e'), KeyAction::EditMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('f'), KeyAction::ForwardMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('d'), KeyAction::DeleteMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('y'), KeyAction::CopyMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('n'), KeyAction::NextSearchResult);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('p'), KeyAction::PrevSearchResult);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('m'), KeyAction::OpenActionMenu);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Char('Q'), KeyAction::JumpToQuote);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('o'), KeyAction::JumpBack);
-    bind(&mut global, KeyModifiers::ALT, KeyCode::Char('s'), KeyAction::SidebarSearch);
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('r'),
+        KeyAction::React,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('q'),
+        KeyAction::Quote,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('e'),
+        KeyAction::EditMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('f'),
+        KeyAction::ForwardMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('d'),
+        KeyAction::DeleteMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('y'),
+        KeyAction::CopyMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('n'),
+        KeyAction::NextSearchResult,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('p'),
+        KeyAction::PrevSearchResult,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('m'),
+        KeyAction::OpenActionMenu,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Char('Q'),
+        KeyAction::JumpToQuote,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('o'),
+        KeyAction::JumpBack,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::ALT,
+        KeyCode::Char('s'),
+        KeyAction::SidebarSearch,
+    );
 
     KeyBindings {
         profile_name: "Emacs".into(),
@@ -681,38 +1120,173 @@ pub fn minimal_profile() -> KeyBindings {
     let mut insert = HashMap::new();
 
     // --- Global ---
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('q'), KeyAction::Quit);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('c'), KeyAction::Quit);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::Tab, KeyAction::NextConversation);
-    bind(&mut global, KeyModifiers::SHIFT, KeyCode::BackTab, KeyAction::PrevConversation);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Left, KeyAction::ResizeSidebarLeft);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Right, KeyAction::ResizeSidebarRight);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::PageUp, KeyAction::PageScrollUp);
-    bind(&mut global, KeyModifiers::NONE, KeyCode::PageDown, KeyAction::PageScrollDown);
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('q'),
+        KeyAction::Quit,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('c'),
+        KeyAction::Quit,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::Tab,
+        KeyAction::NextConversation,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::SHIFT,
+        KeyCode::BackTab,
+        KeyAction::PrevConversation,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Left,
+        KeyAction::ResizeSidebarLeft,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Right,
+        KeyAction::ResizeSidebarRight,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::PageUp,
+        KeyAction::PageScrollUp,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::NONE,
+        KeyCode::PageDown,
+        KeyAction::PageScrollDown,
+    );
 
     // --- Normal: arrow-key navigation ---
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Up, KeyAction::ScrollUp);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Down, KeyAction::ScrollDown);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Char('i'), KeyAction::InsertAtCursor);
-    bind(&mut normal, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ClearInput);
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Up,
+        KeyAction::ScrollUp,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Down,
+        KeyAction::ScrollDown,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Char('i'),
+        KeyAction::InsertAtCursor,
+    );
+    bind(
+        &mut normal,
+        KeyModifiers::NONE,
+        KeyCode::Esc,
+        KeyAction::ClearInput,
+    );
 
     // --- Insert ---
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::Esc, KeyAction::ExitInsert);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::Enter, KeyAction::SendMessage);
-    bind(&mut insert, KeyModifiers::ALT, KeyCode::Enter, KeyAction::InsertNewline);
-    bind(&mut insert, KeyModifiers::SHIFT, KeyCode::Enter, KeyAction::InsertNewline);
-    bind(&mut insert, KeyModifiers::CONTROL, KeyCode::Char('w'), KeyAction::DeleteWordBack);
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::Esc,
+        KeyAction::ExitInsert,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::Enter,
+        KeyAction::SendMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::ALT,
+        KeyCode::Enter,
+        KeyAction::InsertNewline,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::SHIFT,
+        KeyCode::Enter,
+        KeyAction::InsertNewline,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('w'),
+        KeyAction::DeleteWordBack,
+    );
     // F-key actions
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(2), KeyAction::React);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(3), KeyAction::Quote);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(4), KeyAction::EditMessage);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(5), KeyAction::CopyMessage);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(6), KeyAction::DeleteMessage);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(7), KeyAction::ForwardMessage);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(8), KeyAction::OpenActionMenu);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(9), KeyAction::JumpToQuote);
-    bind(&mut insert, KeyModifiers::NONE, KeyCode::F(10), KeyAction::JumpBack);
-    bind(&mut global, KeyModifiers::CONTROL, KeyCode::Char('s'), KeyAction::SidebarSearch);
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(2),
+        KeyAction::React,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(3),
+        KeyAction::Quote,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(4),
+        KeyAction::EditMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(5),
+        KeyAction::CopyMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(6),
+        KeyAction::DeleteMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(7),
+        KeyAction::ForwardMessage,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(8),
+        KeyAction::OpenActionMenu,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(9),
+        KeyAction::JumpToQuote,
+    );
+    bind(
+        &mut insert,
+        KeyModifiers::NONE,
+        KeyCode::F(10),
+        KeyAction::JumpBack,
+    );
+    bind(
+        &mut global,
+        KeyModifiers::CONTROL,
+        KeyCode::Char('s'),
+        KeyAction::SidebarSearch,
+    );
 
     KeyBindings {
         profile_name: "Minimal".into(),
@@ -819,7 +1393,8 @@ enum TomlKeyValue {
 
 /// Parse a custom profile from TOML.
 fn parse_profile_toml(contents: &str) -> Result<KeyBindings, String> {
-    let toml: ProfileToml = toml::from_str(contents).map_err(|e| format!("TOML parse error: {e}"))?;
+    let toml: ProfileToml =
+        toml::from_str(contents).map_err(|e| format!("TOML parse error: {e}"))?;
 
     let mut global = HashMap::new();
     let mut normal = HashMap::new();
@@ -897,9 +1472,14 @@ pub fn save_overrides(overrides: &KeyBindingOverrides) {
                 .trim_matches('"')
                 .to_string();
             if combos.len() == 1 {
-                lines.push(format!("{} = \"{}\"", action_str, format_key_combo(&combos[0]).to_lowercase()));
+                lines.push(format!(
+                    "{} = \"{}\"",
+                    action_str,
+                    format_key_combo(&combos[0]).to_lowercase()
+                ));
             } else {
-                let keys: Vec<String> = combos.iter()
+                let keys: Vec<String> = combos
+                    .iter()
                     .map(|c| format!("\"{}\"", format_key_combo(c).to_lowercase()))
                     .collect();
                 lines.push(format!("{} = [{}]", action_str, keys.join(", ")));
@@ -914,13 +1494,17 @@ pub fn save_overrides(overrides: &KeyBindingOverrides) {
         content.push('\n');
     }
     if !overrides.normal.is_empty() {
-        if !content.is_empty() { content.push('\n'); }
+        if !content.is_empty() {
+            content.push('\n');
+        }
         content.push_str("[normal]\n");
         content.push_str(&section_to_toml(&overrides.normal));
         content.push('\n');
     }
     if !overrides.insert.is_empty() {
-        if !content.is_empty() { content.push('\n'); }
+        if !content.is_empty() {
+            content.push('\n');
+        }
         content.push_str("[insert]\n");
         content.push_str(&section_to_toml(&overrides.insert));
         content.push('\n');
@@ -945,7 +1529,8 @@ struct OverridesToml {
 }
 
 fn parse_overrides_toml(contents: &str) -> Result<KeyBindingOverrides, String> {
-    let toml: OverridesToml = toml::from_str(contents).map_err(|e| format!("TOML parse error: {e}"))?;
+    let toml: OverridesToml =
+        toml::from_str(contents).map_err(|e| format!("TOML parse error: {e}"))?;
 
     let parse_section = |section: &HashMap<String, TomlKeyValue>| -> Result<Vec<(KeyAction, Vec<KeyCombo>)>, String> {
         let mut result = Vec::new();
@@ -980,7 +1565,11 @@ mod tests {
     fn default_profile_resolves_ctrl_c_as_quit() {
         let kb = default_profile();
         assert_eq!(
-            kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('c'), BindingMode::Normal),
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('c'),
+                BindingMode::Normal
+            ),
             Some(KeyAction::Quit)
         );
     }
@@ -1075,7 +1664,10 @@ mod tests {
             ("Shift+Tab", KeyModifiers::SHIFT, KeyCode::BackTab),
         ];
         for (expected, mods, code) in cases {
-            let combo = KeyCombo { modifiers: mods, code };
+            let combo = KeyCombo {
+                modifiers: mods,
+                code,
+            };
             assert_eq!(format_key_combo(&combo), expected);
         }
     }
@@ -1101,10 +1693,18 @@ mod tests {
     fn rebind_works() {
         let mut kb = default_profile();
         let new_combo = parse_key_combo("ctrl+j").unwrap();
-        let displaced = kb.rebind(BindingMode::Normal, KeyAction::ScrollDown, new_combo.clone());
+        let displaced = kb.rebind(
+            BindingMode::Normal,
+            KeyAction::ScrollDown,
+            new_combo.clone(),
+        );
         assert!(displaced.is_none());
         assert_eq!(
-            kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('j'), BindingMode::Normal),
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('j'),
+                BindingMode::Normal
+            ),
             Some(KeyAction::ScrollDown)
         );
         // Old ScrollDown binding (ctrl+e) should be gone, but j is now FocusNextMessage
@@ -1130,11 +1730,22 @@ mod tests {
         let new_combo = parse_key_combo("ctrl+j").unwrap();
         kb.rebind(BindingMode::Normal, KeyAction::ScrollDown, new_combo);
         // Now ctrl+e shouldn't resolve to ScrollDown
-        assert_eq!(kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('e'), BindingMode::Normal), None);
+        assert_eq!(
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('e'),
+                BindingMode::Normal
+            ),
+            None
+        );
         // Reset
         kb.reset_action(BindingMode::Normal, KeyAction::ScrollDown);
         assert_eq!(
-            kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('e'), BindingMode::Normal),
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('e'),
+                BindingMode::Normal
+            ),
             Some(KeyAction::ScrollDown)
         );
     }
@@ -1150,12 +1761,20 @@ mod tests {
         kb.apply_overrides(&overrides);
         // Old Ctrl+C should be gone
         assert_eq!(
-            kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('c'), BindingMode::Normal),
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('c'),
+                BindingMode::Normal
+            ),
             None
         );
         // New Ctrl+Q should work
         assert_eq!(
-            kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('q'), BindingMode::Normal),
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('q'),
+                BindingMode::Normal
+            ),
             Some(KeyAction::Quit)
         );
     }
@@ -1180,7 +1799,11 @@ mod tests {
     fn emacs_profile_has_ctrl_n_scroll() {
         let kb = emacs_profile();
         assert_eq!(
-            kb.resolve(KeyModifiers::CONTROL, KeyCode::Char('n'), BindingMode::Insert),
+            kb.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('n'),
+                BindingMode::Insert
+            ),
             Some(KeyAction::ScrollDown)
         );
     }
@@ -1221,7 +1844,11 @@ send_message = "enter"
         let profile = parse_profile_toml(toml).unwrap();
         assert_eq!(profile.profile_name, "Test");
         assert_eq!(
-            profile.resolve(KeyModifiers::CONTROL, KeyCode::Char('q'), BindingMode::Normal),
+            profile.resolve(
+                KeyModifiers::CONTROL,
+                KeyCode::Char('q'),
+                BindingMode::Normal
+            ),
             Some(KeyAction::Quit)
         );
         assert_eq!(

--- a/src/link.rs
+++ b/src/link.rs
@@ -90,7 +90,10 @@ pub async fn run_linking_flow(
             }
         })?;
 
-    let stdout = child.stdout.take().context("No stdout from signal-cli link")?;
+    let stdout = child
+        .stdout
+        .take()
+        .context("No stdout from signal-cli link")?;
     let mut reader = tokio::io::BufReader::new(stdout).lines();
 
     // Read lines until we find the linking URI
@@ -160,7 +163,11 @@ fn render_qr_lines(qr: &qrcode::QrCode) -> Vec<Line<'static>> {
     while y < total_h {
         let mut spans = Vec::new();
         for (x, &top) in grid[y].iter().enumerate() {
-            let bottom = if y + 1 < total_h { grid[y + 1][x] } else { false };
+            let bottom = if y + 1 < total_h {
+                grid[y + 1][x]
+            } else {
+                false
+            };
 
             let (ch, fg, bg) = match (top, bottom) {
                 (true, true) => ('\u{2588}', Color::Black, Color::Reset),
@@ -168,10 +175,7 @@ fn render_qr_lines(qr: &qrcode::QrCode) -> Vec<Line<'static>> {
                 (false, true) => ('\u{2584}', Color::Black, Color::White),
                 (false, false) => (' ', Color::White, Color::White),
             };
-            spans.push(Span::styled(
-                ch.to_string(),
-                Style::default().fg(fg).bg(bg),
-            ));
+            spans.push(Span::styled(ch.to_string(), Style::default().fg(fg).bg(bg)));
         }
         lines.push(Line::from(spans));
         y += 2;
@@ -239,9 +243,10 @@ fn draw_qr_screen(frame: &mut ratatui::Frame, qr_lines: &[Line<'static>]) {
 
     // Check if terminal is too small
     if area.width < qr_width + 4 || area.height < qr_height + 8 {
-        let msg = Paragraph::new("Terminal too small to display QR code.\nPlease resize your terminal.")
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::Red));
+        let msg =
+            Paragraph::new("Terminal too small to display QR code.\nPlease resize your terminal.")
+                .alignment(Alignment::Center)
+                .style(Style::default().fg(Color::Red));
         let msg_area = centered_rect(60, 4, area);
         frame.render_widget(msg, msg_area);
         return;
@@ -249,13 +254,13 @@ fn draw_qr_screen(frame: &mut ratatui::Frame, qr_lines: &[Line<'static>]) {
 
     // Vertical layout: title, qr, instructions
     let [_, title_area, _, qr_area, _, instr_area, _] = Layout::vertical([
-        Constraint::Min(1),        // top padding
-        Constraint::Length(3),     // title
-        Constraint::Length(1),     // gap
+        Constraint::Min(1),                // top padding
+        Constraint::Length(3),             // title
+        Constraint::Length(1),             // gap
         Constraint::Length(qr_height + 2), // qr + border
-        Constraint::Length(1),     // gap
-        Constraint::Length(5),     // instructions
-        Constraint::Min(1),        // bottom padding
+        Constraint::Length(1),             // gap
+        Constraint::Length(5),             // instructions
+        Constraint::Min(1),                // bottom padding
     ])
     .flex(Flex::Center)
     .areas(area);
@@ -299,7 +304,11 @@ fn draw_qr_screen(frame: &mut ratatui::Frame, qr_lines: &[Line<'static>]) {
 }
 
 /// Helper to create a centered rect of given percentage width and fixed height.
-fn centered_rect(percent_x: u16, height: u16, area: ratatui::layout::Rect) -> ratatui::layout::Rect {
+fn centered_rect(
+    percent_x: u16,
+    height: u16,
+    area: ratatui::layout::Rect,
+) -> ratatui::layout::Rect {
     let [centered] = Layout::vertical([Constraint::Length(height)])
         .flex(Flex::Center)
         .areas(area);

--- a/src/list_overlay.rs
+++ b/src/list_overlay.rs
@@ -107,10 +107,7 @@ mod tests {
 
     #[test]
     fn arrow_keys_navigate() {
-        assert_eq!(
-            classify_list_key(KeyCode::Down, false),
-            ListKeyAction::Down
-        );
+        assert_eq!(classify_list_key(KeyCode::Down, false), ListKeyAction::Down);
         assert_eq!(classify_list_key(KeyCode::Up, false), ListKeyAction::Up);
     }
 
@@ -124,10 +121,7 @@ mod tests {
 
     #[test]
     fn esc_closes() {
-        assert_eq!(
-            classify_list_key(KeyCode::Esc, false),
-            ListKeyAction::Close
-        );
+        assert_eq!(classify_list_key(KeyCode::Esc, false), ListKeyAction::Close);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
 mod app;
-mod config;
 mod autocomplete;
+mod config;
 mod conversation_store;
 mod db;
 mod debug_log;
+mod domain;
 mod image_render;
 mod input;
 mod keybindings;
-mod list_overlay;
 mod link;
+mod list_overlay;
 mod settings_profile;
 mod setup;
 mod signal;
-mod domain;
 mod theme;
 mod ui;
 
@@ -23,10 +23,16 @@ use std::time::{Duration, Instant};
 use anyhow::Result;
 use crossterm::{
     cursor::{Hide, MoveTo, RestorePosition, SavePosition, Show},
-    event::{self, EnableBracketedPaste, DisableBracketedPaste, EnableMouseCapture, DisableMouseCapture, Event, KeyEventKind},
+    event::{
+        self, DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture,
+        Event, KeyEventKind,
+    },
     execute, queue,
     style::{Print, ResetColor, SetForegroundColor},
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen, BeginSynchronizedUpdate, EndSynchronizedUpdate},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, EndSynchronizedUpdate,
+        EnterAlternateScreen, LeaveAlternateScreen,
+    },
 };
 use ratatui::{
     backend::CrosstermBackend,
@@ -137,7 +143,9 @@ async fn main() -> Result<()> {
                 eprintln!("  -a, --account <NUMBER>  Phone number (E.164 format)");
                 eprintln!("  -c, --config <PATH>     Config file path");
                 eprintln!("      --setup             Run first-time setup wizard");
-                eprintln!("      --demo              Launch with dummy data (no signal-cli needed)");
+                eprintln!(
+                    "      --demo              Launch with dummy data (no signal-cli needed)"
+                );
                 eprintln!("      --incognito         No local message storage (in-memory only)");
                 eprintln!("      --debug             Write debug log (PII redacted)");
                 eprintln!("      --debug-full        Write debug log (full, unredacted)");
@@ -169,7 +177,12 @@ async fn main() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     if config.mouse_enabled {
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste)?;
+        execute!(
+            stdout,
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
     } else {
         execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
     }
@@ -177,11 +190,23 @@ async fn main() -> Result<()> {
     let mut terminal = Terminal::new(backend)?;
 
     // Run the main flow inside a closure so we can always restore the terminal
-    let result = run_main_flow(&mut terminal, &mut config, force_setup, demo_mode, incognito).await;
+    let result = run_main_flow(
+        &mut terminal,
+        &mut config,
+        force_setup,
+        demo_mode,
+        incognito,
+    )
+    .await;
 
     // Restore terminal
     disable_raw_mode()?;
-    execute!(terminal.backend_mut(), LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste)?;
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture,
+        DisableBracketedPaste
+    )?;
     terminal.show_cursor()?;
 
     if let Err(e) = result {
@@ -201,8 +226,18 @@ async fn run_main_flow(
 ) -> Result<()> {
     if demo_mode {
         let database = db::Database::open_in_memory()?;
-        let demo_config = Config { account: "+15551234567".to_string(), ..Config::default() };
-        return run_app(terminal, MessagingBackend::Demo, &demo_config, database, false).await;
+        let demo_config = Config {
+            account: "+15551234567".to_string(),
+            ..Config::default()
+        };
+        return run_app(
+            terminal,
+            MessagingBackend::Demo,
+            &demo_config,
+            database,
+            false,
+        )
+        .await;
     }
 
     // Run setup wizard if needed
@@ -319,7 +354,14 @@ async fn run_main_flow(
     }
 
     // Run the app
-    let result = run_app(terminal, MessagingBackend::Signal(&mut signal_client), config, database, incognito).await;
+    let result = run_app(
+        terminal,
+        MessagingBackend::Signal(&mut signal_client),
+        config,
+        database,
+        incognito,
+    )
+    .await;
 
     // Shut down signal-cli
     signal_client.shutdown().await?;
@@ -458,10 +500,7 @@ fn emit_osc8_links(
         let safe_url: String = link.url.chars().filter(|c| !c.is_control()).collect();
         queue!(
             backend,
-            Print(format!(
-                "\x1b]8;;{}\x07{}\x1b]8;;\x07",
-                safe_url, link.text
-            ))
+            Print(format!("\x1b]8;;{}\x07{}\x1b]8;;\x07", safe_url, link.text))
         )?;
         queue!(backend, ResetColor)?;
     }
@@ -495,10 +534,7 @@ fn get_or_cache_png(
 ///
 /// For iTerm2: overlay pre-resized images on top of the halfblock placeholders
 /// using cursor-positioned inline image sequences.
-fn emit_native_images(
-    backend: &mut CrosstermBackend<io::Stdout>,
-    app: &mut App,
-) -> Result<()> {
+fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App) -> Result<()> {
     let protocol = app.image.image_protocol;
     if protocol == image_render::ImageProtocol::Halfblock {
         return Ok(());
@@ -515,7 +551,12 @@ fn emit_native_images(
         }
 
         for (id, path, cols, rows) in &pending {
-            let b64 = match get_or_cache_png(&mut app.image.native_image_cache, path, *cols as u32, *rows as u32) {
+            let b64 = match get_or_cache_png(
+                &mut app.image.native_image_cache,
+                path,
+                *cols as u32,
+                *rows as u32,
+            ) {
                 Some(b) => b,
                 None => continue,
             };
@@ -536,10 +577,7 @@ fn emit_native_images(
             }
 
             // Create virtual placement (U=1 enables Unicode Placeholder mode)
-            write!(
-                backend,
-                "\x1b_Ga=p,U=1,i={id},c={cols},r={rows},q=2\x1b\\",
-            )?;
+            write!(backend, "\x1b_Ga=p,U=1,i={id},c={cols},r={rows},q=2\x1b\\",)?;
 
             app.image.kitty_transmitted.insert(*id);
         }
@@ -601,7 +639,12 @@ fn emit_native_images(
     queue!(backend, SavePosition)?;
 
     for img in &images {
-        let b64 = match get_or_cache_png(&mut app.image.native_image_cache, &img.path, img.width as u32, img.full_height as u32) {
+        let b64 = match get_or_cache_png(
+            &mut app.image.native_image_cache,
+            &img.path,
+            img.width as u32,
+            img.full_height as u32,
+        ) {
             Some(b) => b,
             None => continue,
         };
@@ -613,10 +656,23 @@ fn emit_native_images(
             if let Some(cached) = app.image.iterm2_crop_cache.get(&crop_key) {
                 cached.clone()
             } else {
-                let px_h = app.image.native_image_cache.get(&img.path).map(|c| c.2).unwrap_or(0);
-                let cropped = image_render::crop_png_vertical(&b64, px_h, img.full_height, img.crop_top, img.height)
-                    .unwrap_or(b64);
-                app.image.iterm2_crop_cache.insert(crop_key, cropped.clone());
+                let px_h = app
+                    .image
+                    .native_image_cache
+                    .get(&img.path)
+                    .map(|c| c.2)
+                    .unwrap_or(0);
+                let cropped = image_render::crop_png_vertical(
+                    &b64,
+                    px_h,
+                    img.full_height,
+                    img.crop_top,
+                    img.height,
+                )
+                .unwrap_or(b64);
+                app.image
+                    .iterm2_crop_cache
+                    .insert(crop_key, cropped.clone());
                 cropped
             }
         } else {
@@ -640,22 +696,41 @@ fn emit_native_images(
 }
 
 /// Dispatch a SendRequest to signal-cli.
-async fn dispatch_send(
-    signal_client: &mut SignalClient,
-    app: &mut App,
-    req: SendRequest,
-) {
+async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: SendRequest) {
     match req {
-        SendRequest::Message { recipient, body, is_group, local_ts_ms, mentions, attachment, quote_timestamp, quote_author, quote_body } => {
+        SendRequest::Message {
+            recipient,
+            body,
+            is_group,
+            local_ts_ms,
+            mentions,
+            attachment,
+            quote_timestamp,
+            quote_author,
+            quote_body,
+        } => {
             let attachments: Vec<std::path::PathBuf> = attachment.into_iter().collect();
             let quote = match (quote_author, quote_timestamp, quote_body) {
                 (Some(author), Some(ts), Some(body_text)) => Some((author, ts, body_text)),
                 _ => None,
             };
             let att_refs: Vec<&std::path::Path> = attachments.iter().map(|p| p.as_path()).collect();
-            match signal_client.send_message(&recipient, &body, is_group, &mentions, &att_refs, quote.as_ref().map(|(a, t, b)| (a.as_str(), *t, b.as_str()))).await {
+            match signal_client
+                .send_message(
+                    &recipient,
+                    &body,
+                    is_group,
+                    &mentions,
+                    &att_refs,
+                    quote.as_ref().map(|(a, t, b)| (a.as_str(), *t, b.as_str())),
+                )
+                .await
+            {
                 Ok(rpc_id) => {
-                    debug_log::logf(format_args!("send: to={} ts={local_ts_ms}", debug_log::mask_phone(&recipient)));
+                    debug_log::logf(format_args!(
+                        "send: to={} ts={local_ts_ms}",
+                        debug_log::mask_phone(&recipient)
+                    ));
                     app.pending_sends
                         .insert(rpc_id.clone(), (recipient.to_string(), local_ts_ms));
                     // Register any paste temp file for deferred deletion. The actual delete is
@@ -683,48 +758,109 @@ async fn dispatch_send(
             }
         }
         SendRequest::Reaction {
-            conv_id, emoji, is_group, target_author, target_timestamp, remove,
+            conv_id,
+            emoji,
+            is_group,
+            target_author,
+            target_timestamp,
+            remove,
         } => {
             if let Err(e) = signal_client
-                .send_reaction(&conv_id, is_group, &emoji, &target_author, target_timestamp, remove)
+                .send_reaction(
+                    &conv_id,
+                    is_group,
+                    &emoji,
+                    &target_author,
+                    target_timestamp,
+                    remove,
+                )
                 .await
             {
                 app.status_message = format!("reaction error: {e}");
             }
         }
-        SendRequest::Edit { recipient, body, is_group, edit_timestamp, local_ts_ms, mentions, quote_timestamp, quote_author, quote_body } => {
+        SendRequest::Edit {
+            recipient,
+            body,
+            is_group,
+            edit_timestamp,
+            local_ts_ms,
+            mentions,
+            quote_timestamp,
+            quote_author,
+            quote_body,
+        } => {
             let quote = match (quote_author, quote_timestamp, quote_body) {
                 (Some(author), Some(ts), Some(body_text)) => Some((author, ts, body_text)),
                 _ => None,
             };
-            match signal_client.send_edit_message(&recipient, &body, is_group, edit_timestamp, &mentions, quote.as_ref().map(|(a, t, b)| (a.as_str(), *t, b.as_str()))).await {
+            match signal_client
+                .send_edit_message(
+                    &recipient,
+                    &body,
+                    is_group,
+                    edit_timestamp,
+                    &mentions,
+                    quote.as_ref().map(|(a, t, b)| (a.as_str(), *t, b.as_str())),
+                )
+                .await
+            {
                 Ok(rpc_id) => {
-                    debug_log::logf(format_args!("edit: to={} ts={edit_timestamp}", debug_log::mask_phone(&recipient)));
-                    app.pending_sends.insert(rpc_id, (recipient.to_string(), local_ts_ms));
+                    debug_log::logf(format_args!(
+                        "edit: to={} ts={edit_timestamp}",
+                        debug_log::mask_phone(&recipient)
+                    ));
+                    app.pending_sends
+                        .insert(rpc_id, (recipient.to_string(), local_ts_ms));
                 }
                 Err(e) => {
                     app.status_message = format!("edit error: {e}");
                 }
             }
         }
-        SendRequest::RemoteDelete { recipient, is_group, target_timestamp } => {
-            if let Err(e) = signal_client.send_remote_delete(&recipient, is_group, target_timestamp).await {
+        SendRequest::RemoteDelete {
+            recipient,
+            is_group,
+            target_timestamp,
+        } => {
+            if let Err(e) = signal_client
+                .send_remote_delete(&recipient, is_group, target_timestamp)
+                .await
+            {
                 app.status_message = format!("delete error: {e}");
             }
         }
-        SendRequest::Typing { recipient, is_group, stop } => {
+        SendRequest::Typing {
+            recipient,
+            is_group,
+            stop,
+        } => {
             let _ = signal_client.send_typing(&recipient, is_group, stop).await;
         }
-        SendRequest::ReadReceipt { recipient, timestamps } => {
-            if let Err(e) = signal_client.send_read_receipt(&recipient, &timestamps).await {
+        SendRequest::ReadReceipt {
+            recipient,
+            timestamps,
+        } => {
+            if let Err(e) = signal_client
+                .send_read_receipt(&recipient, &timestamps)
+                .await
+            {
                 debug_log::logf(format_args!("read receipt error: {e}"));
             }
         }
-        SendRequest::UpdateExpiration { conv_id, is_group, seconds } => {
+        SendRequest::UpdateExpiration {
+            conv_id,
+            is_group,
+            seconds,
+        } => {
             let result = if is_group {
-                signal_client.send_update_group_expiration(&conv_id, seconds).await
+                signal_client
+                    .send_update_group_expiration(&conv_id, seconds)
+                    .await
             } else {
-                signal_client.send_update_contact_expiration(&conv_id, seconds).await
+                signal_client
+                    .send_update_contact_expiration(&conv_id, seconds)
+                    .await
             };
             if let Err(e) = result {
                 app.status_message = format!("expiration error: {e}");
@@ -749,19 +885,36 @@ async fn dispatch_send(
             if let Err(e) = signal_client.add_group_members(&group_id, &members).await {
                 app.status_message = format!("add member error: {e}");
             } else {
-                let names: Vec<String> = members.iter()
-                    .map(|m| app.store.contact_names.get(m).cloned().unwrap_or_else(|| m.clone()))
+                let names: Vec<String> = members
+                    .iter()
+                    .map(|m| {
+                        app.store
+                            .contact_names
+                            .get(m)
+                            .cloned()
+                            .unwrap_or_else(|| m.clone())
+                    })
                     .collect();
                 app.status_message = format!("Added {}", names.join(", "));
                 let _ = signal_client.list_groups().await;
             }
         }
         SendRequest::RemoveGroupMembers { group_id, members } => {
-            if let Err(e) = signal_client.remove_group_members(&group_id, &members).await {
+            if let Err(e) = signal_client
+                .remove_group_members(&group_id, &members)
+                .await
+            {
                 app.status_message = format!("remove member error: {e}");
             } else {
-                let names: Vec<String> = members.iter()
-                    .map(|m| app.store.contact_names.get(m).cloned().unwrap_or_else(|| m.clone()))
+                let names: Vec<String> = members
+                    .iter()
+                    .map(|m| {
+                        app.store
+                            .contact_names
+                            .get(m)
+                            .cloned()
+                            .unwrap_or_else(|| m.clone())
+                    })
                     .collect();
                 app.status_message = format!("Removed {}", names.join(", "));
                 let _ = signal_client.list_groups().await;
@@ -775,7 +928,9 @@ async fn dispatch_send(
                 if let Some(conv) = app.store.conversations.get_mut(&group_id) {
                     conv.name = name.clone();
                 }
-                app.store.contact_names.insert(group_id.clone(), name.clone());
+                app.store
+                    .contact_names
+                    .insert(group_id.clone(), name.clone());
                 app.status_message = format!("Renamed group to \"{}\"", name);
                 let _ = signal_client.list_groups().await;
             }
@@ -784,7 +939,10 @@ async fn dispatch_send(
             if let Err(e) = signal_client.quit_group(&group_id).await {
                 app.status_message = format!("leave group error: {e}");
             } else {
-                let name = app.store.conversations.get(&group_id)
+                let name = app
+                    .store
+                    .conversations
+                    .get(&group_id)
                     .map(|c| c.name.clone())
                     .unwrap_or_else(|| group_id.clone());
                 app.store.conversations.remove(&group_id);
@@ -796,28 +954,67 @@ async fn dispatch_send(
                 app.status_message = format!("Left group \"{}\"", name);
             }
         }
-        SendRequest::Block { recipient, is_group } => {
+        SendRequest::Block {
+            recipient,
+            is_group,
+        } => {
             if let Err(e) = signal_client.block_contact(&recipient, is_group).await {
                 app.status_message = format!("block error: {e}");
             }
         }
-        SendRequest::Unblock { recipient, is_group } => {
+        SendRequest::Unblock {
+            recipient,
+            is_group,
+        } => {
             if let Err(e) = signal_client.unblock_contact(&recipient, is_group).await {
                 app.status_message = format!("unblock error: {e}");
             }
         }
-        SendRequest::Pin { recipient, is_group, target_author, target_timestamp, pin_duration } => {
-            if let Err(e) = signal_client.send_pin_message(&recipient, is_group, &target_author, target_timestamp, pin_duration).await {
+        SendRequest::Pin {
+            recipient,
+            is_group,
+            target_author,
+            target_timestamp,
+            pin_duration,
+        } => {
+            if let Err(e) = signal_client
+                .send_pin_message(
+                    &recipient,
+                    is_group,
+                    &target_author,
+                    target_timestamp,
+                    pin_duration,
+                )
+                .await
+            {
                 app.status_message = format!("pin error: {e}");
             }
         }
-        SendRequest::Unpin { recipient, is_group, target_author, target_timestamp } => {
-            if let Err(e) = signal_client.send_unpin_message(&recipient, is_group, &target_author, target_timestamp).await {
+        SendRequest::Unpin {
+            recipient,
+            is_group,
+            target_author,
+            target_timestamp,
+        } => {
+            if let Err(e) = signal_client
+                .send_unpin_message(&recipient, is_group, &target_author, target_timestamp)
+                .await
+            {
                 app.status_message = format!("unpin error: {e}");
             }
         }
-        SendRequest::PollCreate { recipient, is_group, question, options, allow_multiple, local_ts_ms } => {
-            match signal_client.send_poll_create(&recipient, is_group, &question, &options, allow_multiple).await {
+        SendRequest::PollCreate {
+            recipient,
+            is_group,
+            question,
+            options,
+            allow_multiple,
+            local_ts_ms,
+        } => {
+            match signal_client
+                .send_poll_create(&recipient, is_group, &question, &options, allow_multiple)
+                .await
+            {
                 Ok(rpc_id) => {
                     app.pending_sends.insert(rpc_id, (recipient, local_ts_ms));
                 }
@@ -826,18 +1023,49 @@ async fn dispatch_send(
                 }
             }
         }
-        SendRequest::PollVote { recipient, is_group, poll_author, poll_timestamp, option_indexes, vote_count } => {
-            if let Err(e) = signal_client.send_poll_vote(&recipient, is_group, &poll_author, poll_timestamp, &option_indexes, vote_count).await {
+        SendRequest::PollVote {
+            recipient,
+            is_group,
+            poll_author,
+            poll_timestamp,
+            option_indexes,
+            vote_count,
+        } => {
+            if let Err(e) = signal_client
+                .send_poll_vote(
+                    &recipient,
+                    is_group,
+                    &poll_author,
+                    poll_timestamp,
+                    &option_indexes,
+                    vote_count,
+                )
+                .await
+            {
                 app.status_message = format!("vote error: {e}");
             }
         }
-        SendRequest::PollTerminate { recipient, is_group, poll_timestamp } => {
-            if let Err(e) = signal_client.send_poll_terminate(&recipient, is_group, poll_timestamp).await {
+        SendRequest::PollTerminate {
+            recipient,
+            is_group,
+            poll_timestamp,
+        } => {
+            if let Err(e) = signal_client
+                .send_poll_terminate(&recipient, is_group, poll_timestamp)
+                .await
+            {
                 app.status_message = format!("end poll error: {e}");
             }
         }
-        SendRequest::MessageRequestResponse { recipient, is_group, response_type } => {
-            if let Err(e) = signal_client.send_message_request_response(&recipient, is_group, &response_type).await {
+        SendRequest::MessageRequestResponse {
+            recipient,
+            is_group,
+            response_type,
+        } => {
+            if let Err(e) = signal_client
+                .send_message_request_response(&recipient, is_group, &response_type)
+                .await
+            {
                 app.status_message = format!("message request error: {e}");
             } else {
                 app.status_message = match response_type.as_str() {
@@ -850,17 +1078,37 @@ async fn dispatch_send(
         SendRequest::ListIdentities => {
             let _ = signal_client.list_identities().await;
         }
-        SendRequest::TrustIdentity { recipient, safety_number } => {
-            if let Err(e) = signal_client.trust_identity(&recipient, &safety_number).await {
+        SendRequest::TrustIdentity {
+            recipient,
+            safety_number,
+        } => {
+            if let Err(e) = signal_client
+                .trust_identity(&recipient, &safety_number)
+                .await
+            {
                 app.status_message = format!("trust error: {e}");
             } else {
-                app.status_message = format!("Verified {}", app.store.contact_names.get(&recipient).unwrap_or(&recipient));
+                app.status_message = format!(
+                    "Verified {}",
+                    app.store
+                        .contact_names
+                        .get(&recipient)
+                        .unwrap_or(&recipient)
+                );
                 // Re-fetch identities to update trust levels
                 let _ = signal_client.list_identities().await;
             }
         }
-        SendRequest::UpdateProfile { given_name, family_name, about, about_emoji } => {
-            if let Err(e) = signal_client.update_profile(&given_name, &family_name, &about, &about_emoji).await {
+        SendRequest::UpdateProfile {
+            given_name,
+            family_name,
+            about,
+            about_emoji,
+        } => {
+            if let Err(e) = signal_client
+                .update_profile(&given_name, &family_name, &about, &about_emoji)
+                .await
+            {
                 app.status_message = format!("profile error: {e}");
             } else {
                 app.status_message = "Profile updated".to_string();
@@ -882,7 +1130,9 @@ impl MessagingBackend<'_> {
     }
 
     fn drain_events(&mut self, app: &mut App) -> bool {
-        let MessagingBackend::Signal(sc) = self else { return false };
+        let MessagingBackend::Signal(sc) = self else {
+            return false;
+        };
         let mut changed = false;
         loop {
             match sc.event_rx.try_recv() {
@@ -894,7 +1144,9 @@ impl MessagingBackend<'_> {
                     if app.connection_error.is_none() {
                         let stderr = sc.stderr_output();
                         let exit_info = sc.try_child_exit();
-                        let msg = if let Some(last_line) = stderr.lines().last().filter(|l| !l.is_empty()) {
+                        let msg = if let Some(last_line) =
+                            stderr.lines().last().filter(|l| !l.is_empty())
+                        {
                             format!("signal-cli: {last_line}")
                         } else if let Some(code) = exit_info {
                             match code {
@@ -957,7 +1209,10 @@ async fn run_app(
     app.settings_profiles.name = config.settings_profile.clone();
     app.settings_profiles.available = settings_profile::all_settings_profiles();
     app.load_from_db()?;
-    app.expiring_msg_count = app.store.conversations.values()
+    app.expiring_msg_count = app
+        .store
+        .conversations
+        .values()
         .flat_map(|c| &c.messages)
         .filter(|m| m.expires_in_seconds > 0)
         .count();
@@ -991,7 +1246,11 @@ async fn run_app(
     // Re-enable terminal modes — on Windows, spawning cmd.exe subprocesses
     // (signal-cli.bat, check_account_registered) can reset console input mode flags.
     if config.mouse_enabled {
-        execute!(terminal.backend_mut(), EnableMouseCapture, EnableBracketedPaste)?;
+        execute!(
+            terminal.backend_mut(),
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
     } else {
         execute!(terminal.backend_mut(), EnableBracketedPaste)?;
     }
@@ -1000,8 +1259,8 @@ async fn run_app(
         // Only redraw when state has changed (avoids resetting cursor blink timer every 50ms)
         if needs_redraw {
             let native = app.image.image_mode == "native";
-            let sixel_mode = native
-                && app.image.image_protocol == image_render::ImageProtocol::Sixel;
+            let sixel_mode =
+                native && app.image.image_protocol == image_render::ImageProtocol::Sixel;
 
             // Always start sync update for atomic rendering (prevents cursor flicker).
             queue!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
@@ -1025,12 +1284,15 @@ async fn run_app(
             // Post-draw work that needs cursor hidden: OSC8 links use MoveTo,
             // and non-Sixel native images write escape sequences. Sixel emit
             // happens outside sync and handles its own cursor.
-            let has_post_draw = !app.image.link_regions.is_empty()
-                || (native && !sixel_mode);
+            let has_post_draw = !app.image.link_regions.is_empty() || (native && !sixel_mode);
             if has_post_draw && app.mode == InputMode::Insert {
                 queue!(terminal.backend_mut(), Hide)?;
             }
-            emit_osc8_links(terminal.backend_mut(), &app.image.link_regions, app.theme.link)?;
+            emit_osc8_links(
+                terminal.backend_mut(),
+                &app.image.link_regions,
+                app.theme.link,
+            )?;
             if native && !sixel_mode {
                 emit_native_images(terminal.backend_mut(), &mut app)?;
             }
@@ -1141,7 +1403,15 @@ async fn run_app(
 
         // Dispatch queued read receipts
         for (recipient, timestamps) in std::mem::take(&mut app.pending_read_receipts) {
-            backend.dispatch(&mut app, SendRequest::ReadReceipt { recipient, timestamps }).await;
+            backend
+                .dispatch(
+                    &mut app,
+                    SendRequest::ReadReceipt {
+                        recipient,
+                        timestamps,
+                    },
+                )
+                .await;
         }
 
         // Expire stale typing indicators
@@ -1193,7 +1463,10 @@ async fn run_app(
         } else {
             "siggy".to_string()
         };
-        execute!(terminal.backend_mut(), crossterm::terminal::SetTitle(&title))?;
+        execute!(
+            terminal.backend_mut(),
+            crossterm::terminal::SetTitle(&title)
+        )?;
 
         if app.should_quit {
             break;
@@ -1201,9 +1474,7 @@ async fn run_app(
     }
 
     // Restore terminal title on exit
-    execute!(terminal.backend_mut(), crossterm::terminal::SetTitle(""))
-        .ok();
+    execute!(terminal.backend_mut(), crossterm::terminal::SetTitle("")).ok();
 
     Ok(())
 }
-

--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -156,7 +156,13 @@ pub fn find_settings_profile(name: &str) -> SettingsProfile {
 /// Convert a profile name to a safe filename (lowercase, spaces to hyphens).
 fn name_to_filename(name: &str) -> String {
     name.chars()
-        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .map(|c| {
+            if c.is_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
         .collect()
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -101,25 +101,22 @@ pub async fn run_setup(
                                 return Ok(SetupResult::Cancelled);
                             }
                             _ if custom_path_mode => match key.code {
-                                KeyCode::Enter
-                                    if !custom_path_input.is_empty() => {
-                                        signal_cli_path = custom_path_input.clone();
-                                        signal_cli_found = false;
-                                        custom_path_mode = false;
-                                        // Will re-check on next loop
-                                    }
-                                KeyCode::Backspace
-                                    if custom_path_cursor > 0 => {
-                                        custom_path_cursor -= 1;
-                                        custom_path_input.remove(custom_path_cursor);
-                                    }
+                                KeyCode::Enter if !custom_path_input.is_empty() => {
+                                    signal_cli_path = custom_path_input.clone();
+                                    signal_cli_found = false;
+                                    custom_path_mode = false;
+                                    // Will re-check on next loop
+                                }
+                                KeyCode::Backspace if custom_path_cursor > 0 => {
+                                    custom_path_cursor -= 1;
+                                    custom_path_input.remove(custom_path_cursor);
+                                }
                                 KeyCode::Left => {
                                     custom_path_cursor = custom_path_cursor.saturating_sub(1);
                                 }
-                                KeyCode::Right
-                                    if custom_path_cursor < custom_path_input.len() => {
-                                        custom_path_cursor += 1;
-                                    }
+                                KeyCode::Right if custom_path_cursor < custom_path_input.len() => {
+                                    custom_path_cursor += 1;
+                                }
                                 KeyCode::Char(c) => {
                                     custom_path_input.insert(custom_path_cursor, c);
                                     custom_path_cursor += 1;
@@ -164,18 +161,16 @@ pub async fn run_setup(
                                 phone_cursor = 0;
                                 phone_error = None;
                             }
-                            (_, KeyCode::Enter) => {
-                                match validate_phone(&phone_input) {
-                                    Ok(()) => {
-                                        working_config.account = phone_input.clone();
-                                        phone_error = None;
-                                        step = Step::Linking;
-                                    }
-                                    Err(msg) => {
-                                        phone_error = Some(msg);
-                                    }
+                            (_, KeyCode::Enter) => match validate_phone(&phone_input) {
+                                Ok(()) => {
+                                    working_config.account = phone_input.clone();
+                                    phone_error = None;
+                                    step = Step::Linking;
                                 }
-                            }
+                                Err(msg) => {
+                                    phone_error = Some(msg);
+                                }
+                            },
                             (_, KeyCode::Backspace) => {
                                 if phone_cursor > 0 {
                                     phone_cursor -= 1;
@@ -186,10 +181,9 @@ pub async fn run_setup(
                             (_, KeyCode::Left) => {
                                 phone_cursor = phone_cursor.saturating_sub(1);
                             }
-                            (_, KeyCode::Right)
-                                if phone_cursor < phone_input.len() => {
-                                    phone_cursor += 1;
-                                }
+                            (_, KeyCode::Right) if phone_cursor < phone_input.len() => {
+                                phone_cursor += 1;
+                            }
                             (_, KeyCode::Char(c)) => {
                                 phone_input.insert(phone_cursor, c);
                                 phone_cursor += 1;
@@ -203,7 +197,9 @@ pub async fn run_setup(
 
             Step::Linking => {
                 // Check if already registered
-                let registered = link::check_account_registered(&working_config).await.unwrap_or(false);
+                let registered = link::check_account_registered(&working_config)
+                    .await
+                    .unwrap_or(false);
                 if registered {
                     // Already registered, skip linking
                     terminal.draw(|frame| {
@@ -405,7 +401,11 @@ fn draw_signal_cli_step(
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Cyan))
         .title(" Setup ")
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
     let inner = block.inner(content);
     frame.render_widget(block, content);
 
@@ -413,7 +413,9 @@ fn draw_signal_cli_step(
         Line::from(""),
         Line::from(Span::styled(
             "  Welcome to siggy!",
-            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -423,7 +425,9 @@ fn draw_signal_cli_step(
         Line::from(""),
         Line::from(Span::styled(
             format!("  {}: Signal-CLI", step_label(Step::SignalCli)),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         )),
     ];
 
@@ -432,7 +436,12 @@ fn draw_signal_cli_step(
     if found {
         lines.push(Line::from(vec![
             Span::styled("  ", Style::default()),
-            Span::styled("V ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "V ",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 format!("Found signal-cli at {location}"),
                 Style::default().fg(Color::Green),
@@ -457,11 +466,11 @@ fn draw_signal_cli_step(
     } else {
         lines.push(Line::from(vec![
             Span::styled("  ", Style::default()),
-            Span::styled("X ", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)),
             Span::styled(
-                "signal-cli not found",
-                Style::default().fg(Color::Red),
+                "X ",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
             ),
+            Span::styled("signal-cli not found", Style::default().fg(Color::Red)),
         ]));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -510,7 +519,11 @@ fn draw_account_step(
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Cyan))
         .title(" Setup ")
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
     let inner = block.inner(content);
     frame.render_widget(block, content);
 
@@ -518,7 +531,9 @@ fn draw_account_step(
         Line::from(""),
         Line::from(Span::styled(
             format!("  {}: Phone Number", step_label(Step::Account)),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -586,7 +601,12 @@ fn draw_registered_screen(frame: &mut ratatui::Frame, account: &str) {
     let lines = vec![
         Line::from(""),
         Line::from(vec![
-            Span::styled("  V ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  V ",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 format!("Account {account} is already registered"),
                 Style::default().fg(Color::Green),
@@ -665,21 +685,35 @@ fn draw_preferences_step(frame: &mut ratatui::Frame, config: &Config) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(Color::Cyan))
         .title(" Setup ")
-        .title_style(Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD));
+        .title_style(
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        );
     let inner = block.inner(content);
     frame.render_widget(block, content);
 
     let on = Style::default().fg(Color::Green);
     let off = Style::default().fg(Color::Red);
 
-    let direct_state = if config.notify_direct { ("on", on) } else { ("off", off) };
-    let group_state = if config.notify_group { ("on", on) } else { ("off", off) };
+    let direct_state = if config.notify_direct {
+        ("on", on)
+    } else {
+        ("off", off)
+    };
+    let group_state = if config.notify_group {
+        ("on", on)
+    } else {
+        ("off", off)
+    };
 
     let lines = vec![
         Line::from(""),
         Line::from(Span::styled(
             format!("  {}: Notifications", step_label(Step::Preferences)),
-            Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -692,12 +726,22 @@ fn draw_preferences_step(frame: &mut ratatui::Frame, config: &Config) {
         )),
         Line::from(""),
         Line::from(vec![
-            Span::styled("  1 ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  1 ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("Direct messages  ", Style::default().fg(Color::White)),
             Span::styled(direct_state.0, direct_state.1),
         ]),
         Line::from(vec![
-            Span::styled("  2 ", Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "  2 ",
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("Group messages   ", Style::default().fg(Color::White)),
             Span::styled(group_state.0, group_state.1),
         ]),
@@ -738,7 +782,9 @@ fn draw_done_screen(frame: &mut ratatui::Frame) {
         Line::from(""),
         Line::from(Span::styled(
             "  All set! Starting siggy...",
-            Style::default().fg(Color::Green).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -85,7 +85,9 @@ impl SignalClient {
 
                         let event = if let Some(method) = pending_method {
                             if let Some(ref err) = resp.error {
-                                crate::debug_log::logf(format_args!("rpc error: method={method} error={err:?}"));
+                                crate::debug_log::logf(format_args!(
+                                    "rpc error: method={method} error={err:?}"
+                                ));
                                 // RPC error — emit SendFailed for send requests,
                                 // surface other errors to the status bar
                                 if method == "send" {
@@ -94,9 +96,9 @@ impl SignalClient {
                                     Some(SignalEvent::Error(format!("{method}: {}", err.message)))
                                 }
                             } else {
-                                resp.result
-                                    .as_ref()
-                                    .and_then(|result| parse_rpc_result(&method, result, rpc_id.as_deref()))
+                                resp.result.as_ref().and_then(|result| {
+                                    parse_rpc_result(&method, result, rpc_id.as_deref())
+                                })
                             }
                         } else {
                             parse_signal_event(&resp, &download_dir)
@@ -104,7 +106,10 @@ impl SignalClient {
 
                         if let Some(ref event) = event {
                             if crate::debug_log::redact() {
-                                crate::debug_log::logf(format_args!("event: {}", event.redacted_summary()));
+                                crate::debug_log::logf(format_args!(
+                                    "event: {}",
+                                    event.redacted_summary()
+                                ));
                             } else {
                                 crate::debug_log::logf(format_args!("event: {event:?}"));
                             }
@@ -207,9 +212,7 @@ impl SignalClient {
             // signal-cli expects mentions as colon-separated strings: "start:length:uuid"
             let mention_arr: Vec<serde_json::Value> = mentions
                 .iter()
-                .map(|(start, uuid)| {
-                    serde_json::Value::String(format!("{start}:1:{uuid}"))
-                })
+                .map(|(start, uuid)| serde_json::Value::String(format!("{start}:1:{uuid}")))
                 .collect();
             params["mention"] = serde_json::Value::Array(mention_arr);
         }
@@ -570,16 +573,14 @@ impl SignalClient {
         Ok(())
     }
 
-    pub async fn send_typing(
-        &self,
-        recipient: &str,
-        is_group: bool,
-        stop: bool,
-    ) -> Result<()> {
+    pub async fn send_typing(&self, recipient: &str, is_group: bool, stop: bool) -> Result<()> {
         let id = Uuid::new_v4().to_string();
 
         if let Ok(mut map) = self.pending_requests.lock() {
-            map.insert(id.clone(), ("sendTypingIndicator".to_string(), Instant::now()));
+            map.insert(
+                id.clone(),
+                ("sendTypingIndicator".to_string(), Instant::now()),
+            );
         }
 
         let mut params = if is_group {
@@ -615,11 +616,7 @@ impl SignalClient {
 
     /// Send a read receipt to a single recipient for one or more message timestamps.
     /// Fire-and-forget — no useful result is expected from signal-cli.
-    pub async fn send_read_receipt(
-        &self,
-        recipient: &str,
-        timestamps: &[i64],
-    ) -> Result<()> {
+    pub async fn send_read_receipt(&self, recipient: &str, timestamps: &[i64]) -> Result<()> {
         let id = Uuid::new_v4().to_string();
 
         if let Ok(mut map) = self.pending_requests.lock() {
@@ -657,7 +654,10 @@ impl SignalClient {
     ) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         if let Ok(mut map) = self.pending_requests.lock() {
-            map.insert(id.clone(), ("sendMessageRequestResponse".to_string(), Instant::now()));
+            map.insert(
+                id.clone(),
+                ("sendMessageRequestResponse".to_string(), Instant::now()),
+            );
         }
         let mut params = serde_json::json!({
             "type": response_type,
@@ -731,7 +731,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send createGroup to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send createGroup to signal-cli stdin")?;
         Ok(())
     }
 
@@ -753,7 +756,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send addGroupMembers to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send addGroupMembers to signal-cli stdin")?;
         Ok(())
     }
 
@@ -775,7 +781,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send removeGroupMembers to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send removeGroupMembers to signal-cli stdin")?;
         Ok(())
     }
 
@@ -797,7 +806,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send renameGroup to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send renameGroup to signal-cli stdin")?;
         Ok(())
     }
 
@@ -827,7 +839,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send updateProfile to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send updateProfile to signal-cli stdin")?;
         Ok(())
     }
 
@@ -855,7 +870,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send block to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send block to signal-cli stdin")?;
         Ok(())
     }
 
@@ -883,7 +901,10 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send unblock to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send unblock to signal-cli stdin")?;
         Ok(())
     }
 
@@ -904,16 +925,15 @@ impl SignalClient {
             params: Some(params),
         };
         let json = serde_json::to_string(&request)?;
-        self.stdin_tx.send(json).await.context("Failed to send quitGroup to signal-cli stdin")?;
+        self.stdin_tx
+            .send(json)
+            .await
+            .context("Failed to send quitGroup to signal-cli stdin")?;
         Ok(())
     }
 
     /// Set the disappearing message timer for a group.
-    pub async fn send_update_group_expiration(
-        &self,
-        group_id: &str,
-        seconds: i64,
-    ) -> Result<()> {
+    pub async fn send_update_group_expiration(&self, group_id: &str, seconds: i64) -> Result<()> {
         let id = Uuid::new_v4().to_string();
         if let Ok(mut map) = self.pending_requests.lock() {
             map.insert(id.clone(), ("updateGroup".to_string(), Instant::now()));
@@ -1006,10 +1026,8 @@ impl SignalClient {
             map.insert(id.clone(), ("sendPollVote".to_string(), Instant::now()));
         }
 
-        let option_arr: Vec<serde_json::Value> = options
-            .iter()
-            .map(|&o| serde_json::json!(o))
-            .collect();
+        let option_arr: Vec<serde_json::Value> =
+            options.iter().map(|&o| serde_json::json!(o)).collect();
 
         let mut params = if is_group {
             serde_json::json!({
@@ -1057,7 +1075,10 @@ impl SignalClient {
         let id = Uuid::new_v4().to_string();
 
         if let Ok(mut map) = self.pending_requests.lock() {
-            map.insert(id.clone(), ("sendPollTerminate".to_string(), Instant::now()));
+            map.insert(
+                id.clone(),
+                ("sendPollTerminate".to_string(), Instant::now()),
+            );
         }
 
         let params = if is_group {
@@ -1091,7 +1112,10 @@ impl SignalClient {
 
     /// Returns accumulated stderr output from the signal-cli process.
     pub fn stderr_output(&self) -> String {
-        self.stderr_buffer.lock().map(|buf| buf.clone()).unwrap_or_default()
+        self.stderr_buffer
+            .lock()
+            .map(|buf| buf.clone())
+            .unwrap_or_default()
     }
 
     /// Non-blocking check: returns `Some(exit_code)` if the child has exited.
@@ -1122,15 +1146,24 @@ impl SignalClient {
     }
 }
 
-pub fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option<&str>) -> Option<SignalEvent> {
+pub fn parse_rpc_result(
+    method: &str,
+    result: &serde_json::Value,
+    rpc_id: Option<&str>,
+) -> Option<SignalEvent> {
     match method {
         "send" => {
             let id = rpc_id?.to_string();
             // signal-cli send response includes result.timestamp (server-assigned ms epoch)
-            let server_ts = result.get("timestamp").and_then(|v| v.as_i64())
+            let server_ts = result
+                .get("timestamp")
+                .and_then(|v| v.as_i64())
                 .or_else(|| result.as_i64())
                 .unwrap_or(0);
-            Some(SignalEvent::SendTimestamp { rpc_id: id, server_ts })
+            Some(SignalEvent::SendTimestamp {
+                rpc_id: id,
+                server_ts,
+            })
         }
         "listContacts" => {
             let arr = result.as_array()?;
@@ -1145,7 +1178,10 @@ pub fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option
                         .or_else(|| obj.get("name").and_then(|v| v.as_str()))
                         .filter(|s| !s.is_empty())
                         .map(|s| s.to_string());
-                    let uuid = obj.get("uuid").and_then(|v| v.as_str()).map(|s| s.to_string());
+                    let uuid = obj
+                        .get("uuid")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
                     Some(Contact {
                         number: number.to_string(),
                         name,
@@ -1172,7 +1208,8 @@ pub fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option
                         for m in arr {
                             // signal-cli returns members as objects: {"number": "+1...", "uuid": "..."}
                             // Fall back to plain string for compatibility
-                            let phone = m.get("number")
+                            let phone = m
+                                .get("number")
                                 .and_then(|v| v.as_str())
                                 .or_else(|| m.as_str());
                             if let Some(phone) = phone {
@@ -1198,14 +1235,33 @@ pub fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option
             let identities: Vec<IdentityInfo> = arr
                 .iter()
                 .map(|obj| {
-                    let number = obj.get("number").and_then(|v| v.as_str()).map(|s| s.to_string());
-                    let uuid = obj.get("uuid").and_then(|v| v.as_str()).map(|s| s.to_string());
-                    let fingerprint = obj.get("fingerprint").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                    let safety_number = obj.get("safetyNumber").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                    let trust_level = obj.get("trustLevel").and_then(|v| v.as_str())
+                    let number = obj
+                        .get("number")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let uuid = obj
+                        .get("uuid")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let fingerprint = obj
+                        .get("fingerprint")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let safety_number = obj
+                        .get("safetyNumber")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let trust_level = obj
+                        .get("trustLevel")
+                        .and_then(|v| v.as_str())
                         .map(TrustLevel::from_str)
                         .unwrap_or(TrustLevel::TrustedUnverified);
-                    let added_timestamp = obj.get("addedTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+                    let added_timestamp = obj
+                        .get("addedTimestamp")
+                        .and_then(|v| v.as_i64())
+                        .unwrap_or(0);
                     IdentityInfo {
                         number,
                         uuid,
@@ -1220,12 +1276,31 @@ pub fn parse_rpc_result(method: &str, result: &serde_json::Value, rpc_id: Option
         }
         "sendPollCreate" => {
             let id = rpc_id?.to_string();
-            let server_ts = result.get("timestamp").and_then(|v| v.as_i64())
+            let server_ts = result
+                .get("timestamp")
+                .and_then(|v| v.as_i64())
                 .or_else(|| result.as_i64())
                 .unwrap_or(0);
-            Some(SignalEvent::SendTimestamp { rpc_id: id, server_ts })
+            Some(SignalEvent::SendTimestamp {
+                rpc_id: id,
+                server_ts,
+            })
         }
-        "sendReaction" | "remoteDelete" | "sendTypingIndicator" | "sendReceipt" | "updateContact" | "updateGroup" | "quitGroup" | "sendMessageRequestResponse" | "block" | "unblock" | "sendPinMessage" | "sendUnpinMessage" | "sendPollVote" | "sendPollTerminate" | "trust" => None, // fire-and-forget, no action needed
+        "sendReaction"
+        | "remoteDelete"
+        | "sendTypingIndicator"
+        | "sendReceipt"
+        | "updateContact"
+        | "updateGroup"
+        | "quitGroup"
+        | "sendMessageRequestResponse"
+        | "block"
+        | "unblock"
+        | "sendPinMessage"
+        | "sendUnpinMessage"
+        | "sendPollVote"
+        | "sendPollTerminate"
+        | "trust" => None, // fire-and-forget, no action needed
         _ => None,
     }
 }
@@ -1250,7 +1325,10 @@ fn parse_receive_event(
 ) -> Option<SignalEvent> {
     // signal-cli reports exceptions for messages it can't parse (e.g. 1:1 sent sync)
     if let Some(exc) = params.get("exception") {
-        let msg = exc.get("message").and_then(|v| v.as_str()).unwrap_or("unknown error");
+        let msg = exc
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown error");
         if msg.contains("SyncMessage missing destination") {
             return None; // Known signal-cli bug — silently ignore
         }
@@ -1295,13 +1373,20 @@ fn parse_receive_event(
                 .and_then(|o| o.get("type"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("AUDIO_CALL");
-            let kind = if call_type == "VIDEO_CALL" { "video" } else { "voice" };
+            let kind = if call_type == "VIDEO_CALL" {
+                "video"
+            } else {
+                "voice"
+            };
             let conv_id = envelope
                 .get("sourceNumber")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
                 .to_string();
-            let timestamp_ms = envelope.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+            let timestamp_ms = envelope
+                .get("timestamp")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
             let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
             return Some(SignalEvent::SystemMessage {
                 conv_id,
@@ -1322,7 +1407,8 @@ fn parse_receive_event(
         if let Some(sent) = sync.get("sentMessage") {
             // Check for edit in sync
             if let Some(edit_msg) = sent.get("editMessage") {
-                let dest = sent.get("destinationNumber")
+                let dest = sent
+                    .get("destinationNumber")
                     .or_else(|| sent.get("destination"))
                     .and_then(|v| v.as_str());
                 return parse_edit_message(envelope, edit_msg, true, dest);
@@ -1354,7 +1440,9 @@ fn parse_read_sync(sync: &serde_json::Value) -> Option<SignalEvent> {
     if entries.is_empty() {
         return None;
     }
-    Some(SignalEvent::ReadSyncReceived { read_messages: entries })
+    Some(SignalEvent::ReadSyncReceived {
+        read_messages: entries,
+    })
 }
 
 fn parse_typing_indicator(envelope: &serde_json::Value) -> Option<SignalEvent> {
@@ -1378,7 +1466,12 @@ fn parse_typing_indicator(envelope: &serde_json::Value) -> Option<SignalEvent> {
         .get("groupId")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
-    Some(SignalEvent::TypingIndicator { sender, sender_name, is_typing, group_id })
+    Some(SignalEvent::TypingIndicator {
+        sender,
+        sender_name,
+        is_typing,
+        group_id,
+    })
 }
 
 fn parse_receipt_message(envelope: &serde_json::Value) -> Option<SignalEvent> {
@@ -1389,22 +1482,42 @@ fn parse_receipt_message(envelope: &serde_json::Value) -> Option<SignalEvent> {
         .unwrap_or("unknown")
         .to_string();
     // signal-cli uses boolean fields: isDelivery, isRead, isViewed
-    let receipt_type = if receipt.get("isRead").and_then(|v| v.as_bool()).unwrap_or(false) {
+    let receipt_type = if receipt
+        .get("isRead")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         "READ"
-    } else if receipt.get("isViewed").and_then(|v| v.as_bool()).unwrap_or(false) {
+    } else if receipt
+        .get("isViewed")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         "VIEWED"
-    } else if receipt.get("isDelivery").and_then(|v| v.as_bool()).unwrap_or(false) {
+    } else if receipt
+        .get("isDelivery")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         "DELIVERY"
     } else {
         // Fallback: try "type" string field (older signal-cli versions)
-        receipt.get("type").and_then(|v| v.as_str()).unwrap_or("UNKNOWN")
-    }.to_string();
+        receipt
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("UNKNOWN")
+    }
+    .to_string();
     let timestamps: Vec<i64> = receipt
         .get("timestamps")
         .and_then(|v| v.as_array())
         .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect())
         .unwrap_or_default();
-    Some(SignalEvent::ReceiptReceived { sender, receipt_type, timestamps })
+    Some(SignalEvent::ReceiptReceived {
+        sender,
+        receipt_type,
+        timestamps,
+    })
 }
 
 fn parse_data_message(
@@ -1419,20 +1532,32 @@ fn parse_data_message(
                 .as_object()
                 .map(|obj| obj.keys().map(|k| k.as_str()).collect())
                 .unwrap_or_default();
-            let interesting: Vec<&&str> = keys.iter()
-                .filter(|k| !matches!(**k,
-                    "source" | "sourceNumber" | "sourceName" | "sourceUuid"
-                    | "sourceDevice" | "timestamp" | "serverReceivedTimestamp"
-                    | "serverDeliveredTimestamp" | "relay"
-                ))
+            let interesting: Vec<&&str> = keys
+                .iter()
+                .filter(|k| {
+                    !matches!(
+                        **k,
+                        "source"
+                            | "sourceNumber"
+                            | "sourceName"
+                            | "sourceUuid"
+                            | "sourceDevice"
+                            | "timestamp"
+                            | "serverReceivedTimestamp"
+                            | "serverDeliveredTimestamp"
+                            | "relay"
+                    )
+                })
                 .collect();
             if !interesting.is_empty() {
-                return Some(SignalEvent::Error(
-                    format!("unhandled envelope type: {}", interesting.iter()
+                return Some(SignalEvent::Error(format!(
+                    "unhandled envelope type: {}",
+                    interesting
+                        .iter()
                         .map(|k| **k)
                         .collect::<Vec<_>>()
-                        .join(", "))
-                ));
+                        .join(", ")
+                )));
             }
             return None;
         }
@@ -1449,8 +1574,15 @@ fn parse_data_message(
 
     // Check for pin message
     if let Some(pin) = data.get("pinMessage") {
-        let target_author = pin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-        let target_timestamp = pin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let target_author = pin
+            .get("targetAuthor")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let target_timestamp = pin
+            .get("targetSentTimestamp")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
         let sender = envelope
             .get("sourceNumber")
             .and_then(|v| v.as_str())
@@ -1479,8 +1611,15 @@ fn parse_data_message(
 
     // Check for unpin message
     if let Some(unpin) = data.get("unpinMessage") {
-        let target_author = unpin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-        let target_timestamp = unpin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let target_author = unpin
+            .get("targetAuthor")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let target_timestamp = unpin
+            .get("targetSentTimestamp")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
         let sender = envelope
             .get("sourceNumber")
             .and_then(|v| v.as_str())
@@ -1541,14 +1680,26 @@ fn parse_data_message(
     }
 
     // Expiration timer update → ExpirationTimerChanged event
-    if data.get("isExpirationUpdate").and_then(|v| v.as_bool()).unwrap_or(false) {
-        let group_id = data.get("groupInfo").and_then(|g| g.get("groupId")).and_then(|v| v.as_str());
-        let conv_id = group_id
-            .map(|g| g.to_string())
-            .unwrap_or_else(|| {
-                envelope.get("sourceNumber").and_then(|v| v.as_str()).unwrap_or("unknown").to_string()
-            });
-        let seconds = data.get("expiresInSeconds").and_then(|v| v.as_i64()).unwrap_or(0);
+    if data
+        .get("isExpirationUpdate")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        let group_id = data
+            .get("groupInfo")
+            .and_then(|g| g.get("groupId"))
+            .and_then(|v| v.as_str());
+        let conv_id = group_id.map(|g| g.to_string()).unwrap_or_else(|| {
+            envelope
+                .get("sourceNumber")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string()
+        });
+        let seconds = data
+            .get("expiresInSeconds")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
         let timestamp_ms = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
         let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
         return Some(SignalEvent::ExpirationTimerChanged {
@@ -1562,14 +1713,20 @@ fn parse_data_message(
 
     // Group update with no body/reaction/remoteDelete → system message
     if let Some(group_info) = data.get("groupInfo") {
-        let group_type = group_info.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let group_type = group_info
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         if group_type == "UPDATE"
             && data.get("message").and_then(|v| v.as_str()).is_none()
             && data.get("reaction").is_none()
             && data.get("remoteDelete").is_none()
         {
-            let conv_id = group_info.get("groupId").and_then(|v| v.as_str())
-                .unwrap_or("unknown").to_string();
+            let conv_id = group_info
+                .get("groupId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
             let timestamp_ms = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
             let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
             return Some(SignalEvent::SystemMessage {
@@ -1597,21 +1754,18 @@ fn parse_data_message(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let timestamp_ms = data
-        .get("timestamp")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let timestamp_ms = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
 
-    let timestamp = DateTime::from_timestamp_millis(timestamp_ms)
-        .unwrap_or_default();
+    let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
 
     // Synthesize body for sticker messages
-    let sticker_body = data.get("sticker").map(|sticker| {
-        match sticker.get("emoji").and_then(|v| v.as_str()) {
-            Some(emoji) => format!("[Sticker: {}]", emoji),
-            None => "[Sticker]".to_string(),
-        }
-    });
+    let sticker_body =
+        data.get("sticker").map(
+            |sticker| match sticker.get("emoji").and_then(|v| v.as_str()) {
+                Some(emoji) => format!("[Sticker: {}]", emoji),
+                None => "[Sticker]".to_string(),
+            },
+        );
 
     let mut body = data
         .get("message")
@@ -1644,7 +1798,11 @@ fn parse_data_message(
     let mut previews = parse_link_previews(data, download_dir);
 
     // View-once messages: replace content with placeholder
-    if data.get("viewOnce").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if data
+        .get("viewOnce")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         body = Some("[View-once message]".to_string());
         attachments = Vec::new();
         previews = Vec::new();
@@ -1658,12 +1816,19 @@ fn parse_data_message(
     let quote = data.get("quote").and_then(|q| {
         let q_ts = q.get("id").and_then(|v| v.as_i64())?;
         let q_author = q.get("authorNumber").and_then(|v| v.as_str())?.to_string();
-        let q_body = q.get("text").and_then(|v| v.as_str()).unwrap_or("")
-            .replace('\u{FFFC}', "").to_string();
+        let q_body = q
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .replace('\u{FFFC}', "")
+            .to_string();
         Some((q_ts, q_author, q_body))
     });
 
-    let expires_in_seconds = data.get("expiresInSeconds").and_then(|v| v.as_i64()).unwrap_or(0);
+    let expires_in_seconds = data
+        .get("expiresInSeconds")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
 
     Some(SignalEvent::MessageReceived(SignalMessage {
         source,
@@ -1689,8 +1854,14 @@ fn parse_poll_create(
     data: &serde_json::Value,
     poll_create: &serde_json::Value,
 ) -> Option<SignalEvent> {
-    let question = poll_create.get("question").and_then(|v| v.as_str())?.to_string();
-    let allow_multiple = poll_create.get("allowMultiple").and_then(|v| v.as_bool()).unwrap_or(false);
+    let question = poll_create
+        .get("question")
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let allow_multiple = poll_create
+        .get("allowMultiple")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
     let options: Vec<crate::signal::types::PollOption> = poll_create
         .get("options")
         .and_then(|v| v.as_array())
@@ -1706,8 +1877,14 @@ fn parse_poll_create(
         })
         .unwrap_or_default();
 
-    let group_id = data.get("groupInfo").and_then(|g| g.get("groupId")).and_then(|v| v.as_str());
-    let sender = envelope.get("sourceNumber").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let group_id = data
+        .get("groupInfo")
+        .and_then(|g| g.get("groupId"))
+        .and_then(|v| v.as_str());
+    let sender = envelope
+        .get("sourceNumber")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
     let conv_id = group_id.unwrap_or(sender).to_string();
     let timestamp = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
 
@@ -1731,7 +1908,9 @@ fn parse_poll_vote(
     data: &serde_json::Value,
     poll_vote: &serde_json::Value,
 ) -> Option<SignalEvent> {
-    let target_timestamp = poll_vote.get("targetSentTimestamp").and_then(|v| v.as_i64())?;
+    let target_timestamp = poll_vote
+        .get("targetSentTimestamp")
+        .and_then(|v| v.as_i64())?;
     let voter = poll_vote
         .get("authorNumber")
         .and_then(|v| v.as_str())
@@ -1748,10 +1927,19 @@ fn parse_poll_vote(
         .and_then(|v| v.as_array())
         .map(|arr| arr.iter().filter_map(|v| v.as_i64()).collect())
         .unwrap_or_default();
-    let vote_count = poll_vote.get("voteCount").and_then(|v| v.as_i64()).unwrap_or(1);
+    let vote_count = poll_vote
+        .get("voteCount")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(1);
 
-    let group_id = data.get("groupInfo").and_then(|g| g.get("groupId")).and_then(|v| v.as_str());
-    let sender = envelope.get("sourceNumber").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let group_id = data
+        .get("groupInfo")
+        .and_then(|g| g.get("groupId"))
+        .and_then(|v| v.as_str());
+    let sender = envelope
+        .get("sourceNumber")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
     let conv_id = group_id.unwrap_or(sender).to_string();
 
     Some(SignalEvent::PollVoteReceived {
@@ -1769,9 +1957,17 @@ fn parse_poll_terminate(
     data: &serde_json::Value,
     poll_terminate: &serde_json::Value,
 ) -> Option<SignalEvent> {
-    let target_timestamp = poll_terminate.get("targetSentTimestamp").and_then(|v| v.as_i64())?;
-    let group_id = data.get("groupInfo").and_then(|g| g.get("groupId")).and_then(|v| v.as_str());
-    let sender = envelope.get("sourceNumber").and_then(|v| v.as_str()).unwrap_or("unknown");
+    let target_timestamp = poll_terminate
+        .get("targetSentTimestamp")
+        .and_then(|v| v.as_i64())?;
+    let group_id = data
+        .get("groupInfo")
+        .and_then(|g| g.get("groupId"))
+        .and_then(|v| v.as_str());
+    let sender = envelope
+        .get("sourceNumber")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
     let conv_id = group_id.unwrap_or(sender).to_string();
 
     Some(SignalEvent::PollTerminated {
@@ -1803,8 +1999,15 @@ fn parse_sent_sync(
 
     // Check for synced pin message
     if let Some(pin) = sent.get("pinMessage") {
-        let target_author = pin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-        let target_timestamp = pin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let target_author = pin
+            .get("targetAuthor")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let target_timestamp = pin
+            .get("targetSentTimestamp")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
         let sender = envelope
             .get("sourceNumber")
             .and_then(|v| v.as_str())
@@ -1839,8 +2042,15 @@ fn parse_sent_sync(
 
     // Check for synced unpin message
     if let Some(unpin) = sent.get("unpinMessage") {
-        let target_author = unpin.get("targetAuthor").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
-        let target_timestamp = unpin.get("targetSentTimestamp").and_then(|v| v.as_i64()).unwrap_or(0);
+        let target_author = unpin
+            .get("targetAuthor")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown")
+            .to_string();
+        let target_timestamp = unpin
+            .get("targetSentTimestamp")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
         let sender = envelope
             .get("sourceNumber")
             .and_then(|v| v.as_str())
@@ -1902,8 +2112,15 @@ fn parse_sent_sync(
     }
 
     // Expiration timer update (synced) → ExpirationTimerChanged event
-    if sent.get("isExpirationUpdate").and_then(|v| v.as_bool()).unwrap_or(false) {
-        let group_id = sent.get("groupInfo").and_then(|g| g.get("groupId")).and_then(|v| v.as_str());
+    if sent
+        .get("isExpirationUpdate")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        let group_id = sent
+            .get("groupInfo")
+            .and_then(|g| g.get("groupId"))
+            .and_then(|v| v.as_str());
         let conv_id = group_id
             .map(|g| g.to_string())
             .or_else(|| {
@@ -1913,9 +2130,16 @@ fn parse_sent_sync(
                     .map(|s| s.to_string())
             })
             .unwrap_or_else(|| {
-                envelope.get("sourceNumber").and_then(|v| v.as_str()).unwrap_or("unknown").to_string()
+                envelope
+                    .get("sourceNumber")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown")
+                    .to_string()
             });
-        let seconds = sent.get("expiresInSeconds").and_then(|v| v.as_i64()).unwrap_or(0);
+        let seconds = sent
+            .get("expiresInSeconds")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
         let timestamp_ms = sent.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
         let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
         return Some(SignalEvent::ExpirationTimerChanged {
@@ -1929,14 +2153,20 @@ fn parse_sent_sync(
 
     // Group update (synced) with no body/reaction/remoteDelete → system message
     if let Some(group_info) = sent.get("groupInfo") {
-        let group_type = group_info.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        let group_type = group_info
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
         if group_type == "UPDATE"
             && sent.get("message").and_then(|v| v.as_str()).is_none()
             && sent.get("reaction").is_none()
             && sent.get("remoteDelete").is_none()
         {
-            let conv_id = group_info.get("groupId").and_then(|v| v.as_str())
-                .unwrap_or("unknown").to_string();
+            let conv_id = group_info
+                .get("groupId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown")
+                .to_string();
             let timestamp_ms = sent.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
             let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
             return Some(SignalEvent::SystemMessage {
@@ -1960,20 +2190,18 @@ fn parse_sent_sync(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let timestamp_ms = sent
-        .get("timestamp")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let timestamp_ms = sent.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
 
     let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
 
     // Synthesize body for sticker messages
-    let sticker_body = sent.get("sticker").map(|sticker| {
-        match sticker.get("emoji").and_then(|v| v.as_str()) {
-            Some(emoji) => format!("[Sticker: {}]", emoji),
-            None => "[Sticker]".to_string(),
-        }
-    });
+    let sticker_body =
+        sent.get("sticker").map(
+            |sticker| match sticker.get("emoji").and_then(|v| v.as_str()) {
+                Some(emoji) => format!("[Sticker: {}]", emoji),
+                None => "[Sticker]".to_string(),
+            },
+        );
 
     let mut body = sent
         .get("message")
@@ -2006,7 +2234,11 @@ fn parse_sent_sync(
     let mut previews = parse_link_previews(sent, download_dir);
 
     // View-once messages: replace content with placeholder
-    if sent.get("viewOnce").and_then(|v| v.as_bool()).unwrap_or(false) {
+    if sent
+        .get("viewOnce")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
         body = Some("[View-once message]".to_string());
         attachments = Vec::new();
         previews = Vec::new();
@@ -2020,12 +2252,19 @@ fn parse_sent_sync(
     let quote = sent.get("quote").and_then(|q| {
         let q_ts = q.get("id").and_then(|v| v.as_i64())?;
         let q_author = q.get("authorNumber").and_then(|v| v.as_str())?.to_string();
-        let q_body = q.get("text").and_then(|v| v.as_str()).unwrap_or("")
-            .replace('\u{FFFC}', "").to_string();
+        let q_body = q
+            .get("text")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .replace('\u{FFFC}', "")
+            .to_string();
         Some((q_ts, q_author, q_body))
     });
 
-    let expires_in_seconds = sent.get("expiresInSeconds").and_then(|v| v.as_i64()).unwrap_or(0);
+    let expires_in_seconds = sent
+        .get("expiresInSeconds")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
 
     Some(SignalEvent::MessageReceived(SignalMessage {
         source,
@@ -2052,9 +2291,17 @@ fn parse_reaction(
     group_id: Option<&str>,
 ) -> Option<SignalEvent> {
     let emoji = reaction.get("emoji").and_then(|v| v.as_str())?.to_string();
-    let target_author = reaction.get("targetAuthor").and_then(|v| v.as_str())?.to_string();
-    let target_timestamp = reaction.get("targetSentTimestamp").and_then(|v| v.as_i64())?;
-    let is_remove = reaction.get("isRemove").and_then(|v| v.as_bool()).unwrap_or(false);
+    let target_author = reaction
+        .get("targetAuthor")
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let target_timestamp = reaction
+        .get("targetSentTimestamp")
+        .and_then(|v| v.as_i64())?;
+    let is_remove = reaction
+        .get("isRemove")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let sender = envelope
         .get("sourceNumber")
@@ -2088,9 +2335,17 @@ fn parse_reaction_sync(
     reaction: &serde_json::Value,
 ) -> Option<SignalEvent> {
     let emoji = reaction.get("emoji").and_then(|v| v.as_str())?.to_string();
-    let target_author = reaction.get("targetAuthor").and_then(|v| v.as_str())?.to_string();
-    let target_timestamp = reaction.get("targetSentTimestamp").and_then(|v| v.as_i64())?;
-    let is_remove = reaction.get("isRemove").and_then(|v| v.as_bool()).unwrap_or(false);
+    let target_author = reaction
+        .get("targetAuthor")
+        .and_then(|v| v.as_str())?
+        .to_string();
+    let target_timestamp = reaction
+        .get("targetSentTimestamp")
+        .and_then(|v| v.as_i64())?;
+    let is_remove = reaction
+        .get("isRemove")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let sender = envelope
         .get("sourceNumber")
@@ -2130,7 +2385,9 @@ fn parse_edit_message(
     is_outgoing: bool,
     destination: Option<&str>,
 ) -> Option<SignalEvent> {
-    let target_timestamp = edit_msg.get("targetSentTimestamp").and_then(|v| v.as_i64())?;
+    let target_timestamp = edit_msg
+        .get("targetSentTimestamp")
+        .and_then(|v| v.as_i64())?;
     let data = edit_msg.get("dataMessage")?;
     let new_body = data.get("message").and_then(|v| v.as_str())?.to_string();
     let new_timestamp = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -2151,16 +2408,14 @@ fn parse_edit_message(
         .and_then(|g| g.get("groupId"))
         .and_then(|v| v.as_str());
 
-    let conv_id = group_id
-        .map(|g| g.to_string())
-        .or_else(|| {
-            if is_outgoing {
-                // For outgoing sync edits, use destination (recipient) as conv_id
-                destination.map(|d| d.to_string())
-            } else {
-                Some(sender.clone())
-            }
-        })?;
+    let conv_id = group_id.map(|g| g.to_string()).or_else(|| {
+        if is_outgoing {
+            // For outgoing sync edits, use destination (recipient) as conv_id
+            destination.map(|d| d.to_string())
+        } else {
+            Some(sender.clone())
+        }
+    })?;
 
     Some(SignalEvent::EditReceived {
         conv_id,
@@ -2192,7 +2447,11 @@ fn parse_attachment(
     let mut effective_name = filename.clone().unwrap_or_else(|| {
         let ext = mime_to_ext(&content_type);
         // Use last 8 chars of attachment ID for uniqueness
-        let short_id = if id.len() > 8 { &id[id.len() - 8..] } else { &id };
+        let short_id = if id.len() > 8 {
+            &id[id.len() - 8..]
+        } else {
+            &id
+        };
         format!("{short_id}.{ext}")
     });
 
@@ -2207,19 +2466,25 @@ fn parse_attachment(
 
     // Sanitize filename: strip path separators and traversal sequences
     // to prevent writes outside the download directory.
-    effective_name = effective_name
-        .replace(['/', '\\'], "_")
-        .replace("..", "_");
+    effective_name = effective_name.replace(['/', '\\'], "_").replace("..", "_");
     if effective_name.is_empty() {
-        let short_id = if id.len() > 8 { &id[id.len() - 8..] } else { &id };
+        let short_id = if id.len() > 8 {
+            &id[id.len() - 8..]
+        } else {
+            &id
+        };
         effective_name = format!("{short_id}.bin");
     }
 
     let dest = download_dir.join(&effective_name);
 
     // Defense-in-depth: verify resolved path stays within download directory.
-    let canon_dir = download_dir.canonicalize().unwrap_or_else(|_| download_dir.to_path_buf());
-    let canon_dest = dest.canonicalize().unwrap_or_else(|_| canon_dir.join(&effective_name));
+    let canon_dir = download_dir
+        .canonicalize()
+        .unwrap_or_else(|_| download_dir.to_path_buf());
+    let canon_dest = dest
+        .canonicalize()
+        .unwrap_or_else(|_| canon_dir.join(&effective_name));
     if !canon_dest.starts_with(&canon_dir) {
         return None;
     }
@@ -2241,7 +2506,8 @@ fn parse_attachment(
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(download_dir, std::fs::Permissions::from_mode(0o700));
+                let _ =
+                    std::fs::set_permissions(download_dir, std::fs::Permissions::from_mode(0o700));
             }
             match std::fs::copy(&src, &dest) {
                 Ok(_) => Some(dest.to_string_lossy().to_string()),
@@ -2274,12 +2540,26 @@ fn parse_link_previews(
     arr.iter()
         .filter_map(|p| {
             let url = p.get("url").and_then(|v| v.as_str())?.to_string();
-            let title = p.get("title").and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
-            let description = p.get("description").and_then(|v| v.as_str()).filter(|s| !s.is_empty()).map(|s| s.to_string());
-            let image_path = p.get("image")
+            let title = p
+                .get("title")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            let description = p
+                .get("description")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string());
+            let image_path = p
+                .get("image")
                 .and_then(|img| parse_attachment(img, download_dir))
                 .and_then(|att| att.local_path);
-            Some(LinkPreview { url, title, description, image_path })
+            Some(LinkPreview {
+                url,
+                title,
+                description,
+                image_path,
+            })
         })
         .collect()
 }
@@ -2296,7 +2576,12 @@ fn find_signal_cli_attachment(id: &str, content_type: &str) -> Option<std::path:
     }
     // Also check ~/.local/share (POSIX-style, common on MSYS/WSL)
     if let Some(home) = dirs::home_dir() {
-        candidates.push(home.join(".local").join("share").join("signal-cli").join("attachments"));
+        candidates.push(
+            home.join(".local")
+                .join("share")
+                .join("signal-cli")
+                .join("attachments"),
+        );
     }
 
     let ext = mime_to_ext(content_type);
@@ -2380,7 +2665,11 @@ fn parse_mentions(data: &serde_json::Value) -> Vec<Mention> {
                     .or_else(|| r.get("mentionUuid"))
                     .and_then(|v| v.as_str())?
                     .to_string();
-                Some(Mention { start, length, uuid })
+                Some(Mention {
+                    start,
+                    length,
+                    uuid,
+                })
             })
             .collect()
     })
@@ -2410,7 +2699,11 @@ fn parse_text_styles(data: &serde_json::Value) -> Vec<TextStyle> {
                     "SPOILER" => StyleType::Spoiler,
                     _ => return None,
                 };
-                Some(TextStyle { start, length, style })
+                Some(TextStyle {
+                    start,
+                    length,
+                    style,
+                })
             })
             .collect()
     })
@@ -2527,10 +2820,13 @@ mod tests {
                 assert_eq!(groups[0].id, "group1");
                 assert_eq!(groups[0].name, "Family");
                 assert_eq!(groups[0].members, vec!["+1", "+2"]);
-                assert_eq!(groups[0].member_uuids, vec![
-                    ("+1".to_string(), "uuid-1".to_string()),
-                    ("+2".to_string(), "uuid-2".to_string()),
-                ]);
+                assert_eq!(
+                    groups[0].member_uuids,
+                    vec![
+                        ("+1".to_string(), "uuid-1".to_string()),
+                        ("+2".to_string(), "uuid-2".to_string()),
+                    ]
+                );
                 assert_eq!(groups[1].id, "group2");
                 assert_eq!(groups[1].name, "Work");
                 assert!(groups[1].members.is_empty());
@@ -2637,7 +2933,11 @@ mod tests {
         }));
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
-            SignalEvent::ReceiptReceived { sender, receipt_type, timestamps } => {
+            SignalEvent::ReceiptReceived {
+                sender,
+                receipt_type,
+                timestamps,
+            } => {
                 assert_eq!(sender, "+15551234567");
                 assert_eq!(receipt_type, expected_type);
                 assert_eq!(timestamps.len(), expected_count);
@@ -2678,7 +2978,13 @@ mod tests {
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
             SignalEvent::ReactionReceived {
-                conv_id, emoji, sender, sender_name, target_author, target_timestamp, is_remove,
+                conv_id,
+                emoji,
+                sender,
+                sender_name,
+                target_author,
+                target_timestamp,
+                is_remove,
             } => {
                 assert_eq!(conv_id, "+15551234567");
                 assert_eq!(emoji, "👍");
@@ -2793,7 +3099,11 @@ mod tests {
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
             SignalEvent::ReactionReceived {
-                conv_id, emoji, sender, target_author, ..
+                conv_id,
+                emoji,
+                sender,
+                target_author,
+                ..
             } => {
                 assert_eq!(conv_id, "+15559876543");
                 assert_eq!(emoji, "😂");
@@ -3053,7 +3363,12 @@ mod tests {
         }));
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
-            SignalEvent::ExpirationTimerChanged { conv_id, seconds, body, .. } => {
+            SignalEvent::ExpirationTimerChanged {
+                conv_id,
+                seconds,
+                body,
+                ..
+            } => {
                 assert_eq!(conv_id, "+15551234567");
                 assert_eq!(seconds, expire_seconds);
                 assert_eq!(body, expected_body);
@@ -3087,8 +3402,14 @@ mod tests {
         match event {
             SignalEvent::ReadSyncReceived { read_messages } => {
                 assert_eq!(read_messages.len(), 2);
-                assert_eq!(read_messages[0], ("+15551234567".to_string(), 1700000000001));
-                assert_eq!(read_messages[1], ("+15559876543".to_string(), 1700000000002));
+                assert_eq!(
+                    read_messages[0],
+                    ("+15551234567".to_string(), 1700000000001)
+                );
+                assert_eq!(
+                    read_messages[1],
+                    ("+15559876543".to_string(), 1700000000002)
+                );
             }
             _ => panic!("Expected ReadSyncReceived, got {:?}", event),
         }
@@ -3369,7 +3690,11 @@ mod tests {
         }));
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
-            SignalEvent::PollCreated { conv_id, timestamp, poll_data } => {
+            SignalEvent::PollCreated {
+                conv_id,
+                timestamp,
+                poll_data,
+            } => {
                 assert_eq!(conv_id, "+15551234567");
                 assert_eq!(timestamp, 1700000000000);
                 assert_eq!(poll_data.question, "What for lunch?");
@@ -3403,7 +3728,14 @@ mod tests {
         }));
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
-            SignalEvent::PollVoteReceived { conv_id, target_timestamp, voter, option_indexes, vote_count, .. } => {
+            SignalEvent::PollVoteReceived {
+                conv_id,
+                target_timestamp,
+                voter,
+                option_indexes,
+                vote_count,
+                ..
+            } => {
                 assert_eq!(conv_id, "+15559876543");
                 assert_eq!(target_timestamp, 1700000000000);
                 assert_eq!(voter, "+15559876543");
@@ -3431,7 +3763,10 @@ mod tests {
         }));
         let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
         match event {
-            SignalEvent::PollTerminated { conv_id, target_timestamp } => {
+            SignalEvent::PollTerminated {
+                conv_id,
+                target_timestamp,
+            } => {
                 assert_eq!(conv_id, "+15551234567");
                 assert_eq!(target_timestamp, 1700000000000);
             }
@@ -3458,7 +3793,10 @@ mod tests {
         assert_eq!(previews.len(), 1);
         assert_eq!(previews[0].url, "https://example.com/article");
         assert_eq!(previews[0].title.as_deref(), Some("Example Article"));
-        assert_eq!(previews[0].description.as_deref(), Some("An interesting article"));
+        assert_eq!(
+            previews[0].description.as_deref(),
+            Some("An interesting article")
+        );
     }
 
     #[test]
@@ -3544,7 +3882,12 @@ mod tests {
         });
         let event = parse_signal_event(&make_resp(params), std::path::Path::new("/tmp")).unwrap();
         match event {
-            SignalEvent::TypingIndicator { sender, group_id, is_typing, .. } => {
+            SignalEvent::TypingIndicator {
+                sender,
+                group_id,
+                is_typing,
+                ..
+            } => {
                 assert_eq!(sender, "+15551234567");
                 assert_eq!(group_id, Some("group-abc".to_string()));
                 assert!(is_typing);

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -213,7 +213,7 @@ pub enum SignalEvent {
 impl SignalEvent {
     /// Format this event for debug logging with PII redacted.
     pub fn redacted_summary(&self) -> String {
-        use crate::debug_log::{mask_phone, mask_body};
+        use crate::debug_log::{mask_body, mask_phone};
         match self {
             Self::MessageReceived(msg) => format!(
                 "MessageReceived(from={}, body={}, attachments={}, group={})",
@@ -364,8 +364,8 @@ pub struct JsonRpcError {
 #[derive(Debug, Clone)]
 pub struct Mention {
     pub start: usize,  // UTF-16 offset in body
-    pub length: usize,  // Always 1 (U+FFFC)
-    pub uuid: String,   // ACI UUID of mentioned user
+    pub length: usize, // Always 1 (U+FFFC)
+    pub uuid: String,  // ACI UUID of mentioned user
 }
 
 /// A text style range from signal-cli's textStyles/bodyRanges array.

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -126,17 +126,17 @@ pub fn default_theme() -> Theme {
 fn catppuccin_mocha() -> Theme {
     Theme {
         name: "Catppuccin Mocha".into(),
-        bg: Color::Rgb(30, 30, 46),          // base
-        bg_selected: Color::Rgb(69, 71, 90), // surface1
-        fg: Color::Rgb(205, 214, 244),        // text
-        fg_secondary: Color::Rgb(166, 173, 200), // subtext0
-        fg_muted: Color::Rgb(108, 112, 134),  // overlay0
-        accent: Color::Rgb(203, 166, 247),     // mauve
+        bg: Color::Rgb(30, 30, 46),                  // base
+        bg_selected: Color::Rgb(69, 71, 90),         // surface1
+        fg: Color::Rgb(205, 214, 244),               // text
+        fg_secondary: Color::Rgb(166, 173, 200),     // subtext0
+        fg_muted: Color::Rgb(108, 112, 134),         // overlay0
+        accent: Color::Rgb(203, 166, 247),           // mauve
         accent_secondary: Color::Rgb(249, 226, 175), // yellow
-        success: Color::Rgb(166, 227, 161),    // green
-        error: Color::Rgb(243, 139, 168),      // red
-        warning: Color::Rgb(249, 226, 175),    // yellow
-        sender_self: Color::Rgb(166, 227, 161), // green
+        success: Color::Rgb(166, 227, 161),          // green
+        error: Color::Rgb(243, 139, 168),            // red
+        warning: Color::Rgb(249, 226, 175),          // yellow
+        sender_self: Color::Rgb(166, 227, 161),      // green
         sender_palette: [
             Color::Rgb(137, 180, 250), // blue
             Color::Rgb(245, 194, 231), // pink
@@ -147,14 +147,14 @@ fn catppuccin_mocha() -> Theme {
             Color::Rgb(148, 226, 213), // teal
             Color::Rgb(203, 166, 247), // mauve
         ],
-        link: Color::Rgb(137, 180, 250),       // blue
-        mention: Color::Rgb(203, 166, 247),    // mauve
-        quote: Color::Rgb(108, 112, 134),      // overlay0
-        system_msg: Color::Rgb(108, 112, 134), // overlay0
+        link: Color::Rgb(137, 180, 250),         // blue
+        mention: Color::Rgb(203, 166, 247),      // mauve
+        quote: Color::Rgb(108, 112, 134),        // overlay0
+        system_msg: Color::Rgb(108, 112, 134),   // overlay0
         msg_selected_bg: Color::Rgb(49, 50, 68), // surface0
         input_insert: Color::Rgb(203, 166, 247), // mauve
         input_normal: Color::Rgb(249, 226, 175), // yellow
-        statusbar_bg: Color::Rgb(24, 24, 37),  // mantle
+        statusbar_bg: Color::Rgb(24, 24, 37),    // mantle
         statusbar_fg: Color::Rgb(205, 214, 244), // text
         receipt_failed: Color::Rgb(243, 139, 168),
         receipt_sending: Color::Rgb(108, 112, 134),
@@ -168,17 +168,17 @@ fn catppuccin_mocha() -> Theme {
 fn catppuccin_latte() -> Theme {
     Theme {
         name: "Catppuccin Latte".into(),
-        bg: Color::Rgb(239, 241, 245),        // base
-        bg_selected: Color::Rgb(188, 192, 204), // surface1
-        fg: Color::Rgb(76, 79, 105),           // text
-        fg_secondary: Color::Rgb(108, 111, 133), // subtext0
-        fg_muted: Color::Rgb(140, 143, 161),   // overlay0
-        accent: Color::Rgb(136, 57, 239),      // mauve
+        bg: Color::Rgb(239, 241, 245),              // base
+        bg_selected: Color::Rgb(188, 192, 204),     // surface1
+        fg: Color::Rgb(76, 79, 105),                // text
+        fg_secondary: Color::Rgb(108, 111, 133),    // subtext0
+        fg_muted: Color::Rgb(140, 143, 161),        // overlay0
+        accent: Color::Rgb(136, 57, 239),           // mauve
         accent_secondary: Color::Rgb(223, 142, 29), // yellow
-        success: Color::Rgb(64, 160, 43),       // green
-        error: Color::Rgb(210, 15, 57),         // red
-        warning: Color::Rgb(223, 142, 29),      // yellow
-        sender_self: Color::Rgb(64, 160, 43),   // green
+        success: Color::Rgb(64, 160, 43),           // green
+        error: Color::Rgb(210, 15, 57),             // red
+        warning: Color::Rgb(223, 142, 29),          // yellow
+        sender_self: Color::Rgb(64, 160, 43),       // green
         sender_palette: [
             Color::Rgb(30, 102, 245),  // blue
             Color::Rgb(234, 118, 203), // pink
@@ -189,15 +189,15 @@ fn catppuccin_latte() -> Theme {
             Color::Rgb(23, 146, 153),  // teal
             Color::Rgb(136, 57, 239),  // mauve
         ],
-        link: Color::Rgb(30, 102, 245),         // blue
-        mention: Color::Rgb(136, 57, 239),      // mauve
-        quote: Color::Rgb(140, 143, 161),       // overlay0
-        system_msg: Color::Rgb(140, 143, 161),  // overlay0
+        link: Color::Rgb(30, 102, 245),             // blue
+        mention: Color::Rgb(136, 57, 239),          // mauve
+        quote: Color::Rgb(140, 143, 161),           // overlay0
+        system_msg: Color::Rgb(140, 143, 161),      // overlay0
         msg_selected_bg: Color::Rgb(204, 208, 218), // surface0
-        input_insert: Color::Rgb(136, 57, 239), // mauve
-        input_normal: Color::Rgb(223, 142, 29), // yellow
-        statusbar_bg: Color::Rgb(230, 233, 239), // mantle
-        statusbar_fg: Color::Rgb(76, 79, 105),  // text
+        input_insert: Color::Rgb(136, 57, 239),     // mauve
+        input_normal: Color::Rgb(223, 142, 29),     // yellow
+        statusbar_bg: Color::Rgb(230, 233, 239),    // mantle
+        statusbar_fg: Color::Rgb(76, 79, 105),      // text
         receipt_failed: Color::Rgb(210, 15, 57),
         receipt_sending: Color::Rgb(140, 143, 161),
         receipt_sent: Color::Rgb(140, 143, 161),
@@ -210,17 +210,17 @@ fn catppuccin_latte() -> Theme {
 fn dracula() -> Theme {
     Theme {
         name: "Dracula".into(),
-        bg: Color::Rgb(40, 42, 54),           // background
-        bg_selected: Color::Rgb(68, 71, 90),  // current line
-        fg: Color::Rgb(248, 248, 242),         // foreground
-        fg_secondary: Color::Rgb(189, 147, 249), // purple (secondary info)
-        fg_muted: Color::Rgb(98, 114, 164),   // comment
-        accent: Color::Rgb(189, 147, 249),     // purple
+        bg: Color::Rgb(40, 42, 54),                  // background
+        bg_selected: Color::Rgb(68, 71, 90),         // current line
+        fg: Color::Rgb(248, 248, 242),               // foreground
+        fg_secondary: Color::Rgb(189, 147, 249),     // purple (secondary info)
+        fg_muted: Color::Rgb(98, 114, 164),          // comment
+        accent: Color::Rgb(189, 147, 249),           // purple
         accent_secondary: Color::Rgb(241, 250, 140), // yellow
-        success: Color::Rgb(80, 250, 123),     // green
-        error: Color::Rgb(255, 85, 85),        // red
-        warning: Color::Rgb(241, 250, 140),    // yellow
-        sender_self: Color::Rgb(80, 250, 123), // green
+        success: Color::Rgb(80, 250, 123),           // green
+        error: Color::Rgb(255, 85, 85),              // red
+        warning: Color::Rgb(241, 250, 140),          // yellow
+        sender_self: Color::Rgb(80, 250, 123),       // green
         sender_palette: [
             Color::Rgb(139, 233, 253), // cyan
             Color::Rgb(255, 121, 198), // pink
@@ -231,10 +231,10 @@ fn dracula() -> Theme {
             Color::Rgb(255, 184, 108), // orange
             Color::Rgb(139, 233, 253), // cyan (alt)
         ],
-        link: Color::Rgb(139, 233, 253),       // cyan
-        mention: Color::Rgb(255, 121, 198),    // pink
-        quote: Color::Rgb(98, 114, 164),       // comment
-        system_msg: Color::Rgb(98, 114, 164),  // comment
+        link: Color::Rgb(139, 233, 253),      // cyan
+        mention: Color::Rgb(255, 121, 198),   // pink
+        quote: Color::Rgb(98, 114, 164),      // comment
+        system_msg: Color::Rgb(98, 114, 164), // comment
         msg_selected_bg: Color::Rgb(55, 57, 69),
         input_insert: Color::Rgb(189, 147, 249), // purple
         input_normal: Color::Rgb(241, 250, 140), // yellow
@@ -252,17 +252,17 @@ fn dracula() -> Theme {
 fn nord() -> Theme {
     Theme {
         name: "Nord".into(),
-        bg: Color::Rgb(46, 52, 64),           // nord0 polar night
-        bg_selected: Color::Rgb(67, 76, 94),  // nord2
-        fg: Color::Rgb(236, 239, 244),         // nord6 snow storm
-        fg_secondary: Color::Rgb(216, 222, 233), // nord4
-        fg_muted: Color::Rgb(76, 86, 106),    // nord3
-        accent: Color::Rgb(136, 192, 208),     // nord8 frost
+        bg: Color::Rgb(46, 52, 64),                  // nord0 polar night
+        bg_selected: Color::Rgb(67, 76, 94),         // nord2
+        fg: Color::Rgb(236, 239, 244),               // nord6 snow storm
+        fg_secondary: Color::Rgb(216, 222, 233),     // nord4
+        fg_muted: Color::Rgb(76, 86, 106),           // nord3
+        accent: Color::Rgb(136, 192, 208),           // nord8 frost
         accent_secondary: Color::Rgb(235, 203, 139), // nord13 aurora yellow
-        success: Color::Rgb(163, 190, 140),    // nord14 aurora green
-        error: Color::Rgb(191, 97, 106),       // nord11 aurora red
-        warning: Color::Rgb(235, 203, 139),    // nord13 aurora yellow
-        sender_self: Color::Rgb(163, 190, 140), // nord14
+        success: Color::Rgb(163, 190, 140),          // nord14 aurora green
+        error: Color::Rgb(191, 97, 106),             // nord11 aurora red
+        warning: Color::Rgb(235, 203, 139),          // nord13 aurora yellow
+        sender_self: Color::Rgb(163, 190, 140),      // nord14
         sender_palette: [
             Color::Rgb(136, 192, 208), // nord8
             Color::Rgb(180, 142, 173), // nord15 purple
@@ -273,14 +273,14 @@ fn nord() -> Theme {
             Color::Rgb(143, 188, 187), // nord7
             Color::Rgb(208, 135, 112), // nord12 orange
         ],
-        link: Color::Rgb(129, 161, 193),       // nord9
-        mention: Color::Rgb(180, 142, 173),    // nord15
-        quote: Color::Rgb(76, 86, 106),        // nord3
-        system_msg: Color::Rgb(76, 86, 106),   // nord3
+        link: Color::Rgb(129, 161, 193),         // nord9
+        mention: Color::Rgb(180, 142, 173),      // nord15
+        quote: Color::Rgb(76, 86, 106),          // nord3
+        system_msg: Color::Rgb(76, 86, 106),     // nord3
         msg_selected_bg: Color::Rgb(59, 66, 82), // nord1
         input_insert: Color::Rgb(136, 192, 208), // nord8
         input_normal: Color::Rgb(235, 203, 139), // nord13
-        statusbar_bg: Color::Rgb(59, 66, 82),  // nord1
+        statusbar_bg: Color::Rgb(59, 66, 82),    // nord1
         statusbar_fg: Color::Rgb(236, 239, 244), // nord6
         receipt_failed: Color::Rgb(191, 97, 106),
         receipt_sending: Color::Rgb(76, 86, 106),
@@ -294,17 +294,17 @@ fn nord() -> Theme {
 fn gruvbox_dark() -> Theme {
     Theme {
         name: "Gruvbox Dark".into(),
-        bg: Color::Rgb(40, 40, 40),           // bg
-        bg_selected: Color::Rgb(80, 73, 69),  // bg2
-        fg: Color::Rgb(235, 219, 178),         // fg
-        fg_secondary: Color::Rgb(189, 174, 147), // fg3
-        fg_muted: Color::Rgb(124, 111, 100),  // bg4
-        accent: Color::Rgb(254, 128, 25),      // orange
+        bg: Color::Rgb(40, 40, 40),                 // bg
+        bg_selected: Color::Rgb(80, 73, 69),        // bg2
+        fg: Color::Rgb(235, 219, 178),              // fg
+        fg_secondary: Color::Rgb(189, 174, 147),    // fg3
+        fg_muted: Color::Rgb(124, 111, 100),        // bg4
+        accent: Color::Rgb(254, 128, 25),           // orange
         accent_secondary: Color::Rgb(250, 189, 47), // yellow
-        success: Color::Rgb(184, 187, 38),     // green
-        error: Color::Rgb(251, 73, 52),        // red
-        warning: Color::Rgb(250, 189, 47),     // yellow
-        sender_self: Color::Rgb(184, 187, 38), // green
+        success: Color::Rgb(184, 187, 38),          // green
+        error: Color::Rgb(251, 73, 52),             // red
+        warning: Color::Rgb(250, 189, 47),          // yellow
+        sender_self: Color::Rgb(184, 187, 38),      // green
         sender_palette: [
             Color::Rgb(131, 165, 152), // aqua
             Color::Rgb(211, 134, 155), // purple
@@ -315,14 +315,14 @@ fn gruvbox_dark() -> Theme {
             Color::Rgb(254, 128, 25),  // orange
             Color::Rgb(142, 192, 124), // bright green
         ],
-        link: Color::Rgb(131, 165, 152),       // aqua
-        mention: Color::Rgb(211, 134, 155),    // purple
-        quote: Color::Rgb(124, 111, 100),      // bg4
-        system_msg: Color::Rgb(124, 111, 100), // bg4
+        link: Color::Rgb(131, 165, 152),         // aqua
+        mention: Color::Rgb(211, 134, 155),      // purple
+        quote: Color::Rgb(124, 111, 100),        // bg4
+        system_msg: Color::Rgb(124, 111, 100),   // bg4
         msg_selected_bg: Color::Rgb(60, 56, 54), // bg1
-        input_insert: Color::Rgb(254, 128, 25), // orange
-        input_normal: Color::Rgb(250, 189, 47), // yellow
-        statusbar_bg: Color::Rgb(50, 48, 47),  // bg0_h
+        input_insert: Color::Rgb(254, 128, 25),  // orange
+        input_normal: Color::Rgb(250, 189, 47),  // yellow
+        statusbar_bg: Color::Rgb(50, 48, 47),    // bg0_h
         statusbar_fg: Color::Rgb(235, 219, 178), // fg
         receipt_failed: Color::Rgb(251, 73, 52),
         receipt_sending: Color::Rgb(124, 111, 100),
@@ -580,12 +580,10 @@ fn string_to_color(s: &str) -> Result<Color, String> {
     // Hex: #rrggbb
     if let Some(hex) = s.strip_prefix('#') {
         if hex.len() == 6 {
-            let r = u8::from_str_radix(&hex[0..2], 16)
-                .map_err(|e| format!("bad hex red: {e}"))?;
-            let g = u8::from_str_radix(&hex[2..4], 16)
-                .map_err(|e| format!("bad hex green: {e}"))?;
-            let b = u8::from_str_radix(&hex[4..6], 16)
-                .map_err(|e| format!("bad hex blue: {e}"))?;
+            let r = u8::from_str_radix(&hex[0..2], 16).map_err(|e| format!("bad hex red: {e}"))?;
+            let g =
+                u8::from_str_radix(&hex[2..4], 16).map_err(|e| format!("bad hex green: {e}"))?;
+            let b = u8::from_str_radix(&hex[4..6], 16).map_err(|e| format!("bad hex blue: {e}"))?;
             return Ok(Color::Rgb(r, g, b));
         }
         return Err(format!("hex color must be 6 digits: {s}"));

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -10,13 +10,16 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, SettingDef, VisibleImage, PIN_DURATIONS, QUICK_REACTIONS, SETTINGS};
+use crate::app::{
+    App, AutocompleteMode, GroupMenuState, InputMode, SettingDef, VisibleImage, PIN_DURATIONS,
+    QUICK_REACTIONS, SETTINGS,
+};
 use crate::domain::CATEGORIES;
+use crate::image_render::{self, ImageProtocol};
+use crate::input::{format_compact_duration, COMMANDS};
 use crate::keybindings::{self, BindingMode, KeyAction};
 use crate::list_overlay;
 use crate::signal::types::{MessageStatus, PollData, PollVote, Reaction, StyleType, TrustLevel};
-use crate::image_render::{self, ImageProtocol};
-use crate::input::{COMMANDS, format_compact_duration};
 use crate::theme::Theme;
 
 // Layout constants
@@ -52,7 +55,9 @@ fn emoji_to_text(input: &str) -> String {
         candidate.push(c);
         // Consume variation selectors and ZWJ sequences
         while let Some(&next) = chars.peek() {
-            if next == '\u{fe0f}' || next == '\u{200d}' || next == '\u{20e3}'
+            if next == '\u{fe0f}'
+                || next == '\u{200d}'
+                || next == '\u{20e3}'
                 || ('\u{1f3fb}'..='\u{1f3ff}').contains(&next)
             {
                 candidate.push(chars.next().unwrap());
@@ -80,7 +85,8 @@ fn emoji_to_text(input: &str) -> String {
                 "\u{1f60d}" => "<3_<3",
                 "\u{2764}\u{fe0f}" | "\u{2764}" => "<3",
                 "\u{1f495}" | "\u{1f496}" | "\u{1f497}" | "\u{1f498}" => "<3",
-                "\u{1f44d}" | "\u{1f44d}\u{1f3fb}" | "\u{1f44d}\u{1f3fc}" | "\u{1f44d}\u{1f3fd}" | "\u{1f44d}\u{1f3fe}" | "\u{1f44d}\u{1f3ff}" => "+1",
+                "\u{1f44d}" | "\u{1f44d}\u{1f3fb}" | "\u{1f44d}\u{1f3fc}"
+                | "\u{1f44d}\u{1f3fd}" | "\u{1f44d}\u{1f3fe}" | "\u{1f44d}\u{1f3ff}" => "+1",
                 "\u{1f44e}" => "-1",
                 "\u{1f61b}" | "\u{1f61c}" | "\u{1f61d}" => ":P",
                 "\u{1f610}" | "\u{1f611}" => ":|",
@@ -108,14 +114,19 @@ fn emoji_to_text(input: &str) -> String {
 }
 
 /// Map a MessageStatus to its display symbol and color.
-pub(crate) fn status_symbol(status: MessageStatus, nerd_fonts: bool, color: bool, theme: &Theme) -> (&'static str, Color) {
+pub(crate) fn status_symbol(
+    status: MessageStatus,
+    nerd_fonts: bool,
+    color: bool,
+    theme: &Theme,
+) -> (&'static str, Color) {
     let (unicode_sym, nerd_sym, colored) = match status {
-        MessageStatus::Failed   => ("\u{2717}", "\u{f055c}", theme.receipt_failed),
-        MessageStatus::Sending  => ("\u{25cc}", "\u{f0996}", theme.receipt_sending),
-        MessageStatus::Sent     => ("\u{25cb}", "\u{f0954}", theme.receipt_sent),
-        MessageStatus::Delivered=> ("\u{2713}", "\u{f012c}", theme.receipt_delivered),
-        MessageStatus::Read     => ("\u{25cf}", "\u{f012d}", theme.receipt_read),
-        MessageStatus::Viewed   => ("\u{25c9}", "\u{f0208}", theme.receipt_viewed),
+        MessageStatus::Failed => ("\u{2717}", "\u{f055c}", theme.receipt_failed),
+        MessageStatus::Sending => ("\u{25cc}", "\u{f0996}", theme.receipt_sending),
+        MessageStatus::Sent => ("\u{25cb}", "\u{f0954}", theme.receipt_sent),
+        MessageStatus::Delivered => ("\u{2713}", "\u{f012c}", theme.receipt_delivered),
+        MessageStatus::Read => ("\u{25cf}", "\u{f012d}", theme.receipt_read),
+        MessageStatus::Viewed => ("\u{25c9}", "\u{f0208}", theme.receipt_viewed),
     };
     let sym = if nerd_fonts { nerd_sym } else { unicode_sym };
     let fg = if color { colored } else { theme.fg_muted };
@@ -127,7 +138,9 @@ pub(crate) fn sender_color(name: &str, theme: &Theme) -> Color {
     if name == "you" {
         return theme.sender_self;
     }
-    let hash: u32 = name.bytes().fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
+    let hash: u32 = name
+        .bytes()
+        .fold(0u32, |acc, b| acc.wrapping_mul(31).wrapping_add(b as u32));
     theme.sender_palette[(hash as usize) % theme.sender_palette.len()]
 }
 
@@ -158,7 +171,11 @@ pub(crate) fn build_separator(label: &str, width: usize, style: Style) -> Line<'
 /// Create a centered popup overlay: clears the area, returns the Rect and a styled Block.
 /// Preferred width/height are clamped to fit within the terminal.
 fn centered_popup(
-    frame: &mut Frame, area: Rect, pref_width: u16, pref_height: u16, title: &str,
+    frame: &mut Frame,
+    area: Rect,
+    pref_width: u16,
+    pref_height: u16,
+    title: &str,
     theme: &Theme,
 ) -> (Rect, Block<'static>) {
     let w = pref_width.min(area.width.saturating_sub(4));
@@ -172,7 +189,11 @@ fn centered_popup(
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.accent))
         .title(title.to_string())
-        .title_style(Style::default().fg(theme.accent).add_modifier(Modifier::BOLD))
+        .title_style(
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        )
         .style(Style::default().bg(theme.bg));
     (popup_area, block)
 }
@@ -272,7 +293,8 @@ fn collect_link_regions(buf: &Buffer, area: Rect, link_color: Color) -> Vec<Link
 
             // Capture background color from the first cell of the link run so
             // emit_osc8_links can preserve it (e.g. highlight bg on selection).
-            let bg = buf.cell(Position::new(start_x, y))
+            let bg = buf
+                .cell(Position::new(start_x, y))
                 .and_then(|c| c.style().bg);
             regions.push(LinkRegion {
                 x: start_x,
@@ -370,7 +392,9 @@ fn styled_uri_spans(
                     .unwrap_or(uri_slice.len());
                 let abs_end = abs_start + uri_len;
                 // Only add if not overlapping a mention region
-                let overlaps = regions.iter().any(|(ms, me, _)| abs_start < *me && abs_end > *ms);
+                let overlaps = regions
+                    .iter()
+                    .any(|(ms, me, _)| abs_start < *me && abs_end > *ms);
                 if !overlaps {
                     regions.push((abs_start, abs_end, link_style));
                 }
@@ -461,7 +485,9 @@ fn styled_uri_spans(
                     match st {
                         StyleType::Bold => style = style.add_modifier(Modifier::BOLD),
                         StyleType::Italic => style = style.add_modifier(Modifier::ITALIC),
-                        StyleType::Strikethrough => style = style.add_modifier(Modifier::CROSSED_OUT),
+                        StyleType::Strikethrough => {
+                            style = style.add_modifier(Modifier::CROSSED_OUT)
+                        }
                         StyleType::Monospace => style = style.fg(theme.fg_muted),
                         StyleType::Spoiler => {} // handled above
                     }
@@ -503,9 +529,23 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     let input_area = if show_sidebar {
         let (sidebar_idx, chat_idx, constraints) = if app.sidebar_on_right {
-            (1, 0, [Constraint::Min(MIN_CHAT_WIDTH), Constraint::Length(app.sidebar_width)])
+            (
+                1,
+                0,
+                [
+                    Constraint::Min(MIN_CHAT_WIDTH),
+                    Constraint::Length(app.sidebar_width),
+                ],
+            )
         } else {
-            (0, 1, [Constraint::Length(app.sidebar_width), Constraint::Min(MIN_CHAT_WIDTH)])
+            (
+                0,
+                1,
+                [
+                    Constraint::Length(app.sidebar_width),
+                    Constraint::Min(MIN_CHAT_WIDTH),
+                ],
+            )
         };
         let horizontal = Layout::default()
             .direction(Direction::Horizontal)
@@ -662,11 +702,14 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
             app.sidebar_filtered.clone()
         }
     } else {
-        app.store.conversation_order
+        app.store
+            .conversation_order
             .iter()
             .filter(|id| {
                 app.active_conversation.as_ref() == Some(id)
-                    || app.store.conversations
+                    || app
+                        .store
+                        .conversations
                         .get(*id)
                         .is_some_and(|c| !c.is_stale())
             })
@@ -693,7 +736,9 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
             if is_active {
                 spans.push(Span::styled(
                     "▸ ",
-                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD),
                 ));
             } else {
                 spans.push(Span::raw("  "));
@@ -710,18 +755,13 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
 
             // Group prefix (dimmed #)
             if conv.is_group {
-                spans.push(Span::styled(
-                    "#",
-                    Style::default().fg(theme.fg_muted),
-                ));
+                spans.push(Span::styled("#", Style::default().fg(theme.fg_muted)));
             }
 
             // Conversation name
             let is_muted = app.muted_conversations.contains(id);
             let name_style = if is_active {
-                Style::default()
-                    .fg(theme.fg)
-                    .add_modifier(Modifier::BOLD)
+                Style::default().fg(theme.fg).add_modifier(Modifier::BOLD)
             } else if has_unread {
                 Style::default().fg(theme.warning)
             } else if is_muted {
@@ -749,7 +789,11 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
         })
         .collect();
 
-    let border_side = if app.sidebar_on_right { Borders::LEFT } else { Borders::RIGHT };
+    let border_side = if app.sidebar_on_right {
+        Borders::LEFT
+    } else {
+        Borders::RIGHT
+    };
     let title = if app.sidebar_filter_active {
         if app.sidebar_filter.is_empty() {
             " /_ ".to_string()
@@ -760,9 +804,13 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
         " Chats ".to_string()
     };
     let title_style = if app.sidebar_filter_active {
-        Style::default().fg(theme.warning).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(theme.warning)
+            .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD)
     };
     let block = Block::default()
         .borders(border_side)
@@ -781,7 +829,7 @@ fn draw_chat_area(frame: &mut Frame, app: &mut App, area: Rect) -> Rect {
     let chat_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Min(1),   // messages (typing indicator rendered inside)
+            Constraint::Min(1),               // messages (typing indicator rendered inside)
             Constraint::Length(input_height), // input
         ])
         .split(area);
@@ -801,17 +849,21 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         Some(id) => {
             let conv = &app.store.conversations[id];
             let prefix = if conv.is_group { " #" } else { " " };
-            let mut spans = vec![
-                Span::styled(
-                    format!("{prefix}{} ", conv.name),
-                    Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
-                ),
-            ];
+            let mut spans = vec![Span::styled(
+                format!("{prefix}{} ", conv.name),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            )];
 
             // Timer indicator when disappearing messages are enabled
             if conv.expiration_timer > 0 {
                 let timer_label = format_compact_duration(conv.expiration_timer);
-                let icon = if app.nerd_fonts { "\u{F0150}" } else { "\u{23F1}" };
+                let icon = if app.nerd_fonts {
+                    "\u{F0150}"
+                } else {
+                    "\u{23F1}"
+                };
                 spans.push(Span::styled(
                     format!("{icon} {timer_label} "),
                     Style::default().fg(theme.fg_muted),
@@ -847,10 +899,15 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             };
             (spans, right)
         }
-        None => (vec![Span::styled(
-            " siggy ".to_string(),
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
-        )], String::new()),
+        None => (
+            vec![Span::styled(
+                " siggy ".to_string(),
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            )],
+            String::new(),
+        ),
     };
 
     let mut block = Block::default()
@@ -874,7 +931,10 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
 
     // Build pinned message banner text
     let pinned_banner_text: Option<String> = messages_ref.and_then(|msgs| {
-        let pinned: Vec<_> = msgs.iter().filter(|m| m.is_pinned && !m.is_deleted).collect();
+        let pinned: Vec<_> = msgs
+            .iter()
+            .filter(|m| m.is_pinned && !m.is_deleted)
+            .collect();
         match pinned.len() {
             0 => None,
             1 => {
@@ -900,7 +960,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         if let Some(banner) = banner_area {
             let pin_line = Line::from(Span::styled(
                 truncate(pin_text, banner.width as usize),
-                Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.warning)
+                    .add_modifier(Modifier::BOLD),
             ));
             frame.render_widget(Paragraph::new(pin_line), banner);
         }
@@ -949,7 +1011,8 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     let mut line_msg_idx: Vec<Option<usize>> = Vec::new();
 
     // Track images for native protocol overlay: (first_line_index, line_count, path)
-    let use_native = app.image.image_mode == "native" && app.image.image_protocol != ImageProtocol::Halfblock;
+    let use_native =
+        app.image.image_mode == "native" && app.image.image_protocol != ImageProtocol::Halfblock;
     let mut image_records: Vec<(usize, usize, String)> = Vec::new();
 
     for (i, msg) in visible.iter().enumerate() {
@@ -971,7 +1034,11 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                         local.format("%b %-d, %Y").to_string()
                     };
                     let label = format!(" {friendly} ");
-                    lines.push(build_separator(&label, inner_width, Style::default().fg(theme.fg_muted)));
+                    lines.push(build_separator(
+                        &label,
+                        inner_width,
+                        Style::default().fg(theme.fg_muted),
+                    ));
                     line_msg_idx.push(None);
                 }
                 prev_date = Some(date_str);
@@ -983,13 +1050,19 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             lines.push(build_separator(
                 " new messages ",
                 inner_width,
-                Style::default().fg(theme.error).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.error)
+                    .add_modifier(Modifier::BOLD),
             ));
             line_msg_idx.push(None);
         }
 
         if msg.is_system {
-            let body = if app.reactions.emoji_to_text { emoji_to_text(&msg.body) } else { msg.body.clone() };
+            let body = if app.reactions.emoji_to_text {
+                emoji_to_text(&msg.body)
+            } else {
+                msg.body.clone()
+            };
             lines.push(Line::from(Span::styled(
                 format!("  {body}"),
                 Style::default().fg(theme.system_msg),
@@ -998,7 +1071,11 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         } else {
             // Render quoted reply line above message
             if let Some(ref quote) = msg.quote {
-                let raw_body = if app.reactions.emoji_to_text { emoji_to_text(&quote.body) } else { quote.body.clone() };
+                let raw_body = if app.reactions.emoji_to_text {
+                    emoji_to_text(&quote.body)
+                } else {
+                    quote.body.clone()
+                };
                 let quote_body = truncate(&raw_body, 50);
                 lines.push(Line::from(vec![
                     Span::styled("  \u{256D} ", Style::default().fg(theme.quote)),
@@ -1008,10 +1085,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                             .fg(sender_color(&quote.author, theme))
                             .add_modifier(Modifier::BOLD),
                     ),
-                    Span::styled(
-                        format!(" {quote_body}"),
-                        Style::default().fg(theme.quote),
-                    ),
+                    Span::styled(format!(" {quote_body}"), Style::default().fg(theme.quote)),
                 ]));
                 line_msg_idx.push(Some(msg_index));
             }
@@ -1022,16 +1096,18 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             // Status symbol for outgoing messages (before timestamp)
             if app.show_receipts {
                 if let Some(status) = msg.status {
-                    let (sym, color) = status_symbol(status, app.nerd_fonts, app.color_receipts, theme);
-                    spans.push(Span::styled(
-                        format!("{sym} "),
-                        Style::default().fg(color),
-                    ));
+                    let (sym, color) =
+                        status_symbol(status, app.nerd_fonts, app.color_receipts, theme);
+                    spans.push(Span::styled(format!("{sym} "), Style::default().fg(color)));
                 }
             }
 
             if msg.expires_in_seconds > 0 {
-                let icon = if app.nerd_fonts { "\u{F0150}" } else { "\u{23F1}" };
+                let icon = if app.nerd_fonts {
+                    "\u{F0150}"
+                } else {
+                    "\u{23F1}"
+                };
                 spans.push(Span::styled(
                     format!("{icon} [{}] ", time),
                     Style::default().fg(theme.fg_muted),
@@ -1053,7 +1129,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             if msg.is_edited {
                 spans.push(Span::styled(
                     " (edited)",
-                    Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
+                    Style::default()
+                        .fg(theme.fg_muted)
+                        .add_modifier(Modifier::ITALIC),
                 ));
             }
 
@@ -1061,7 +1139,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             if msg.is_pinned {
                 spans.push(Span::styled(
                     " (pinned)",
-                    Style::default().fg(theme.warning).add_modifier(Modifier::ITALIC),
+                    Style::default()
+                        .fg(theme.warning)
+                        .add_modifier(Modifier::ITALIC),
                 ));
             }
 
@@ -1069,21 +1149,27 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 // Deleted message body
                 spans.push(Span::styled(
                     " [deleted]",
-                    Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
+                    Style::default()
+                        .fg(theme.fg_muted)
+                        .add_modifier(Modifier::ITALIC),
                 ));
             } else {
                 // Style URIs and @mentions
-                let (body_spans, hidden_url) = styled_uri_spans(&msg.body, &msg.mention_ranges, &msg.style_ranges, theme);
+                let (body_spans, hidden_url) =
+                    styled_uri_spans(&msg.body, &msg.mention_ranges, &msg.style_ranges, theme);
                 if let Some(url) = hidden_url {
                     // Collect display text for link_url_map lookup
-                    let display_text: String = body_spans.iter().map(|s| s.content.as_ref()).collect();
+                    let display_text: String =
+                        body_spans.iter().map(|s| s.content.as_ref()).collect();
                     app.image.link_url_map.insert(display_text, url);
                 }
                 spans.push(Span::raw(" ".to_string()));
                 if app.reactions.emoji_to_text {
-                    spans.extend(body_spans.into_iter().map(|s| {
-                        Span::styled(emoji_to_text(&s.content), s.style)
-                    }));
+                    spans.extend(
+                        body_spans
+                            .into_iter()
+                            .map(|s| Span::styled(emoji_to_text(&s.content), s.style)),
+                    );
                 } else {
                     spans.extend(body_spans);
                 }
@@ -1127,10 +1213,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                         // Description is a middle line; URL always follows
                         lines.push(Line::from(vec![
                             Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
-                            Span::styled(
-                                truncate(desc, 60),
-                                Style::default().fg(theme.fg_muted),
-                            ),
+                            Span::styled(truncate(desc, 60), Style::default().fg(theme.fg_muted)),
                         ]));
                         line_msg_idx.push(Some(msg_index));
                     }
@@ -1138,7 +1221,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                         Span::styled("  \u{2570} ", Style::default().fg(theme.link)),
                         Span::styled(
                             truncate(&preview.url, 60),
-                            Style::default().fg(theme.link).add_modifier(Modifier::UNDERLINED),
+                            Style::default()
+                                .fg(theme.link)
+                                .add_modifier(Modifier::UNDERLINED),
                         ),
                     ]));
                     line_msg_idx.push(Some(msg_index));
@@ -1165,7 +1250,8 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             // Render inline poll display
             if !msg.is_deleted {
                 if let Some(ref poll_data) = msg.poll_data {
-                    let poll_lines = build_poll_display(poll_data, &msg.poll_votes, &app.account, theme);
+                    let poll_lines =
+                        build_poll_display(poll_data, &msg.poll_votes, &app.account, theme);
                     for line in poll_lines {
                         lines.push(line);
                         line_msg_idx.push(Some(msg_index));
@@ -1175,7 +1261,12 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
 
             // Render reaction summary line (skip for deleted or when reactions hidden)
             if app.reactions.show_reactions && !msg.is_deleted && !msg.reactions.is_empty() {
-                lines.push(build_reaction_summary(&msg.reactions, app.reactions.verbose, app.reactions.emoji_to_text, theme));
+                lines.push(build_reaction_summary(
+                    &msg.reactions,
+                    app.reactions.verbose,
+                    app.reactions.emoji_to_text,
+                    theme,
+                ));
                 line_msg_idx.push(Some(msg_index));
             }
         }
@@ -1184,18 +1275,22 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     // Append typing indicator as the last line inside the message area
     if let Some(ref conv_id) = app.active_conversation {
         let typers: Vec<String> = app
-            .typing.indicators
+            .typing
+            .indicators
             .get(conv_id)
             .map(|senders| {
-                senders.keys().map(|sender| {
-                    if let Some(name) = app.store.contact_names.get(sender) {
-                        name.clone()
-                    } else if let Some(conv) = app.store.conversations.get(sender) {
-                        conv.name.clone()
-                    } else {
-                        sender.clone()
-                    }
-                }).collect()
+                senders
+                    .keys()
+                    .map(|sender| {
+                        if let Some(name) = app.store.contact_names.get(sender) {
+                            name.clone()
+                        } else if let Some(conv) = app.store.conversations.get(sender) {
+                            conv.name.clone()
+                        } else {
+                            sender.clone()
+                        }
+                    })
+                    .collect()
             })
             .unwrap_or_default();
 
@@ -1221,12 +1316,15 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     // WordWrapper on realistic text and shifts Kitty placeholder cells off their
     // halfblock origins, which caused images to clip into neighboring messages.
     let inner_w_u16 = inner.width.max(1);
-    let line_heights: Vec<usize> = lines.iter().map(|line| {
-        Paragraph::new(line.clone())
-            .wrap(Wrap { trim: false })
-            .line_count(inner_w_u16)
-            .max(1)
-    }).collect();
+    let line_heights: Vec<usize> = lines
+        .iter()
+        .map(|line| {
+            Paragraph::new(line.clone())
+                .wrap(Wrap { trim: false })
+                .line_count(inner_w_u16)
+                .max(1)
+        })
+        .collect();
     let content_height: usize = line_heights.iter().sum();
 
     // Bottom-align by default; scroll_offset shifts the view upward
@@ -1237,7 +1335,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     // Signal when user has scrolled to the top of loaded content
     app.at_scroll_top = app.scroll_offset >= base_scroll
         && base_scroll > 0
-        && app.active_conversation.as_ref()
+        && app
+            .active_conversation
+            .as_ref()
             .is_some_and(|id| app.store.has_more_messages.contains(id));
 
     // Determine the focused message for highlight and full-timestamp display in Normal mode.
@@ -1346,10 +1446,14 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     if let Some(focused_idx) = render_focus {
         for (i, line) in lines.iter_mut().enumerate() {
             if line_msg_idx.get(i) == Some(&Some(focused_idx)) {
-                let patched: Vec<Span> = line.spans.drain(..).map(|mut s| {
-                    s.style = s.style.bg(theme.msg_selected_bg);
-                    s
-                }).collect();
+                let patched: Vec<Span> = line
+                    .spans
+                    .drain(..)
+                    .map(|mut s| {
+                        s.style = s.style.bg(theme.msg_selected_bg);
+                        s
+                    })
+                    .collect();
                 *line = Line::from(patched);
             }
         }
@@ -1424,15 +1528,28 @@ fn patch_kitty_placeholders(frame: &mut Frame, app: &mut App) {
 }
 
 /// Build a reaction summary line like "    👍 2  ❤️ 1  😂 1"
-pub(crate) fn build_reaction_summary(reactions: &[Reaction], verbose: bool, convert_emoji: bool, theme: &Theme) -> Line<'static> {
+pub(crate) fn build_reaction_summary(
+    reactions: &[Reaction],
+    verbose: bool,
+    convert_emoji: bool,
+    theme: &Theme,
+) -> Line<'static> {
     let display = |emoji: &str| -> String {
-        if convert_emoji { emoji_to_text(emoji) } else { emoji.to_string() }
+        if convert_emoji {
+            emoji_to_text(emoji)
+        } else {
+            emoji.to_string()
+        }
     };
     if verbose {
         // Verbose: group by emoji, show sender names
-        let mut grouped: std::collections::BTreeMap<String, Vec<String>> = std::collections::BTreeMap::new();
+        let mut grouped: std::collections::BTreeMap<String, Vec<String>> =
+            std::collections::BTreeMap::new();
         for r in reactions {
-            grouped.entry(r.emoji.clone()).or_default().push(r.sender.clone());
+            grouped
+                .entry(r.emoji.clone())
+                .or_default()
+                .push(r.sender.clone());
         }
         let mut spans = vec![Span::raw("    ".to_string())];
         for (emoji, senders) in &grouped {
@@ -1446,7 +1563,8 @@ pub(crate) fn build_reaction_summary(reactions: &[Reaction], verbose: bool, conv
         Line::from(spans)
     } else {
         // Summary: emoji + count
-        let mut counts: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+        let mut counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
         for r in reactions {
             *counts.entry(r.emoji.clone()).or_default() += 1;
         }
@@ -1475,13 +1593,20 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 return;
             }
             let popup_height = items.len() as u16 + 4;
-            let title = app.active_conversation.as_ref()
+            let title = app
+                .active_conversation
+                .as_ref()
                 .and_then(|id| app.store.conversations.get(id))
                 .filter(|c| c.is_group)
                 .map(|c| format!(" #{} ", c.name))
                 .unwrap_or_else(|| " Group ".to_string());
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, popup_height, &title, theme,
+                frame,
+                area,
+                GROUP_MENU_POPUP_WIDTH,
+                popup_height,
+                &title,
+                theme,
             );
             let inner = block.inner(popup_area);
             frame.render_widget(block, popup_area);
@@ -1504,7 +1629,10 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                     Style::default()
                 };
                 let hint_style = if is_selected {
-                    Style::default().bg(theme.bg_selected).fg(theme.fg_muted).add_modifier(Modifier::DIM)
+                    Style::default()
+                        .bg(theme.bg_selected)
+                        .fg(theme.fg_muted)
+                        .add_modifier(Modifier::DIM)
                 } else {
                     Style::default().fg(theme.fg_muted)
                 };
@@ -1526,7 +1654,12 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             let pref_height = max_visible as u16 + 5;
             let title = " Members ".to_string();
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, pref_height, &title, theme,
+                frame,
+                area,
+                GROUP_MENU_POPUP_WIDTH,
+                pref_height,
+                &title,
+                theme,
             );
             let inner_height = popup_area.height.saturating_sub(2) as usize;
             let footer_lines = 2;
@@ -1544,7 +1677,10 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 )));
             } else {
                 let end = (scroll_offset + visible_rows).min(app.group_menu.filtered.len());
-                for (i, (phone, name)) in app.group_menu.filtered[scroll_offset..end].iter().enumerate() {
+                for (i, (phone, name)) in app.group_menu.filtered[scroll_offset..end]
+                    .iter()
+                    .enumerate()
+                {
                     let actual_index = scroll_offset + i;
                     let is_selected = actual_index == app.group_menu.index;
                     let is_self = *phone == app.account;
@@ -1554,7 +1690,10 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                         format!("  {}", name)
                     };
                     let name_style = if is_selected {
-                        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                        Style::default()
+                            .bg(theme.bg_selected)
+                            .fg(theme.fg)
+                            .add_modifier(Modifier::BOLD)
                     } else {
                         Style::default().fg(theme.fg)
                     };
@@ -1596,7 +1735,12 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
                 format!(" Remove Member [{}] ", app.group_menu.filter)
             };
             let (popup_area, block) = centered_popup(
-                frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title, theme,
+                frame,
+                area,
+                CONTACTS_POPUP_WIDTH,
+                pref_height,
+                &title,
+                theme,
             );
             let inner_height = popup_area.height.saturating_sub(2) as usize;
             let footer_lines = 2;
@@ -1608,7 +1752,11 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             };
             let mut lines: Vec<Line> = Vec::new();
             if app.group_menu.filtered.is_empty() {
-                let msg = if is_add { "  No contacts to add" } else { "  No members to remove" };
+                let msg = if is_add {
+                    "  No contacts to add"
+                } else {
+                    "  No members to remove"
+                };
                 lines.push(Line::from(Span::styled(
                     msg,
                     Style::default().fg(theme.fg_muted),
@@ -1616,14 +1764,20 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 let end = (scroll_offset + visible_rows).min(app.group_menu.filtered.len());
                 let inner_w = popup_area.width.saturating_sub(2) as usize;
-                for (i, (phone, name)) in app.group_menu.filtered[scroll_offset..end].iter().enumerate() {
+                for (i, (phone, name)) in app.group_menu.filtered[scroll_offset..end]
+                    .iter()
+                    .enumerate()
+                {
                     let actual_index = scroll_offset + i;
                     let is_selected = actual_index == app.group_menu.index;
                     let number_display = format!("  {}", phone);
                     let name_max = inner_w.saturating_sub(number_display.len() + 2);
                     let display_name = truncate(name, name_max);
                     let name_style = if is_selected {
-                        Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                        Style::default()
+                            .bg(theme.bg_selected)
+                            .fg(theme.fg)
+                            .add_modifier(Modifier::BOLD)
                     } else {
                         Style::default().fg(theme.fg)
                     };
@@ -1651,10 +1805,13 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
         }
         GroupMenuState::Rename | GroupMenuState::Create => {
             let is_rename = *state == GroupMenuState::Rename;
-            let title = if is_rename { " Rename Group " } else { " Create Group " };
-            let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, 6, title, theme,
-            );
+            let title = if is_rename {
+                " Rename Group "
+            } else {
+                " Create Group "
+            };
+            let (popup_area, block) =
+                centered_popup(frame, area, GROUP_MENU_POPUP_WIDTH, 6, title, theme);
             let inner = block.inner(popup_area);
             frame.render_widget(block, popup_area);
             let mut lines: Vec<Line> = Vec::new();
@@ -1672,13 +1829,20 @@ fn draw_group_menu(frame: &mut Frame, app: &App, area: Rect) {
             frame.render_widget(popup, inner);
         }
         GroupMenuState::LeaveConfirm => {
-            let group_name = app.active_conversation.as_ref()
+            let group_name = app
+                .active_conversation
+                .as_ref()
                 .and_then(|id| app.store.conversations.get(id))
                 .map(|c| c.name.clone())
                 .unwrap_or_else(|| "this group".to_string());
             let prompt = format!("Leave #{}?", group_name);
             let (popup_area, block) = centered_popup(
-                frame, area, GROUP_MENU_POPUP_WIDTH, 5, " Leave Group ", theme,
+                frame,
+                area,
+                GROUP_MENU_POPUP_WIDTH,
+                5,
+                " Leave Group ",
+                theme,
             );
             let inner = block.inner(popup_area);
             frame.render_widget(block, popup_area);
@@ -1716,22 +1880,48 @@ fn draw_message_request(frame: &mut Frame, app: &App, area: Rect) {
     let (popup_area, block) = centered_popup(frame, area, 36, 9, " Message Request ", theme);
     frame.render_widget(block, popup_area);
 
-    let inner = popup_area.inner(ratatui::layout::Margin { vertical: 1, horizontal: 2 });
+    let inner = popup_area.inner(ratatui::layout::Margin {
+        vertical: 1,
+        horizontal: 2,
+    });
     let lines = vec![
-        Line::from(Span::styled(name.as_str(), Style::default().fg(theme.fg).add_modifier(Modifier::BOLD))),
-        Line::from(Span::styled(phone.as_str(), Style::default().fg(theme.fg_muted))),
         Line::from(Span::styled(
-            format!("{} message{}", msg_count, if msg_count == 1 { "" } else { "s" }),
+            name.as_str(),
+            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            phone.as_str(),
+            Style::default().fg(theme.fg_muted),
+        )),
+        Line::from(Span::styled(
+            format!(
+                "{} message{}",
+                msg_count,
+                if msg_count == 1 { "" } else { "s" }
+            ),
             Style::default().fg(theme.fg_secondary),
         )),
         Line::from(""),
         Line::from(vec![
-            Span::styled("(a)", Style::default().fg(theme.success).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "(a)",
+                Style::default()
+                    .fg(theme.success)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("ccept / ", Style::default().fg(theme.fg_secondary)),
-            Span::styled("(d)", Style::default().fg(theme.error).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                "(d)",
+                Style::default()
+                    .fg(theme.error)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled("elete", Style::default().fg(theme.fg_secondary)),
         ]),
-        Line::from(Span::styled("Esc to go back", Style::default().fg(theme.fg_muted))),
+        Line::from(Span::styled(
+            "Esc to go back",
+            Style::default().fg(theme.fg_muted),
+        )),
     ];
 
     let text = Paragraph::new(lines).alignment(ratatui::layout::Alignment::Center);
@@ -1748,9 +1938,8 @@ fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {
     let popup_width: u16 = 30;
     let popup_height = items.len() as u16 + 4;
 
-    let (popup_area, block) = centered_popup(
-        frame, area, popup_width, popup_height, " Actions ", theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, popup_width, popup_height, " Actions ", theme);
 
     let inner = block.inner(popup_area);
     frame.render_widget(block, popup_area);
@@ -1777,7 +1966,10 @@ fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) {
             Style::default()
         };
         let hint_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.fg_muted).add_modifier(Modifier::DIM)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg_muted)
+                .add_modifier(Modifier::DIM)
         } else {
             Style::default().fg(theme.fg_muted)
         };
@@ -1805,18 +1997,33 @@ fn draw_reaction_picker(frame: &mut Frame, app: &App, area: Rect) {
     let popup_height = 3u16;
 
     let (popup_area, block) = centered_popup(
-        frame, area, popup_width, popup_height, " React (e: search all) ", theme,
+        frame,
+        area,
+        popup_width,
+        popup_height,
+        " React (e: search all) ",
+        theme,
     );
 
     let mut spans = vec![Span::raw(" ".to_string())];
     for (i, emoji) in QUICK_REACTIONS.iter().enumerate() {
         let style = if i == app.reactions.picker_index {
-            Style::default().bg(theme.bg_selected).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default()
         };
-        let prefix = if i == app.reactions.picker_index { "[" } else { " " };
-        let suffix = if i == app.reactions.picker_index { "]" } else { " " };
+        let prefix = if i == app.reactions.picker_index {
+            "["
+        } else {
+            " "
+        };
+        let suffix = if i == app.reactions.picker_index {
+            "]"
+        } else {
+            " "
+        };
         spans.push(Span::styled(format!("{prefix}{emoji}{suffix}"), style));
     }
 
@@ -1835,7 +2042,12 @@ fn draw_emoji_picker(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let (popup_area, block) = centered_popup(
-        frame, area, EMOJI_POPUP_WIDTH, EMOJI_POPUP_HEIGHT, &title, theme,
+        frame,
+        area,
+        EMOJI_POPUP_WIDTH,
+        EMOJI_POPUP_HEIGHT,
+        &title,
+        theme,
     );
 
     let inner = block.inner(popup_area);
@@ -1853,7 +2065,10 @@ fn draw_emoji_picker(frame: &mut Frame, app: &App, area: Rect) {
     let mut cat_spans: Vec<Span<'static>> = Vec::new();
     for (i, (icon, _label)) in CATEGORIES.iter().enumerate() {
         let style = if i == app.emoji_picker.category_index {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg_muted)
         };
@@ -1863,7 +2078,10 @@ fn draw_emoji_picker(frame: &mut Frame, app: &App, area: Rect) {
 
     // Separator
     let sep = "\u{2500}".repeat(inner.width as usize);
-    lines.push(Line::from(Span::styled(sep, Style::default().fg(theme.fg_muted))));
+    lines.push(Line::from(Span::styled(
+        sep,
+        Style::default().fg(theme.fg_muted),
+    )));
 
     // Grid dimensions
     let footer_lines = 3; // blank + preview + help
@@ -1903,13 +2121,20 @@ fn draw_emoji_picker(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     // Preview line: name + shortcode of selected emoji
-    if let Some(entry) = app.emoji_picker.filtered.get(app.emoji_picker.selected_index) {
+    if let Some(entry) = app
+        .emoji_picker
+        .filtered
+        .get(app.emoji_picker.selected_index)
+    {
         let preview = if let Some(sc) = entry.shortcode {
             format!("{} :{sc}: - {}", entry.emoji, entry.name)
         } else {
             format!("{} - {}", entry.emoji, entry.name)
         };
-        lines.push(Line::from(Span::styled(preview, Style::default().fg(theme.accent))));
+        lines.push(Line::from(Span::styled(
+            preview,
+            Style::default().fg(theme.accent),
+        )));
     } else {
         lines.push(Line::from(""));
     }
@@ -1934,9 +2159,7 @@ fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
     let msg = app.selected_message();
     let is_outgoing = msg.is_some_and(|m| m.sender == "you");
 
-    let (popup_area, block) = centered_popup(
-        frame, area, 44, 5, " Delete Message ", theme,
-    );
+    let (popup_area, block) = centered_popup(frame, area, 44, 5, " Delete Message ", theme);
 
     let prompt = if is_outgoing {
         "Delete for everyone? (y)es / (l)ocal / (n)o"
@@ -1963,7 +2186,9 @@ fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
     if let Some(ref err) = app.connection_error {
         lines.push(Line::from(Span::styled(
             "  Connection Error",
-            Style::default().fg(theme.error).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.error)
+                .add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(Span::styled(
             format!("  {err}"),
@@ -1979,7 +2204,9 @@ fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
         let spinner_char = SPINNER[app.spinner_tick % SPINNER.len()];
         lines.push(Line::from(Span::styled(
             "  siggy",
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -1989,7 +2216,9 @@ fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
     } else if app.store.conversation_order.is_empty() {
         lines.push(Line::from(Span::styled(
             "  Welcome to siggy",
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -2016,7 +2245,9 @@ fn draw_welcome(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         lines.push(Line::from(Span::styled(
             "  Welcome to siggy",
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
         )));
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
@@ -2081,22 +2312,28 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
         let label = format!(" replying: {}… ", truncate(snippet, 30));
         block = block.title(Line::from(Span::styled(
             label,
-            Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(theme.fg_muted)
+                .add_modifier(Modifier::ITALIC),
         )));
     } else if app.editing_message.is_some() {
         block = block.title(Line::from(Span::styled(
             " editing… ",
-            Style::default().fg(theme.accent_secondary).add_modifier(Modifier::ITALIC),
+            Style::default()
+                .fg(theme.accent_secondary)
+                .add_modifier(Modifier::ITALIC),
         )));
     }
 
     // Build attachment badge if present
     let badge = app.pending_attachment.as_ref().map(|path| {
-        let fname = path.file_name()
+        let fname = path
+            .file_name()
             .map(|f| f.to_string_lossy().to_string())
             .unwrap_or_else(|| "file".to_string());
         // Detect type hint from extension
-        let ext = path.extension()
+        let ext = path
+            .extension()
             .map(|e| e.to_string_lossy().to_lowercase())
             .unwrap_or_default();
         let type_hint = match ext.as_str() {
@@ -2145,7 +2382,9 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
                 if let Some(ref badge_text) = badge {
                     spans.push(Span::styled(
                         badge_text.clone(),
-                        Style::default().fg(theme.mention).add_modifier(Modifier::BOLD),
+                        Style::default()
+                            .fg(theme.mention)
+                            .add_modifier(Modifier::BOLD),
                     ));
                 }
                 spans.push(Span::styled(prefix, Style::default().fg(theme.fg)));
@@ -2158,17 +2397,15 @@ fn draw_input(frame: &mut Frame, app: &mut App, area: Rect) {
 
             if i == cursor_line {
                 let char_scroll = cursor_col.saturating_sub(text_width);
-                let visible_text: String = line_str.chars().skip(char_scroll).take(text_width).collect();
-                spans.push(Span::styled(
-                    visible_text,
-                    Style::default().fg(theme.fg),
-                ));
+                let visible_text: String = line_str
+                    .chars()
+                    .skip(char_scroll)
+                    .take(text_width)
+                    .collect();
+                spans.push(Span::styled(visible_text, Style::default().fg(theme.fg)));
             } else {
                 let visible_text: String = line_str.chars().take(text_width).collect();
-                spans.push(Span::styled(
-                    visible_text,
-                    Style::default().fg(theme.fg),
-                ));
+                spans.push(Span::styled(visible_text, Style::default().fg(theme.fg)));
             }
             text_lines.push(Line::from(spans));
         }
@@ -2202,7 +2439,9 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
     if app.quit_confirm {
         let bar = Line::from(Span::styled(
             " Unsent message in buffer. Press quit again to confirm.",
-            Style::default().fg(theme.warning).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.warning)
+                .add_modifier(Modifier::BOLD),
         ));
         frame.render_widget(
             Paragraph::new(bar).style(Style::default().bg(theme.statusbar_bg)),
@@ -2214,7 +2453,12 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
     // Sync progress indicator (overrides normal status bar)
     if app.sync.active && app.sync.message_count > 0 {
         let bar = Line::from(vec![
-            Span::styled(" Syncing... ", Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)),
+            Span::styled(
+                " Syncing... ",
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            ),
             Span::styled(
                 format!("({} messages received)", app.sync.message_count),
                 Style::default().fg(theme.statusbar_fg),
@@ -2239,13 +2483,17 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
             };
             segments.push(Span::styled(
                 label,
-                Style::default().fg(theme.accent_secondary).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.accent_secondary)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
         InputMode::Insert => {
             segments.push(Span::styled(
                 " [INSERT] ",
-                Style::default().fg(theme.success).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.success)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
     }
@@ -2261,17 +2509,25 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
         ));
     } else if app.connected {
         segments.push(Span::styled(" ● ", Style::default().fg(theme.success)));
-        segments.push(Span::styled("connected", Style::default().fg(theme.statusbar_fg)));
+        segments.push(Span::styled(
+            "connected",
+            Style::default().fg(theme.statusbar_fg),
+        ));
         if app.incognito {
             segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
             segments.push(Span::styled(
                 "incognito",
-                Style::default().fg(theme.mention).add_modifier(Modifier::BOLD),
+                Style::default()
+                    .fg(theme.mention)
+                    .add_modifier(Modifier::BOLD),
             ));
         }
     } else {
         segments.push(Span::styled(" ● ", Style::default().fg(theme.error)));
-        segments.push(Span::styled("disconnected", Style::default().fg(theme.statusbar_fg)));
+        segments.push(Span::styled(
+            "disconnected",
+            Style::default().fg(theme.statusbar_fg),
+        ));
     }
 
     // Pipe separator
@@ -2322,10 +2578,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_auto_hidden
     // Auto-hidden sidebar indicator
     if sidebar_auto_hidden && app.sidebar_visible {
         segments.push(Span::styled(" │ ", Style::default().fg(theme.fg_muted)));
-        segments.push(Span::styled(
-            "[+]",
-            Style::default().fg(theme.fg_muted),
-        ));
+        segments.push(Span::styled("[+]", Style::default().fg(theme.fg_muted)));
     }
 
     // Pad the rest with background
@@ -2361,7 +2614,10 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
                 let is_selected = i == app.autocomplete.index;
                 let style = if is_selected {
-                    Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .bg(theme.bg_selected)
+                        .fg(theme.fg)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default().fg(theme.fg_secondary)
                 };
@@ -2378,7 +2634,8 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
             }
         }
         AutocompleteMode::Mention => {
-            for (i, (phone, name, _uuid)) in app.autocomplete.mention_candidates.iter().enumerate() {
+            for (i, (phone, name, _uuid)) in app.autocomplete.mention_candidates.iter().enumerate()
+            {
                 let left = format!("  @{name}");
                 let right = format!("  {phone}");
                 let total_len = left.len() + right.len() + 2;
@@ -2388,7 +2645,10 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
                 let is_selected = i == app.autocomplete.index;
                 let style = if is_selected {
-                    Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .bg(theme.bg_selected)
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default().fg(theme.accent)
                 };
@@ -2414,14 +2674,15 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
                 let is_selected = i == app.autocomplete.index;
                 let style = if is_selected {
-                    Style::default().bg(theme.bg_selected).fg(theme.success).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .bg(theme.bg_selected)
+                        .fg(theme.success)
+                        .add_modifier(Modifier::BOLD)
                 } else {
                     Style::default().fg(theme.success)
                 };
 
-                lines.push(Line::from(vec![
-                    Span::styled(left, style),
-                ]));
+                lines.push(Line::from(vec![Span::styled(left, style)]));
             }
         }
     }
@@ -2430,7 +2691,9 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
 
     // Size the popup, clamping to available space
     let terminal_height = frame.area().height;
-    let popup_width = (max_content_width as u16 + 2).min(terminal_width.saturating_sub(2)).max(20);
+    let popup_width = (max_content_width as u16 + 2)
+        .min(terminal_width.saturating_sub(2))
+        .max(20);
     let popup_height = ((count as u16) + 2).min(input_area.y).min(terminal_height); // +2 for border
     if popup_height < 3 {
         return; // not enough space to render anything useful
@@ -2440,7 +2703,12 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
     let x = input_area.x;
     let y = input_area.y.saturating_sub(popup_height);
 
-    let area = Rect::new(x, y, popup_width.min(terminal_width.saturating_sub(x)), popup_height);
+    let area = Rect::new(
+        x,
+        y,
+        popup_width.min(terminal_width.saturating_sub(x)),
+        popup_height,
+    );
     lines.truncate((popup_height.saturating_sub(2)) as usize);
 
     // Clear the area behind the popup so chat text doesn't leak through
@@ -2460,10 +2728,17 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let height = SETTINGS_POPUP_HEIGHT;
     let (popup_area, block) = centered_popup(
-        frame, area, SETTINGS_POPUP_WIDTH, height, " Settings ", theme,
+        frame,
+        area,
+        SETTINGS_POPUP_WIDTH,
+        height,
+        " Settings ",
+        theme,
     );
 
-    let header_style = Style::default().fg(theme.fg_muted).add_modifier(Modifier::BOLD);
+    let header_style = Style::default()
+        .fg(theme.fg_muted)
+        .add_modifier(Modifier::BOLD);
 
     // Render a toggle row
     let render_toggle = |lines: &mut Vec<Line>, i: usize, def: &SettingDef| {
@@ -2471,12 +2746,18 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         let checkbox = if enabled { "[x]" } else { "[ ]" };
         let is_selected = i == app.settings_index;
         let style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg_secondary)
         };
         let check_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
         } else if enabled {
             Style::default().fg(theme.success)
         } else {
@@ -2492,7 +2773,10 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     let render_special = |lines: &mut Vec<Line>, label: &str, value: &str, index: usize| {
         let is_selected = app.settings_index == index;
         let label_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg_secondary)
         };
@@ -2507,7 +2791,9 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
         ]));
     };
 
-    use crate::app::{SETTINGS_SECTION_DISPLAY, SETTINGS_SECTION_MESSAGES, SETTINGS_SECTION_INTERFACE};
+    use crate::app::{
+        SETTINGS_SECTION_DISPLAY, SETTINGS_SECTION_INTERFACE, SETTINGS_SECTION_MESSAGES,
+    };
 
     let preview_index = SETTINGS.len();
     let image_mode_index = SETTINGS.len() + 1;
@@ -2517,21 +2803,49 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
 
     // — Notifications —
     lines.push(Line::from(Span::styled("  Notifications", header_style)));
-    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_DISPLAY) { render_toggle(&mut lines, i, def); }
-    render_special(&mut lines, "Notification preview: ", &app.notifications.notification_preview, preview_index);
+    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_DISPLAY) {
+        render_toggle(&mut lines, i, def);
+    }
+    render_special(
+        &mut lines,
+        "Notification preview: ",
+        &app.notifications.notification_preview,
+        preview_index,
+    );
 
     // — Display —
     lines.push(Line::from(Span::styled("  Display", header_style)));
-    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_MESSAGES).skip(SETTINGS_SECTION_DISPLAY) { render_toggle(&mut lines, i, def); }
-    render_special(&mut lines, "Image mode: ", &app.image.image_mode, image_mode_index);
+    for (i, def) in SETTINGS
+        .iter()
+        .enumerate()
+        .take(SETTINGS_SECTION_MESSAGES)
+        .skip(SETTINGS_SECTION_DISPLAY)
+    {
+        render_toggle(&mut lines, i, def);
+    }
+    render_special(
+        &mut lines,
+        "Image mode: ",
+        &app.image.image_mode,
+        image_mode_index,
+    );
 
     // — Messages —
     lines.push(Line::from(Span::styled("  Messages", header_style)));
-    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_INTERFACE).skip(SETTINGS_SECTION_MESSAGES) { render_toggle(&mut lines, i, def); }
+    for (i, def) in SETTINGS
+        .iter()
+        .enumerate()
+        .take(SETTINGS_SECTION_INTERFACE)
+        .skip(SETTINGS_SECTION_MESSAGES)
+    {
+        render_toggle(&mut lines, i, def);
+    }
 
     // — Interface —
     lines.push(Line::from(Span::styled("  Interface", header_style)));
-    for (i, def) in SETTINGS.iter().enumerate().skip(SETTINGS_SECTION_INTERFACE) { render_toggle(&mut lines, i, def); }
+    for (i, def) in SETTINGS.iter().enumerate().skip(SETTINGS_SECTION_INTERFACE) {
+        render_toggle(&mut lines, i, def);
+    }
     render_special(&mut lines, "Customize...", "", customize_index);
 
     // Hint line for the currently selected item
@@ -2547,7 +2861,9 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     };
     lines.push(Line::from(Span::styled(
         format!("  {hint}"),
-        Style::default().fg(theme.fg_muted).add_modifier(Modifier::ITALIC),
+        Style::default()
+            .fg(theme.fg_muted)
+            .add_modifier(Modifier::ITALIC),
     )));
 
     let popup = Paragraph::new(lines).block(block);
@@ -2557,15 +2873,16 @@ fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
 fn draw_customize(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let items = ["Theme", "Keybindings", "Settings profile"];
-    let (popup_area, block) = centered_popup(
-        frame, area, 30, 5, " Customize ", theme,
-    );
+    let (popup_area, block) = centered_popup(frame, area, 30, 5, " Customize ", theme);
 
     let mut lines: Vec<Line> = Vec::new();
     for (i, label) in items.iter().enumerate() {
         let is_selected = i == app.customize_index;
         let style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg_secondary)
         };
@@ -2597,9 +2914,21 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
 
     // Dynamic shortcuts from active keybindings
     let dk = |a: KeyAction| kb.display_key(a);
-    let nav_keys = format!("{} / {}", dk(KeyAction::NextConversation), dk(KeyAction::PrevConversation));
-    let scroll_keys = format!("{} / {}", dk(KeyAction::PageScrollUp), dk(KeyAction::PageScrollDown));
-    let resize_keys = format!("{} / {}", dk(KeyAction::ResizeSidebarLeft), dk(KeyAction::ResizeSidebarRight));
+    let nav_keys = format!(
+        "{} / {}",
+        dk(KeyAction::NextConversation),
+        dk(KeyAction::PrevConversation)
+    );
+    let scroll_keys = format!(
+        "{} / {}",
+        dk(KeyAction::PageScrollUp),
+        dk(KeyAction::PageScrollDown)
+    );
+    let resize_keys = format!(
+        "{} / {}",
+        dk(KeyAction::ResizeSidebarLeft),
+        dk(KeyAction::ResizeSidebarRight)
+    );
     let quit_key = dk(KeyAction::Quit);
     let shortcuts: Vec<(String, &str)> = vec![
         (nav_keys, "Next / prev conversation"),
@@ -2618,20 +2947,60 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
 
     // Dynamic normal-mode keybindings
     let exit_key = dk(KeyAction::ExitInsert);
-    let insert_keys = format!("{} / {} / {} / {} / {}",
-        dk(KeyAction::InsertAtCursor), dk(KeyAction::InsertAfterCursor),
-        dk(KeyAction::InsertLineStart), dk(KeyAction::InsertLineEnd),
-        dk(KeyAction::OpenLineBelow));
-    let scroll_ud = format!("{} / {}", dk(KeyAction::ScrollDown), dk(KeyAction::ScrollUp));
-    let focus_ud = format!("{} / {}", dk(KeyAction::FocusNextMessage), dk(KeyAction::FocusPrevMessage));
-    let top_bottom = format!("{} / {}", dk(KeyAction::ScrollToTop), dk(KeyAction::ScrollToBottom));
-    let half_page = format!("{} / {}", dk(KeyAction::HalfPageDown), dk(KeyAction::HalfPageUp));
-    let cursor_lr = format!("{} / {}", dk(KeyAction::CursorLeft), dk(KeyAction::CursorRight));
-    let word_fb = format!("{} / {}", dk(KeyAction::WordForward), dk(KeyAction::WordBack));
+    let insert_keys = format!(
+        "{} / {} / {} / {} / {}",
+        dk(KeyAction::InsertAtCursor),
+        dk(KeyAction::InsertAfterCursor),
+        dk(KeyAction::InsertLineStart),
+        dk(KeyAction::InsertLineEnd),
+        dk(KeyAction::OpenLineBelow)
+    );
+    let scroll_ud = format!(
+        "{} / {}",
+        dk(KeyAction::ScrollDown),
+        dk(KeyAction::ScrollUp)
+    );
+    let focus_ud = format!(
+        "{} / {}",
+        dk(KeyAction::FocusNextMessage),
+        dk(KeyAction::FocusPrevMessage)
+    );
+    let top_bottom = format!(
+        "{} / {}",
+        dk(KeyAction::ScrollToTop),
+        dk(KeyAction::ScrollToBottom)
+    );
+    let half_page = format!(
+        "{} / {}",
+        dk(KeyAction::HalfPageDown),
+        dk(KeyAction::HalfPageUp)
+    );
+    let cursor_lr = format!(
+        "{} / {}",
+        dk(KeyAction::CursorLeft),
+        dk(KeyAction::CursorRight)
+    );
+    let word_fb = format!(
+        "{} / {}",
+        dk(KeyAction::WordForward),
+        dk(KeyAction::WordBack)
+    );
     let line_se = format!("{} / {}", dk(KeyAction::LineStart), dk(KeyAction::LineEnd));
-    let del_keys = format!("{} / {}", dk(KeyAction::DeleteChar), dk(KeyAction::DeleteToEnd));
-    let copy_keys = format!("{} / {}", dk(KeyAction::CopyMessage), dk(KeyAction::CopyAllMessages));
-    let search_keys = format!("{} / {}", dk(KeyAction::NextSearchResult), dk(KeyAction::PrevSearchResult));
+    let del_keys = format!(
+        "{} / {}",
+        dk(KeyAction::DeleteChar),
+        dk(KeyAction::DeleteToEnd)
+    );
+    let copy_keys = format!(
+        "{} / {}",
+        dk(KeyAction::CopyMessage),
+        dk(KeyAction::CopyAllMessages)
+    );
+    let search_keys = format!(
+        "{} / {}",
+        dk(KeyAction::NextSearchResult),
+        dk(KeyAction::PrevSearchResult)
+    );
 
     let profile_label = format!("  Keybindings [{}]", app.keybindings.profile_name);
     let vim: Vec<(String, &str)> = vec![
@@ -2658,8 +3027,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
     let key_col_width = 20;
     let desc_col_width = 28;
     let pref_width = (key_col_width + desc_col_width + 6) as u16;
-    let content_lines =
-        commands.len() + shortcuts.len() + vim.len() + cli.len() + 7;
+    let content_lines = commands.len() + shortcuts.len() + vim.len() + cli.len() + 7;
     let pref_height = content_lines as u16 + 2;
 
     let (popup_area, block) = centered_popup(frame, area, pref_width, pref_height, " Help ", theme);
@@ -2674,7 +3042,10 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
 
     let push_row = |lines: &mut Vec<Line>, key: &str, desc: &str| {
         lines.push(Line::from(vec![
-            Span::styled(format!("  {:<width$}", key, width = key_col_width), key_style),
+            Span::styled(
+                format!("  {:<width$}", key, width = key_col_width),
+                key_style,
+            ),
             Span::styled(desc.to_string(), desc_style),
         ]));
     };
@@ -2724,11 +3095,17 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let (popup_area, block) = centered_popup(
-        frame, area, CONTACTS_POPUP_WIDTH, pref_height, &title, theme,
+        frame,
+        area,
+        CONTACTS_POPUP_WIDTH,
+        pref_height,
+        &title,
+        theme,
     );
 
     let inner_height = popup_area.height.saturating_sub(2) as usize; // minus borders
-    let (visible_rows, scroll_offset) = list_overlay::scroll_layout(inner_height, 2, app.contacts_overlay.index);
+    let (visible_rows, scroll_offset) =
+        list_overlay::scroll_layout(inner_height, 2, app.contacts_overlay.index);
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -2741,7 +3118,10 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
         let end = (scroll_offset + visible_rows).min(app.contacts_overlay.filtered.len());
         let inner_w = popup_area.width.saturating_sub(2) as usize;
 
-        for (i, (number, name)) in app.contacts_overlay.filtered[scroll_offset..end].iter().enumerate() {
+        for (i, (number, name)) in app.contacts_overlay.filtered[scroll_offset..end]
+            .iter()
+            .enumerate()
+        {
             let actual_index = scroll_offset + i;
             let is_selected = actual_index == app.contacts_overlay.index;
             let has_conversation = app.store.conversation_order.contains(number);
@@ -2785,7 +3165,12 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
         }
     }
 
-    list_overlay::append_footer(&mut lines, visible_rows, "  j/k navigate  |  Enter select  |  Esc close", theme.fg_muted);
+    list_overlay::append_footer(
+        &mut lines,
+        visible_rows,
+        "  j/k navigate  |  Enter select  |  Esc close",
+        theme.fg_muted,
+    );
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);
@@ -2793,7 +3178,9 @@ fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
 
 fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
-    let is_group = app.active_conversation.as_ref()
+    let is_group = app
+        .active_conversation
+        .as_ref()
         .and_then(|id| app.store.conversations.get(id))
         .map(|c| c.is_group)
         .unwrap_or(false);
@@ -2801,9 +3188,17 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
     let pref_height: u16 = if is_group { 18 } else { 14 };
     let pref_width: u16 = 50;
     let (popup_area, block) = centered_popup(
-        frame, area, pref_width, pref_height, " Verify Identity ", theme,
+        frame,
+        area,
+        pref_width,
+        pref_height,
+        " Verify Identity ",
+        theme,
     );
-    let inner = popup_area.inner(ratatui::layout::Margin { horizontal: 1, vertical: 1 });
+    let inner = popup_area.inner(ratatui::layout::Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
     let mut lines: Vec<Line> = Vec::new();
 
     if app.verify.identities.is_empty() {
@@ -2830,7 +3225,12 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
             let actual_idx = scroll_offset + i;
             let is_selected = actual_idx == app.verify.index;
             let number = identity.number.as_deref().unwrap_or("unknown");
-            let name = app.store.contact_names.get(number).cloned().unwrap_or_else(|| number.to_string());
+            let name = app
+                .store
+                .contact_names
+                .get(number)
+                .cloned()
+                .unwrap_or_else(|| number.to_string());
             let (badge, badge_color) = match identity.trust_level {
                 TrustLevel::TrustedVerified => ("\u{2713}", theme.accent),
                 TrustLevel::Untrusted => ("\u{26A0}", theme.warning),
@@ -2838,7 +3238,10 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
             };
             let prefix = if is_selected { "> " } else { "  " };
             let style = if is_selected {
-                Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .bg(theme.bg_selected)
+                    .fg(theme.fg)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(theme.fg)
             };
@@ -2859,14 +3262,23 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
         // Show selected member's safety number
         if let Some(identity) = app.verify.identities.get(app.verify.index) {
             if !identity.safety_number.is_empty() {
-                lines.push(Line::from(Span::styled("  Safety Number:", Style::default().fg(theme.fg_secondary))));
+                lines.push(Line::from(Span::styled(
+                    "  Safety Number:",
+                    Style::default().fg(theme.fg_secondary),
+                )));
                 let sn = &identity.safety_number;
                 let formatted = format_safety_number(sn);
                 for row in formatted {
-                    lines.push(Line::from(Span::styled(format!("  {row}"), Style::default().fg(theme.fg))));
+                    lines.push(Line::from(Span::styled(
+                        format!("  {row}"),
+                        Style::default().fg(theme.fg),
+                    )));
                 }
             } else {
-                lines.push(Line::from(Span::styled("  Safety number not available", Style::default().fg(theme.fg_muted))));
+                lines.push(Line::from(Span::styled(
+                    "  Safety number not available",
+                    Style::default().fg(theme.fg_muted),
+                )));
             }
         }
 
@@ -2886,7 +3298,12 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
         // 1:1 view: single identity with full details
         let identity = &app.verify.identities[0];
         let number = identity.number.as_deref().unwrap_or("unknown");
-        let name = app.store.contact_names.get(number).cloned().unwrap_or_else(|| number.to_string());
+        let name = app
+            .store
+            .contact_names
+            .get(number)
+            .cloned()
+            .unwrap_or_else(|| number.to_string());
 
         lines.push(Line::from(Span::styled(
             format!("  {} ({})", name, number),
@@ -2905,13 +3322,22 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
         lines.push(Line::from(""));
 
         if !identity.safety_number.is_empty() {
-            lines.push(Line::from(Span::styled("  Safety Number:", Style::default().fg(theme.fg_secondary))));
+            lines.push(Line::from(Span::styled(
+                "  Safety Number:",
+                Style::default().fg(theme.fg_secondary),
+            )));
             let formatted = format_safety_number(&identity.safety_number);
             for row in formatted {
-                lines.push(Line::from(Span::styled(format!("  {row}"), Style::default().fg(theme.fg))));
+                lines.push(Line::from(Span::styled(
+                    format!("  {row}"),
+                    Style::default().fg(theme.fg),
+                )));
             }
         } else {
-            lines.push(Line::from(Span::styled("  Safety number not available", Style::default().fg(theme.fg_muted))));
+            lines.push(Line::from(Span::styled(
+                "  Safety number not available",
+                Style::default().fg(theme.fg_muted),
+            )));
         }
 
         lines.push(Line::from(""));
@@ -2943,13 +3369,12 @@ fn draw_verify(frame: &mut Frame, app: &App, area: Rect) {
 /// Format a safety number string as groups of 5 digits, 6 per line.
 fn format_safety_number(sn: &str) -> Vec<String> {
     let digits: String = sn.chars().filter(|c| c.is_ascii_digit()).collect();
-    let chunks: Vec<&str> = digits.as_bytes()
+    let chunks: Vec<&str> = digits
+        .as_bytes()
         .chunks(5)
         .map(|chunk| std::str::from_utf8(chunk).unwrap_or(""))
         .collect();
-    chunks.chunks(6)
-        .map(|row| row.join(" "))
-        .collect()
+    chunks.chunks(6).map(|row| row.join(" ")).collect()
 }
 
 fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
@@ -2963,9 +3388,8 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
         format!(" Search [{}] ", app.search.query)
     };
 
-    let (popup_area, block) = centered_popup(
-        frame, area, SEARCH_POPUP_WIDTH, pref_height, &title, theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, SEARCH_POPUP_WIDTH, pref_height, &title, theme);
 
     let inner_height = popup_area.height.saturating_sub(2) as usize; // minus borders
     let footer_lines = 2; // footer + empty line
@@ -3024,7 +3448,13 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
 
             // Build spans with highlighted match
             let mut spans = vec![Span::styled(prefix, prefix_style)];
-            spans.extend(highlight_match_spans(&body_snippet, &app.search.query, body_style, is_selected, theme));
+            spans.extend(highlight_match_spans(
+                &body_snippet,
+                &app.search.query,
+                body_style,
+                is_selected,
+                theme,
+            ));
 
             lines.push(Line::from(spans));
         }
@@ -3042,10 +3472,7 @@ fn draw_search(frame: &mut Frame, app: &App, area: Rect) {
         format!("  {}/{}", app.search.index + 1, app.search.results.len())
     };
     lines.push(Line::from(vec![
-        Span::styled(
-            count_text,
-            Style::default().fg(theme.warning),
-        ),
+        Span::styled(count_text, Style::default().fg(theme.warning)),
         Span::styled(
             "  j/k nav | Enter jump | n/N cycle | Esc close",
             Style::default().fg(theme.fg_muted),
@@ -3086,7 +3513,10 @@ pub(crate) fn search_snippet(body: &str, query: &str, max_len: usize) -> String 
         result = format!("…{}", result.chars().skip(1).collect::<String>());
     }
     if end < char_count {
-        let trimmed: String = result.chars().take(result.chars().count().saturating_sub(1)).collect();
+        let trimmed: String = result
+            .chars()
+            .take(result.chars().count().saturating_sub(1))
+            .collect();
         result = format!("{trimmed}…");
     }
     result
@@ -3153,7 +3583,9 @@ fn highlight_match_spans<'a>(
     let mut orig_ranges: Vec<(usize, usize)> = Vec::new();
     for &(low_start, low_end) in &match_ranges {
         let start_char = lower_chars.iter().position(|&(pos, _)| pos == low_start);
-        let end_char = lower_chars.iter().position(|&(pos, _)| pos == low_end)
+        let end_char = lower_chars
+            .iter()
+            .position(|&(pos, _)| pos == low_end)
             .unwrap_or(char_count);
         if let Some(sc) = start_char {
             let orig_start = orig_chars[sc].0;
@@ -3201,9 +3633,11 @@ pub(crate) fn format_file_size(bytes: u64) -> String {
 
 fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
-    let visible_count = FILE_BROWSER_MAX_VISIBLE.min(
-        if app.file_picker.filtered.is_empty() { 1 } else { app.file_picker.filtered.len() }
-    );
+    let visible_count = FILE_BROWSER_MAX_VISIBLE.min(if app.file_picker.filtered.is_empty() {
+        1
+    } else {
+        app.file_picker.filtered.len()
+    });
     let pref_height = visible_count as u16 + 5; // border + header + footer
 
     let title = if app.file_picker.filter.is_empty() {
@@ -3213,7 +3647,12 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let (popup_area, block) = centered_popup(
-        frame, area, FILE_BROWSER_POPUP_WIDTH, pref_height, &title, theme,
+        frame,
+        area,
+        FILE_BROWSER_POPUP_WIDTH,
+        pref_height,
+        &title,
+        theme,
     );
 
     let inner_height = popup_area.height.saturating_sub(2) as usize;
@@ -3229,7 +3668,9 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
     let dir_truncated = truncate(&dir_display, inner_w.saturating_sub(2));
     lines.push(Line::from(Span::styled(
         format!("  {dir_truncated}"),
-        Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+        Style::default()
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD),
     )));
 
     if let Some(ref err) = app.file_picker.error {
@@ -3252,7 +3693,10 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
 
         let end = (scroll_offset + visible_rows).min(app.file_picker.filtered.len());
 
-        for (i, &entry_idx) in app.file_picker.filtered[scroll_offset..end].iter().enumerate() {
+        for (i, &entry_idx) in app.file_picker.filtered[scroll_offset..end]
+            .iter()
+            .enumerate()
+        {
             let actual_index = scroll_offset + i;
             let is_selected = actual_index == app.file_picker.index;
             let (ref name, is_dir, size) = app.file_picker.entries[entry_idx];
@@ -3276,9 +3720,15 @@ fn draw_file_browser(frame: &mut Frame, app: &App, area: Rect) {
 
             let name_style = if is_selected {
                 if is_dir {
-                    Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .bg(theme.bg_selected)
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                    Style::default()
+                        .bg(theme.bg_selected)
+                        .fg(theme.fg)
+                        .add_modifier(Modifier::BOLD)
                 }
             } else if is_dir {
                 Style::default().fg(theme.accent)
@@ -3323,17 +3773,19 @@ fn draw_theme_picker(frame: &mut Frame, app: &App, area: Rect) {
     let max_visible = 12usize.min(app.theme_picker.available_themes.len());
     let pref_height = max_visible as u16 + 5; // border + title + footer
 
-    let (popup_area, block) = centered_popup(
-        frame, area, 50, pref_height, " Theme ", theme,
-    );
+    let (popup_area, block) = centered_popup(frame, area, 50, pref_height, " Theme ", theme);
 
     let inner_height = popup_area.height.saturating_sub(2) as usize;
-    let (visible_rows, scroll_offset) = list_overlay::scroll_layout(inner_height, 2, app.theme_picker.index);
+    let (visible_rows, scroll_offset) =
+        list_overlay::scroll_layout(inner_height, 2, app.theme_picker.index);
 
     let mut lines: Vec<Line> = Vec::new();
 
     let end = (scroll_offset + visible_rows).min(app.theme_picker.available_themes.len());
-    for (i, t) in app.theme_picker.available_themes[scroll_offset..end].iter().enumerate() {
+    for (i, t) in app.theme_picker.available_themes[scroll_offset..end]
+        .iter()
+        .enumerate()
+    {
         let actual_index = scroll_offset + i;
         let is_selected = actual_index == app.theme_picker.index;
         let is_active = t.name == app.theme.name;
@@ -3345,16 +3797,37 @@ fn draw_theme_picker(frame: &mut Frame, app: &App, area: Rect) {
             Style::default().fg(theme.fg)
         };
         let marker_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(if is_active { theme.success } else { theme.fg_muted })
+            Style::default().bg(theme.bg_selected).fg(if is_active {
+                theme.success
+            } else {
+                theme.fg_muted
+            })
         } else {
-            Style::default().fg(if is_active { theme.success } else { theme.fg_muted })
+            Style::default().fg(if is_active {
+                theme.success
+            } else {
+                theme.fg_muted
+            })
         };
 
         // Color swatches: show accent, success, error as colored blocks
-        let swatch_bg = if is_selected { theme.bg_selected } else { theme.bg };
-        let swatch_accent = Span::styled("\u{2588}\u{2588}", Style::default().fg(t.accent).bg(swatch_bg));
-        let swatch_success = Span::styled("\u{2588}\u{2588}", Style::default().fg(t.success).bg(swatch_bg));
-        let swatch_error = Span::styled("\u{2588}\u{2588}", Style::default().fg(t.error).bg(swatch_bg));
+        let swatch_bg = if is_selected {
+            theme.bg_selected
+        } else {
+            theme.bg
+        };
+        let swatch_accent = Span::styled(
+            "\u{2588}\u{2588}",
+            Style::default().fg(t.accent).bg(swatch_bg),
+        );
+        let swatch_success = Span::styled(
+            "\u{2588}\u{2588}",
+            Style::default().fg(t.success).bg(swatch_bg),
+        );
+        let swatch_error = Span::styled(
+            "\u{2588}\u{2588}",
+            Style::default().fg(t.error).bg(swatch_bg),
+        );
 
         // Pad name to align swatches
         let name_width = 28;
@@ -3373,7 +3846,12 @@ fn draw_theme_picker(frame: &mut Frame, app: &App, area: Rect) {
         ]));
     }
 
-    list_overlay::append_footer(&mut lines, visible_rows, "  j/k navigate  |  Enter apply  |  Esc cancel", theme.fg_muted);
+    list_overlay::append_footer(
+        &mut lines,
+        visible_rows,
+        "  j/k navigate  |  Enter apply  |  Esc cancel",
+        theme.fg_muted,
+    );
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);
@@ -3393,9 +3871,8 @@ fn draw_keybindings(frame: &mut Frame, app: &App, area: Rect) {
     let pref_height = max_visible as u16 + 4; // borders + footer
     let pref_width = 52;
 
-    let (popup_area, block) = centered_popup(
-        frame, area, pref_width, pref_height, " Keybindings ", theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, pref_width, pref_height, " Keybindings ", theme);
 
     let inner_height = popup_area.height.saturating_sub(2) as usize;
     let footer_lines = 2;
@@ -3419,7 +3896,10 @@ fn draw_keybindings(frame: &mut Frame, app: &App, area: Rect) {
         if row == 0 {
             // Profile row
             let style = if is_selected {
-                Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .bg(theme.bg_selected)
+                    .fg(theme.fg)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(theme.fg_secondary)
             };
@@ -3442,7 +3922,10 @@ fn draw_keybindings(frame: &mut Frame, app: &App, area: Rect) {
             let header_style = Style::default()
                 .fg(theme.accent_secondary)
                 .add_modifier(Modifier::BOLD);
-            lines.push(Line::from(Span::styled(format!("  -- {label} --"), header_style)));
+            lines.push(Line::from(Span::styled(
+                format!("  -- {label} --"),
+                header_style,
+            )));
         } else {
             // Action row
             let action = action.unwrap();
@@ -3459,7 +3942,10 @@ fn draw_keybindings(frame: &mut Frame, app: &App, area: Rect) {
             };
 
             let row_style = if is_selected {
-                Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+                Style::default()
+                    .bg(theme.bg_selected)
+                    .fg(theme.fg)
+                    .add_modifier(Modifier::BOLD)
             } else {
                 Style::default().fg(theme.fg_secondary)
             };
@@ -3472,7 +3958,10 @@ fn draw_keybindings(frame: &mut Frame, app: &App, area: Rect) {
             let padded_label = format!("{label:width$}", width = key_col_width);
             lines.push(Line::from(vec![
                 Span::styled(format!("  {padded_label}"), row_style),
-                Span::styled(format!("{key_display:>width$}", width = val_col_width), key_style),
+                Span::styled(
+                    format!("{key_display:>width$}", width = val_col_width),
+                    key_style,
+                ),
             ]));
         }
     }
@@ -3497,9 +3986,8 @@ fn draw_keybindings_profile_picker(frame: &mut Frame, app: &App, area: Rect) {
     let max_visible = 8usize.min(app.keybindings_overlay.available_profiles.len());
     let pref_height = max_visible as u16 + 5;
 
-    let (popup_area, block) = centered_popup(
-        frame, area, 36, pref_height, " Keybinding Profile ", theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, 36, pref_height, " Keybinding Profile ", theme);
 
     let inner_height = popup_area.height.saturating_sub(2) as usize;
     let footer_lines = 2;
@@ -3515,23 +4003,38 @@ fn draw_keybindings_profile_picker(frame: &mut Frame, app: &App, area: Rect) {
     let end = (scroll_offset + visible_rows).min(app.keybindings_overlay.available_profiles.len());
     for i in scroll_offset..end {
         let is_selected = i == app.keybindings_overlay.profile_index;
-        let is_active = app.keybindings_overlay.available_profiles[i] == app.keybindings.profile_name;
+        let is_active =
+            app.keybindings_overlay.available_profiles[i] == app.keybindings.profile_name;
         let marker = if is_active { "[*]" } else { "[ ]" };
 
         let row_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg)
         };
         let marker_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(if is_active { theme.success } else { theme.fg_muted })
+            Style::default().bg(theme.bg_selected).fg(if is_active {
+                theme.success
+            } else {
+                theme.fg_muted
+            })
         } else {
-            Style::default().fg(if is_active { theme.success } else { theme.fg_muted })
+            Style::default().fg(if is_active {
+                theme.success
+            } else {
+                theme.fg_muted
+            })
         };
 
         lines.push(Line::from(vec![
             Span::styled(format!("  {marker} "), marker_style),
-            Span::styled(app.keybindings_overlay.available_profiles[i].clone(), row_style),
+            Span::styled(
+                app.keybindings_overlay.available_profiles[i].clone(),
+                row_style,
+            ),
         ]));
     }
 
@@ -3561,9 +4064,8 @@ fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
     let max_visible = 10usize.min(app.settings_profiles.available.len());
     let pref_height = max_visible as u16 + 5; // borders + footer
 
-    let (popup_area, block) = centered_popup(
-        frame, area, 42, pref_height, " Settings Profiles ", theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, 42, pref_height, " Settings Profiles ", theme);
 
     let inner_height = popup_area.height.saturating_sub(2) as usize;
     let footer_lines = 2;
@@ -3576,7 +4078,10 @@ fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     // Determine if current settings differ from loaded profile
-    let has_changes = !app.settings_profiles.available.iter()
+    let has_changes = !app
+        .settings_profiles
+        .available
+        .iter()
         .any(|p| p.name == app.settings_profiles.name && p.matches_app(app));
 
     let mut lines: Vec<Line> = Vec::new();
@@ -3588,14 +4093,25 @@ fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
 
         let marker = if is_active { ">" } else { " " };
         let row_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg)
         };
         let marker_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(if is_active { theme.accent } else { theme.fg_muted })
+            Style::default().bg(theme.bg_selected).fg(if is_active {
+                theme.accent
+            } else {
+                theme.fg_muted
+            })
         } else {
-            Style::default().fg(if is_active { theme.accent } else { theme.fg_muted })
+            Style::default().fg(if is_active {
+                theme.accent
+            } else {
+                theme.fg_muted
+            })
         };
 
         lines.push(Line::from(vec![
@@ -3609,7 +4125,10 @@ fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     // Build contextual footer hints
-    let selected_profile = app.settings_profiles.available.get(app.settings_profiles.index);
+    let selected_profile = app
+        .settings_profiles
+        .available
+        .get(app.settings_profiles.index);
     let is_builtin = selected_profile
         .map(|p| crate::settings_profile::is_builtin(&p.name))
         .unwrap_or(true);
@@ -3637,18 +4156,22 @@ fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
 
 fn draw_settings_profile_save_as(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
-    let (popup_area, block) = centered_popup(
-        frame, area, 40, 7, " Save Profile As ", theme,
-    );
+    let (popup_area, block) = centered_popup(frame, area, 40, 7, " Save Profile As ", theme);
 
-    let cursor_char = if app.settings_profiles.save_as_input.is_empty() { "_" } else { "" };
+    let cursor_char = if app.settings_profiles.save_as_input.is_empty() {
+        "_"
+    } else {
+        ""
+    };
     let lines = vec![
         Line::from(""),
         Line::from(vec![
             Span::styled("  Name: ", Style::default().fg(theme.fg_secondary)),
             Span::styled(
                 format!("{}{cursor_char}", app.settings_profiles.save_as_input),
-                Style::default().fg(theme.fg).add_modifier(Modifier::UNDERLINED),
+                Style::default()
+                    .fg(theme.fg)
+                    .add_modifier(Modifier::UNDERLINED),
             ),
         ]),
         Line::from(""),
@@ -3667,9 +4190,8 @@ fn draw_pin_duration_picker(frame: &mut Frame, app: &App, area: Rect) {
     let item_count = PIN_DURATIONS.len();
     let popup_height = item_count as u16 + 4; // borders + footer
 
-    let (popup_area, block) = centered_popup(
-        frame, area, 24, popup_height, " Pin Duration ", theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, 24, popup_height, " Pin Duration ", theme);
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -3679,7 +4201,11 @@ fn draw_pin_duration_picker(frame: &mut Frame, app: &App, area: Rect) {
         } else {
             Style::default().fg(theme.fg)
         };
-        let marker = if i == app.pin_duration.index { ">" } else { " " };
+        let marker = if i == app.pin_duration.index {
+            ">"
+        } else {
+            " "
+        };
         lines.push(Line::from(Span::styled(
             format!(" {marker} {label}"),
             style,
@@ -3732,7 +4258,9 @@ pub(crate) fn build_poll_display(
 
         let voted_marker = if own_selections[i] { "\u{2713} " } else { "  " };
         let text_style = if own_selections[i] {
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg)
         };
@@ -3745,10 +4273,7 @@ pub(crate) fn build_poll_display(
         };
         lines.push(Line::from(vec![
             Span::styled(format!("  {voted_marker}"), text_style),
-            Span::styled(
-                format!("{:<12}", label),
-                text_style,
-            ),
+            Span::styled(format!("{:<12}", label), text_style),
             Span::styled(bar, Style::default().fg(theme.accent)),
             Span::styled(
                 format!("  {count} ({pct}%)"),
@@ -3757,7 +4282,11 @@ pub(crate) fn build_poll_display(
         ]));
     }
 
-    let mode = if poll.allow_multiple { "multi-select" } else { "single choice" };
+    let mode = if poll.allow_multiple {
+        "multi-select"
+    } else {
+        "single choice"
+    };
     let status = if poll.closed { " [CLOSED]" } else { "" };
     lines.push(Line::from(Span::styled(
         format!("    {total_votes} votes \u{00b7} {mode}{status}"),
@@ -3775,13 +4304,19 @@ fn draw_poll_vote_overlay(frame: &mut Frame, app: &App, area: Rect) {
     };
 
     let option_count = pending.options.len();
-    let max_text_len = pending.options.iter().map(|o| o.text.len()).max().unwrap_or(8);
-    let popup_width = (max_text_len as u16 + 12).max(24).min(area.width.saturating_sub(4));
+    let max_text_len = pending
+        .options
+        .iter()
+        .map(|o| o.text.len())
+        .max()
+        .unwrap_or(8);
+    let popup_width = (max_text_len as u16 + 12)
+        .max(24)
+        .min(area.width.saturating_sub(4));
     let popup_height = option_count as u16 + 5;
 
-    let (popup_area, block) = centered_popup(
-        frame, area, popup_width, popup_height, " Vote ", theme,
-    );
+    let (popup_area, block) =
+        centered_popup(frame, area, popup_width, popup_height, " Vote ", theme);
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -3790,7 +4325,10 @@ fn draw_poll_vote_overlay(frame: &mut Frame, app: &App, area: Rect) {
         let marker = if i == app.poll_vote.index { ">" } else { " " };
         let checkbox = if selected { "[x]" } else { "[ ]" };
         let style = if i == app.poll_vote.index {
-            Style::default().bg(theme.bg_selected).fg(theme.fg).add_modifier(Modifier::BOLD)
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg)
         };
@@ -3801,7 +4339,11 @@ fn draw_poll_vote_overlay(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     lines.push(Line::from(""));
-    let mode_hint = if pending.allow_multiple { "Space: toggle" } else { "Space: select" };
+    let mode_hint = if pending.allow_multiple {
+        "Space: toggle"
+    } else {
+        "Space: select"
+    };
     lines.push(Line::from(Span::styled(
         format!(" {mode_hint}  Enter: submit  Esc"),
         Style::default().fg(theme.fg_muted),
@@ -3819,7 +4361,9 @@ fn draw_about(frame: &mut Frame, app: &App, area: Rect) {
         Line::from(""),
         Line::from(Span::styled(
             format!("  siggy v{version}"),
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
         Line::from(Span::styled(
@@ -3848,7 +4392,12 @@ fn draw_about(frame: &mut Frame, app: &App, area: Rect) {
 
     let pref_height = lines.len() as u16 + 2; // +2 for borders
     let (popup_area, block) = centered_popup(
-        frame, area, ABOUT_POPUP_WIDTH, pref_height, " About ", theme,
+        frame,
+        area,
+        ABOUT_POPUP_WIDTH,
+        pref_height,
+        " About ",
+        theme,
     );
 
     let popup = Paragraph::new(lines).block(block);
@@ -3866,7 +4415,9 @@ fn draw_profile(frame: &mut Frame, app: &App, area: Rect) {
         let is_editing = is_selected && app.profile.editing;
 
         let label_style = if is_selected {
-            Style::default().fg(theme.accent).add_modifier(Modifier::BOLD)
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
         } else {
             Style::default().fg(theme.fg_secondary)
         };
@@ -3875,7 +4426,11 @@ fn draw_profile(frame: &mut Frame, app: &App, area: Rect) {
             format!("{}\u{2588}", app.profile.edit_buffer) // block cursor
         } else {
             let v = &app.profile.fields[i];
-            if v.is_empty() { "(empty)".to_string() } else { v.clone() }
+            if v.is_empty() {
+                "(empty)".to_string()
+            } else {
+                v.clone()
+            }
         };
 
         let value_style = if is_editing || is_selected {
@@ -3906,7 +4461,10 @@ fn draw_profile(frame: &mut Frame, app: &App, area: Rect) {
     // Save button
     let save_selected = app.profile.index == 4;
     let save_style = if save_selected {
-        Style::default().bg(theme.bg_selected).fg(theme.accent).add_modifier(Modifier::BOLD)
+        Style::default()
+            .bg(theme.bg_selected)
+            .fg(theme.accent)
+            .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme.fg_secondary)
     };
@@ -3926,7 +4484,12 @@ fn draw_profile(frame: &mut Frame, app: &App, area: Rect) {
 
     let pref_height = lines.len() as u16 + 2; // +2 for borders
     let (popup_area, block) = centered_popup(
-        frame, area, PROFILE_POPUP_WIDTH, pref_height, " Edit Profile ", theme,
+        frame,
+        area,
+        PROFILE_POPUP_WIDTH,
+        pref_height,
+        " Edit Profile ",
+        theme,
     );
 
     let popup = Paragraph::new(lines).block(block);
@@ -3938,10 +4501,11 @@ fn draw_forward(frame: &mut Frame, app: &App, area: Rect) {
     let max_rows = 10usize;
     let list_height = app.forward.filtered.len().min(max_rows);
     let pref_height = (list_height + 4) as u16; // filter line + blank + list + footer
-    let (popup_area, block) = centered_popup(
-        frame, area, 45, pref_height, " Forward to ", theme,
-    );
-    let inner = popup_area.inner(ratatui::layout::Margin { horizontal: 1, vertical: 1 });
+    let (popup_area, block) = centered_popup(frame, area, 45, pref_height, " Forward to ", theme);
+    let inner = popup_area.inner(ratatui::layout::Margin {
+        horizontal: 1,
+        vertical: 1,
+    });
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -3956,7 +4520,10 @@ fn draw_forward(frame: &mut Frame, app: &App, area: Rect) {
     } else {
         Style::default().fg(theme.fg)
     };
-    lines.push(Line::from(Span::styled(format!("  > {filter_display}"), filter_style)));
+    lines.push(Line::from(Span::styled(
+        format!("  > {filter_display}"),
+        filter_style,
+    )));
     lines.push(Line::from(""));
 
     // Conversation list
@@ -3983,10 +4550,7 @@ fn draw_forward(frame: &mut Frame, app: &App, area: Rect) {
             } else {
                 Style::default().fg(theme.fg)
             };
-            lines.push(Line::from(Span::styled(
-                format!("{prefix}{name}"),
-                style,
-            )));
+            lines.push(Line::from(Span::styled(format!("{prefix}{name}"), style)));
         }
     }
 
@@ -4097,8 +4661,14 @@ mod tests {
     fn reaction_summary_counts() {
         let theme = default_theme();
         let reactions = vec![
-            Reaction { emoji: "\u{1f44d}".to_string(), sender: "Alice".to_string() },
-            Reaction { emoji: "\u{1f44d}".to_string(), sender: "Bob".to_string() },
+            Reaction {
+                emoji: "\u{1f44d}".to_string(),
+                sender: "Alice".to_string(),
+            },
+            Reaction {
+                emoji: "\u{1f44d}".to_string(),
+                sender: "Bob".to_string(),
+            },
         ];
         let line = build_reaction_summary(&reactions, false, false, &theme);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
@@ -4108,9 +4678,10 @@ mod tests {
     #[test]
     fn reaction_summary_verbose_names() {
         let theme = default_theme();
-        let reactions = vec![
-            Reaction { emoji: "\u{2764}".to_string(), sender: "Alice".to_string() },
-        ];
+        let reactions = vec![Reaction {
+            emoji: "\u{2764}".to_string(),
+            sender: "Alice".to_string(),
+        }];
         let line = build_reaction_summary(&reactions, true, false, &theme);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("Alice"), "expected sender name in: {text}");
@@ -4132,19 +4703,41 @@ mod tests {
         let poll = PollData {
             question: "Favorite?".to_string(),
             options: vec![
-                PollOption { id: 0, text: "A".to_string() },
-                PollOption { id: 1, text: "B".to_string() },
+                PollOption {
+                    id: 0,
+                    text: "A".to_string(),
+                },
+                PollOption {
+                    id: 1,
+                    text: "B".to_string(),
+                },
             ],
             allow_multiple: false,
             closed: false,
         };
         let votes = vec![
-            PollVote { voter: "+1".to_string(), voter_name: None, option_indexes: vec![0], vote_count: 1 },
-            PollVote { voter: "+2".to_string(), voter_name: None, option_indexes: vec![0], vote_count: 1 },
+            PollVote {
+                voter: "+1".to_string(),
+                voter_name: None,
+                option_indexes: vec![0],
+                vote_count: 1,
+            },
+            PollVote {
+                voter: "+2".to_string(),
+                voter_name: None,
+                option_indexes: vec![0],
+                vote_count: 1,
+            },
         ];
         let lines = build_poll_display(&poll, &votes, "+99", &theme);
         assert_eq!(lines.len(), 3);
-        let summary: String = lines.last().unwrap().spans.iter().map(|s| s.content.to_string()).collect();
+        let summary: String = lines
+            .last()
+            .unwrap()
+            .spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
         assert!(summary.contains("votes"), "expected 'votes' in: {summary}");
     }
 
@@ -4153,16 +4746,29 @@ mod tests {
         let theme = default_theme();
         let poll = PollData {
             question: "Q?".to_string(),
-            options: vec![PollOption { id: 0, text: "Yes".to_string() }],
+            options: vec![PollOption {
+                id: 0,
+                text: "Yes".to_string(),
+            }],
             allow_multiple: false,
             closed: false,
         };
-        let votes = vec![
-            PollVote { voter: "+me".to_string(), voter_name: None, option_indexes: vec![0], vote_count: 1 },
-        ];
+        let votes = vec![PollVote {
+            voter: "+me".to_string(),
+            voter_name: None,
+            option_indexes: vec![0],
+            vote_count: 1,
+        }];
         let lines = build_poll_display(&poll, &votes, "+me", &theme);
-        let option_text: String = lines[0].spans.iter().map(|s| s.content.to_string()).collect();
-        assert!(option_text.contains("\u{2713}"), "expected checkmark in: {option_text}");
+        let option_text: String = lines[0]
+            .spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(
+            option_text.contains("\u{2713}"),
+            "expected checkmark in: {option_text}"
+        );
     }
 
     #[test]
@@ -4170,13 +4776,25 @@ mod tests {
         let theme = default_theme();
         let poll = PollData {
             question: "Q?".to_string(),
-            options: vec![PollOption { id: 0, text: "X".to_string() }],
+            options: vec![PollOption {
+                id: 0,
+                text: "X".to_string(),
+            }],
             allow_multiple: false,
             closed: true,
         };
         let lines = build_poll_display(&poll, &[], "+me", &theme);
-        let summary: String = lines.last().unwrap().spans.iter().map(|s| s.content.to_string()).collect();
-        assert!(summary.contains("[CLOSED]"), "expected [CLOSED] in: {summary}");
+        let summary: String = lines
+            .last()
+            .unwrap()
+            .spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(
+            summary.contains("[CLOSED]"),
+            "expected [CLOSED] in: {summary}"
+        );
     }
 
     #[test]
@@ -4184,15 +4802,34 @@ mod tests {
         let theme = default_theme();
         let poll = PollData {
             question: "Q?".to_string(),
-            options: vec![PollOption { id: 0, text: "A".to_string() }],
+            options: vec![PollOption {
+                id: 0,
+                text: "A".to_string(),
+            }],
             allow_multiple: false,
             closed: false,
         };
         let lines = build_poll_display(&poll, &[], "+me", &theme);
-        let option_text: String = lines[0].spans.iter().map(|s| s.content.to_string()).collect();
-        assert!(option_text.contains("0 (0%)"), "expected '0 (0%)' in: {option_text}");
-        let summary: String = lines.last().unwrap().spans.iter().map(|s| s.content.to_string()).collect();
-        assert!(summary.contains("0 votes"), "expected '0 votes' in: {summary}");
+        let option_text: String = lines[0]
+            .spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(
+            option_text.contains("0 (0%)"),
+            "expected '0 (0%)' in: {option_text}"
+        );
+        let summary: String = lines
+            .last()
+            .unwrap()
+            .spans
+            .iter()
+            .map(|s| s.content.to_string())
+            .collect();
+        assert!(
+            summary.contains("0 votes"),
+            "expected '0 votes' in: {summary}"
+        );
     }
 
     // --- format_file_size ---
@@ -4220,8 +4857,15 @@ mod tests {
     fn search_snippet_centers_on_match() {
         let body = "a".repeat(100) + "NEEDLE" + &"b".repeat(100);
         let snippet = search_snippet(&body, "NEEDLE", 30);
-        assert!(snippet.chars().count() <= 30, "snippet too long ({} chars): {snippet}", snippet.chars().count());
-        assert!(snippet.contains("NEEDLE"), "expected query in snippet: {snippet}");
+        assert!(
+            snippet.chars().count() <= 30,
+            "snippet too long ({} chars): {snippet}",
+            snippet.chars().count()
+        );
+        assert!(
+            snippet.contains("NEEDLE"),
+            "expected query in snippet: {snippet}"
+        );
     }
 }
 
@@ -4257,9 +4901,7 @@ mod snapshot_tests {
     fn render_to_string(app: &mut App, width: u16, height: u16) -> String {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
-        terminal
-            .draw(|frame| draw(frame, app))
-            .unwrap();
+        terminal.draw(|frame| draw(frame, app)).unwrap();
         let buffer = terminal.backend().buffer().clone();
         let mut output = String::new();
         for y in 0..buffer.area.height {
@@ -4396,15 +5038,18 @@ mod snapshot_tests {
         use crate::app::Conversation;
         let mut app = demo_app();
         let empty_id = "+15550009999".to_string();
-        app.store.conversations.insert(empty_id.clone(), Conversation {
-            name: "Empty".to_string(),
-            id: empty_id.clone(),
-            messages: Vec::new(),
-            unread: 0,
-            is_group: false,
-            expiration_timer: 0,
-            accepted: true,
-        });
+        app.store.conversations.insert(
+            empty_id.clone(),
+            Conversation {
+                name: "Empty".to_string(),
+                id: empty_id.clone(),
+                messages: Vec::new(),
+                unread: 0,
+                is_group: false,
+                expiration_timer: 0,
+                accepted: true,
+            },
+        );
         app.store.conversation_order.push(empty_id.clone());
         app.active_conversation = Some(empty_id);
         let output = render_to_string(&mut app, 100, 30);


### PR DESCRIPTION
## Summary

Two-commit PR:

1. One-off \`cargo fmt\` pass across the codebase (mechanical, no logic changes; 20 files).
2. Adds \`cargo fmt --check\` step to CI.

After this lands, contributor PRs that run \`cargo fmt\` will no longer produce massive formatting diffs (see #319 for an example of what this prevents).

No \`rustfmt.toml\` - default rustfmt is the source of truth.

See \`docs/superpowers/specs/2026-04-19-repo-hygiene-design.md\`.

## Test plan

- [x] \`cargo fmt --check\` passes locally.
- [x] \`cargo clippy --tests -- -D warnings\` passes.
- [x] \`cargo test\` passes (472 tests).
- [ ] CI green (will run the new format check step).

## Review tip

Review commit 1 for logic changes (there should be none - it's pure fmt). Review commit 2 for the CI step placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)