### PR TITLE
fix: re-resolve @mentions when contact/group list arrives (closes #283)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -25,7 +25,7 @@ use crate::input::{self, InputAction, COMMANDS};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
 use crate::list_overlay::{self, classify_list_key, ListKeyAction};
 use crate::signal::types::{
-    Contact, Group, IdentityInfo, MessageStatus, PollData, PollOption, PollVote, Reaction,
+    Contact, Group, IdentityInfo, Mention, MessageStatus, PollData, PollOption, PollVote, Reaction,
     SignalEvent, SignalMessage, StyleType, TrustLevel,
 };
 use crate::theme::{self, Theme};
@@ -4360,7 +4360,9 @@ impl App {
                             image_path: Option<String>,
                             mention_ranges: Vec<(usize, usize)>,
                             style_ranges: Vec<(usize, usize, StyleType)>,
-                            quote: Option<Quote>| {
+                            quote: Option<Quote>,
+                            body_raw: Option<String>,
+                            mentions: Vec<Mention>| {
             // Check for buffered poll data from a race condition (poll event arrived first)
             let deferred_poll = self
                 .poll_vote
@@ -4384,6 +4386,8 @@ impl App {
                         reactions: Vec::new(),
                         mention_ranges,
                         style_ranges,
+                        body_raw: body_raw.clone(),
+                        mentions: mentions.clone(),
                         quote,
                         is_edited: false,
                         is_deleted: false,
@@ -4429,8 +4433,24 @@ impl App {
         };
 
         // Add text body (with resolved @mentions and text styles)
+        let had_mentions = !msg.mentions.is_empty();
         if let Some((resolved, ranges)) = resolved_body {
-            push_msg(resolved, None, None, ranges, resolved_styles, display_quote);
+            let raw_body_for_msg = if had_mentions { msg.body.clone() } else { None };
+            let mentions_for_msg = if had_mentions {
+                msg.mentions.clone()
+            } else {
+                Vec::new()
+            };
+            push_msg(
+                resolved,
+                None,
+                None,
+                ranges,
+                resolved_styles,
+                display_quote,
+                raw_body_for_msg,
+                mentions_for_msg,
+            );
         }
 
         // Add attachment notices
@@ -4459,6 +4479,8 @@ impl App {
                     Vec::new(),
                     Vec::new(),
                     None,
+                    None,
+                    Vec::new(),
                 );
             } else {
                 push_msg(
@@ -4468,6 +4490,20 @@ impl App {
                     Vec::new(),
                     Vec::new(),
                     None,
+                    None,
+                    Vec::new(),
+                );
+            }
+        }
+
+        // Persist raw body + mentions so the display body can be re-resolved
+        // later when the contact list or group list fills in unknown UUIDs.
+        if had_mentions {
+            if let Some(ref raw) = msg.body {
+                db_warn(
+                    self.db
+                        .upsert_message_mentions(&conv_id, msg_ts_ms, raw, &msg.mentions),
+                    "upsert_message_mentions",
                 );
             }
         }
@@ -4640,6 +4676,8 @@ impl App {
                     reactions: Vec::new(),
                     mention_ranges: Vec::new(),
                     style_ranges: Vec::new(),
+                    body_raw: None,
+                    mentions: Vec::new(),
                     quote: None,
                     is_edited: false,
                     is_deleted: false,
@@ -5366,6 +5404,10 @@ impl App {
         // Re-resolve reaction senders: DB stores phone numbers but display
         // needs contact names (or "you" for own reactions).
         self.store.resolve_stored_names(&self.account);
+
+        // Re-resolve @mention display bodies: messages that arrived before the
+        // contact list may have fallen back to truncated UUIDs. (#283)
+        self.store.rebuild_mention_display(&self.db);
     }
 
     fn handle_group_list(&mut self, groups: Vec<Group>) {
@@ -5410,6 +5452,10 @@ impl App {
         }
         // Re-resolve reaction senders with any new names from group members.
         self.store.resolve_stored_names(&self.account);
+
+        // Re-resolve @mention display bodies: group member names may now fill
+        // in UUIDs that weren't known at message-receipt time. (#283)
+        self.store.rebuild_mention_display(&self.db);
     }
 
     fn handle_identity_list(&mut self, identities: Vec<IdentityInfo>) {
@@ -5843,6 +5889,19 @@ impl App {
                             reactions: Vec::new(),
                             mention_ranges,
                             style_ranges: Vec::new(),
+                            body_raw: if wire_mentions.is_empty() {
+                                None
+                            } else {
+                                Some(wire_body.clone())
+                            },
+                            mentions: wire_mentions
+                                .iter()
+                                .map(|(start, uuid)| Mention {
+                                    start: *start,
+                                    length: 1,
+                                    uuid: uuid.clone(),
+                                })
+                                .collect(),
                             quote,
                             is_edited: false,
                             is_deleted: false,
@@ -6242,6 +6301,8 @@ impl App {
                             reactions: Vec::new(),
                             mention_ranges: Vec::new(),
                             style_ranges: Vec::new(),
+                            body_raw: None,
+                            mentions: Vec::new(),
                             quote: None,
                             is_edited: false,
                             is_deleted: false,
@@ -7460,6 +7521,8 @@ impl App {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -8911,6 +8974,8 @@ mod tests {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -8968,6 +9033,8 @@ mod tests {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -9016,6 +9083,8 @@ mod tests {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -9065,6 +9134,8 @@ mod tests {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -9231,6 +9302,8 @@ mod tests {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -9434,6 +9507,8 @@ mod tests {
                 reactions: Vec::new(),
                 mention_ranges: Vec::new(),
                 style_ranges: Vec::new(),
+                body_raw: None,
+                mentions: Vec::new(),
                 quote: None,
                 is_edited: false,
                 is_deleted: false,
@@ -9508,6 +9583,8 @@ mod tests {
             reactions: Vec::new(),
             mention_ranges: Vec::new(),
             style_ranges: Vec::new(),
+            body_raw: None,
+            mentions: Vec::new(),
             quote: None,
             is_edited: false,
             is_deleted: false,
@@ -9546,6 +9623,8 @@ mod tests {
             ],
             mention_ranges: Vec::new(),
             style_ranges: Vec::new(),
+            body_raw: None,
+            mentions: Vec::new(),
             // Quote from own account (should become "you")
             quote: Some(Quote {
                 author: "+10000000000".to_string(),
@@ -9578,6 +9657,8 @@ mod tests {
             reactions: Vec::new(),
             mention_ranges: Vec::new(),
             style_ranges: Vec::new(),
+            body_raw: None,
+            mentions: Vec::new(),
             quote: Some(Quote {
                 author: "+3".to_string(),
                 body: "hey".to_string(),
@@ -9663,6 +9744,54 @@ mod tests {
         for (range, tag) in ranges.iter().zip(expected_tags.iter()) {
             assert_eq!(&resolved[range.0..range.1], *tag);
         }
+    }
+
+    #[rstest]
+    fn mention_reresolves_when_contact_arrives_after_message(mut app: App) {
+        // Regression test for #283: message with mention arrives before
+        // contact list is processed, so the mention initially falls back
+        // to a truncated UUID. When the contact list arrives, the mention
+        // should update to the real name.
+        let msg = SignalMessage {
+            source: "+15550001111".to_string(),
+            source_name: None,
+            source_uuid: Some("aaaaaaaa-1111-1111-1111-111111111111".to_string()),
+            timestamp: chrono::Utc::now(),
+            body: Some("hi \u{FFFC} welcome".to_string()),
+            attachments: vec![],
+            group_id: None,
+            group_name: None,
+            is_outgoing: false,
+            destination: None,
+            mentions: vec![Mention {
+                start: 3,
+                length: 1,
+                uuid: "bbbbbbbb-2222-2222-2222-222222222222".to_string(),
+            }],
+            text_styles: vec![],
+            quote: None,
+            expires_in_seconds: 0,
+            previews: Vec::new(),
+        };
+        app.handle_signal_event(SignalEvent::MessageReceived(msg));
+
+        // Initial resolution falls back to truncated UUID.
+        let body = &app.store.conversations["+15550001111"].messages[0].body;
+        assert!(
+            body.contains("@bbbbbbbb"),
+            "expected truncated UUID fallback, got {body:?}"
+        );
+
+        // Contact list arrives with the mentioned user.
+        app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+            number: "+15550002222".to_string(),
+            name: Some("Bob".to_string()),
+            uuid: Some("bbbbbbbb-2222-2222-2222-222222222222".to_string()),
+        }]));
+
+        // Mention should now resolve to the real name.
+        let body = &app.store.conversations["+15550001111"].messages[0].body;
+        assert_eq!(body, "hi @Bob welcome");
     }
 
     #[rstest]

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -14,6 +14,91 @@ pub(crate) fn db_warn<T>(result: Result<T, impl std::fmt::Display>, context: &st
     }
 }
 
+/// Resolve U+FFFC placeholders in a message body using bodyRanges mentions against
+/// a supplied `uuid_to_name` map. Returns (resolved_body, mention_byte_ranges).
+/// Extracted as a free function so callers can re-resolve against a cloned or
+/// borrowed map without conflicting with mutable iteration over conversations.
+pub fn resolve_mentions_with(
+    body: &str,
+    mentions: &[Mention],
+    uuid_to_name: &HashMap<String, String>,
+) -> (String, Vec<(usize, usize)>) {
+    if mentions.is_empty() {
+        return (body.to_string(), Vec::new());
+    }
+
+    let lookup = |uuid: &str| -> String {
+        uuid_to_name.get(uuid).cloned().unwrap_or_else(|| {
+            // Truncated UUID fallback
+            let short = if uuid.len() > 8 { &uuid[..8] } else { uuid };
+            short.to_string()
+        })
+    };
+
+    // Sort mentions by start descending so replacements don't shift earlier offsets
+    let mut sorted: Vec<&Mention> = mentions.iter().collect();
+    sorted.sort_by_key(|b| std::cmp::Reverse(b.start));
+
+    // Convert body to UTF-16 for offset mapping
+    let utf16: Vec<u16> = body.encode_utf16().collect();
+    let mut result_utf16 = utf16.clone();
+    for mention in &sorted {
+        if mention.start >= result_utf16.len() {
+            continue;
+        }
+        let name = lookup(&mention.uuid);
+        let replacement = format!("@{name}");
+        let replacement_utf16: Vec<u16> = replacement.encode_utf16().collect();
+        let end = (mention.start + mention.length).min(result_utf16.len());
+        result_utf16.splice(mention.start..end, replacement_utf16);
+    }
+
+    let resolved = String::from_utf16_lossy(&result_utf16);
+
+    // Compute byte ranges for each @Name in the resolved string
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    let mut sorted_fwd: Vec<&Mention> = mentions.iter().collect();
+    sorted_fwd.sort_by_key(|m| m.start);
+
+    // Re-build with forward pass to get accurate byte offsets
+    let resolved_utf16: Vec<u16> = resolved.encode_utf16().collect();
+    let mut byte_pos = 0;
+    let resolved_bytes = resolved.as_bytes();
+
+    // Build utf16_offset -> byte_offset mapping
+    let mut utf16_to_byte: Vec<usize> = Vec::with_capacity(resolved_utf16.len() + 1);
+    for ch in resolved.chars() {
+        let utf16_len = ch.len_utf16();
+        let utf8_len = ch.len_utf8();
+        for _ in 0..utf16_len {
+            utf16_to_byte.push(byte_pos);
+        }
+        byte_pos += utf8_len;
+    }
+    utf16_to_byte.push(byte_pos); // sentinel for end
+
+    // Calculate where each mention ended up after all replacements
+    let mut offset_shift: i64 = 0;
+    for mention in &sorted_fwd {
+        let adjusted_start = (mention.start as i64 + offset_shift) as usize;
+        let name = lookup(&mention.uuid);
+        let replacement_utf16_len = format!("@{name}").encode_utf16().count();
+        let byte_start = utf16_to_byte
+            .get(adjusted_start)
+            .copied()
+            .unwrap_or(resolved_bytes.len());
+        let byte_end = utf16_to_byte
+            .get(adjusted_start + replacement_utf16_len)
+            .copied()
+            .unwrap_or(resolved_bytes.len());
+        ranges.push((byte_start, byte_end));
+        // This mention replaced `mention.length` UTF-16 units with `replacement_utf16_len`
+        offset_shift += replacement_utf16_len as i64 - mention.length as i64;
+    }
+
+    (resolved, ranges)
+}
+
 /// Shorten a phone number for display: +15551234567 -> +1***4567
 pub(crate) fn short_name(number: &str) -> String {
     let chars: Vec<char> = number.chars().collect();
@@ -55,6 +140,13 @@ pub struct DisplayMessage {
     pub reactions: Vec<Reaction>,
     /// Byte ranges of @mentions in body (for styling)
     pub mention_ranges: Vec<(usize, usize)>,
+    /// Original body with U+FFFC placeholders, for lazy re-resolution of mentions
+    /// when the contact list updates. `None` for legacy messages or messages with
+    /// no mentions.
+    pub body_raw: Option<String>,
+    /// Raw mentions from signal-cli's bodyRanges array. Empty for messages with
+    /// no mentions or legacy messages without a stored raw body.
+    pub mentions: Vec<Mention>,
     /// Byte ranges + style type for text styling (bold, italic, etc.)
     pub style_ranges: Vec<(usize, usize, StyleType)>,
     /// Quoted reply context
@@ -237,95 +329,40 @@ impl ConversationStore {
         body: &str,
         mentions: &[Mention],
     ) -> (String, Vec<(usize, usize)>) {
-        if mentions.is_empty() {
-            return (body.to_string(), Vec::new());
-        }
+        resolve_mentions_with(body, mentions, &self.uuid_to_name)
+    }
 
-        // Sort mentions by start descending so replacements don't shift earlier offsets
-        let mut sorted: Vec<&Mention> = mentions.iter().collect();
-        sorted.sort_by_key(|b| std::cmp::Reverse(b.start));
-
-        // Convert body to UTF-16 for offset mapping
-        let utf16: Vec<u16> = body.encode_utf16().collect();
-        let mut result_utf16 = utf16.clone();
-        for mention in &sorted {
-            if mention.start >= result_utf16.len() {
-                continue;
+    /// Re-resolve @mentions across all stored messages using the current
+    /// `uuid_to_name` map. Intended to be called after a contact or group list
+    /// update populates previously-unknown UUIDs. Persists updated bodies to
+    /// the database.
+    ///
+    /// Fix for #283: before this, the first render of a message with mentions
+    /// that arrived before the contact list would bake the truncated UUID into
+    /// the display body forever.
+    pub fn rebuild_mention_display(&mut self, db: &Database) {
+        let uuid_to_name = self.uuid_to_name.clone();
+        for (conv_id, conv) in self.conversations.iter_mut() {
+            for msg in conv.messages.iter_mut() {
+                if msg.mentions.is_empty() {
+                    continue;
+                }
+                let body_raw = match &msg.body_raw {
+                    Some(b) => b.clone(),
+                    None => continue,
+                };
+                let (resolved, ranges) =
+                    resolve_mentions_with(&body_raw, &msg.mentions, &uuid_to_name);
+                if resolved != msg.body {
+                    msg.body = resolved.clone();
+                    msg.mention_ranges = ranges;
+                    db_warn(
+                        db.update_message_body(conv_id, msg.timestamp_ms, &resolved),
+                        "update_message_body (rebuild_mentions)",
+                    );
+                }
             }
-            let name = self
-                .uuid_to_name
-                .get(&mention.uuid)
-                .cloned()
-                .unwrap_or_else(|| {
-                    // Truncated UUID fallback
-                    let short = if mention.uuid.len() > 8 {
-                        &mention.uuid[..8]
-                    } else {
-                        &mention.uuid
-                    };
-                    short.to_string()
-                });
-            let replacement = format!("@{name}");
-            let replacement_utf16: Vec<u16> = replacement.encode_utf16().collect();
-            let end = (mention.start + mention.length).min(result_utf16.len());
-            result_utf16.splice(mention.start..end, replacement_utf16);
         }
-
-        let resolved = String::from_utf16_lossy(&result_utf16);
-
-        // Compute byte ranges for each @Name in the resolved string
-        let mut ranges: Vec<(usize, usize)> = Vec::new();
-        let mut sorted_fwd: Vec<&Mention> = mentions.iter().collect();
-        sorted_fwd.sort_by_key(|m| m.start);
-
-        // Re-build with forward pass to get accurate byte offsets
-        let resolved_utf16: Vec<u16> = resolved.encode_utf16().collect();
-        let mut byte_pos = 0;
-        let resolved_bytes = resolved.as_bytes();
-
-        // Build utf16_offset -> byte_offset mapping
-        let mut utf16_to_byte: Vec<usize> = Vec::with_capacity(resolved_utf16.len() + 1);
-        for ch in resolved.chars() {
-            let utf16_len = ch.len_utf16();
-            let utf8_len = ch.len_utf8();
-            for _ in 0..utf16_len {
-                utf16_to_byte.push(byte_pos);
-            }
-            byte_pos += utf8_len;
-        }
-        utf16_to_byte.push(byte_pos); // sentinel for end
-
-        // Calculate where each mention ended up after all replacements
-        let mut offset_shift: i64 = 0;
-        for mention in &sorted_fwd {
-            let adjusted_start = (mention.start as i64 + offset_shift) as usize;
-            let name = self
-                .uuid_to_name
-                .get(&mention.uuid)
-                .cloned()
-                .unwrap_or_else(|| {
-                    let short = if mention.uuid.len() > 8 {
-                        &mention.uuid[..8]
-                    } else {
-                        &mention.uuid
-                    };
-                    short.to_string()
-                });
-            let replacement_utf16_len = format!("@{name}").encode_utf16().count();
-            let byte_start = utf16_to_byte
-                .get(adjusted_start)
-                .copied()
-                .unwrap_or(resolved_bytes.len());
-            let byte_end = utf16_to_byte
-                .get(adjusted_start + replacement_utf16_len)
-                .copied()
-                .unwrap_or(resolved_bytes.len());
-            ranges.push((byte_start, byte_end));
-            // This mention replaced `mention.length` UTF-16 units with `replacement_utf16_len`
-            offset_shift += replacement_utf16_len as i64 - mention.length as i64;
-        }
-
-        (resolved, ranges)
     }
 
     /// Convert text style ranges from UTF-16 offsets (on the original body) to byte offsets

--- a/src/db.rs
+++ b/src/db.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use rusqlite::{params, Connection};
 
 use crate::app::{Conversation, DisplayMessage};
-use crate::signal::types::{LinkPreview, MessageStatus, PollData, PollVote, Reaction};
+use crate::signal::types::{LinkPreview, Mention, MessageStatus, PollData, PollVote, Reaction};
 
 /// (sender, body, timestamp_ms, conversation_id, conversation_name)
 pub type SearchRow = (String, String, i64, String, String);
@@ -226,6 +226,18 @@ impl Database {
             )?;
         }
 
+        if version < 13 {
+            self.conn.execute_batch(
+                "
+                BEGIN;
+                ALTER TABLE messages ADD COLUMN body_raw TEXT;
+                ALTER TABLE messages ADD COLUMN mentions_json TEXT;
+                UPDATE schema_version SET version = 13;
+                COMMIT;
+                ",
+            )?;
+        }
+
         Ok(())
     }
 
@@ -276,7 +288,7 @@ impl Database {
         offset: usize,
     ) -> Result<Vec<DisplayMessage>> {
         let mut msg_stmt = self.conn.prepare(
-            "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data, link_preview FROM messages
+            "SELECT sender, timestamp, body, is_system, status, timestamp_ms, is_edited, is_deleted, quote_author, quote_body, quote_ts_ms, sender_id, expires_in_seconds, expiration_start_ms, pinned, poll_data, link_preview, body_raw, mentions_json FROM messages
              WHERE conversation_id = ?1
              ORDER BY timestamp_ms DESC, rowid DESC LIMIT ?2 OFFSET ?3",
         )?;
@@ -300,6 +312,8 @@ impl Database {
                 let is_pinned: bool = row.get::<_, i32>(14)? != 0;
                 let poll_data_json: Option<String> = row.get(15)?;
                 let link_preview_json: Option<String> = row.get(16)?;
+                let body_raw: Option<String> = row.get(17)?;
+                let mentions_json: Option<String> = row.get(18)?;
                 Ok((
                     sender,
                     ts_str,
@@ -318,6 +332,8 @@ impl Database {
                     is_pinned,
                     poll_data_json,
                     link_preview_json,
+                    body_raw,
+                    mentions_json,
                 ))
             })?
             .filter_map(|r| r.ok())
@@ -340,6 +356,8 @@ impl Database {
                     is_pinned,
                     poll_data_json,
                     link_preview_json,
+                    body_raw,
+                    mentions_json,
                 )| {
                     let timestamp = chrono::DateTime::parse_from_rfc3339(&ts_str)
                         .ok()?
@@ -357,6 +375,10 @@ impl Database {
                         poll_data_json.and_then(|j| serde_json::from_str::<PollData>(&j).ok());
                     let preview = link_preview_json
                         .and_then(|j| serde_json::from_str::<LinkPreview>(&j).ok());
+                    let mentions: Vec<Mention> = mentions_json
+                        .as_deref()
+                        .and_then(|j| serde_json::from_str(j).ok())
+                        .unwrap_or_default();
                     Some(DisplayMessage {
                         sender,
                         timestamp,
@@ -369,6 +391,8 @@ impl Database {
                         reactions: Vec::new(),
                         mention_ranges: Vec::new(),
                         style_ranges: Vec::new(),
+                        body_raw,
+                        mentions,
                         quote,
                         is_edited,
                         is_deleted,
@@ -867,6 +891,24 @@ impl Database {
             "UPDATE messages SET link_preview = ?3
              WHERE conversation_id = ?1 AND timestamp_ms = ?2",
             params![conv_id, timestamp_ms, json],
+        )?;
+        Ok(())
+    }
+
+    /// Store the raw body (with U+FFFC placeholders) and raw mentions for a message,
+    /// so later contact list updates can re-resolve the display body.
+    pub fn upsert_message_mentions(
+        &self,
+        conv_id: &str,
+        timestamp_ms: i64,
+        body_raw: &str,
+        mentions: &[Mention],
+    ) -> Result<()> {
+        let json = serde_json::to_string(mentions)?;
+        self.conn.execute(
+            "UPDATE messages SET body_raw = ?3, mentions_json = ?4
+             WHERE conversation_id = ?1 AND timestamp_ms = ?2",
+            params![conv_id, timestamp_ms, body_raw, json],
         )?;
         Ok(())
     }

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -361,7 +361,7 @@ pub struct JsonRpcError {
 }
 
 /// A body range mention from signal-cli's bodyRanges array.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Mention {
     pub start: usize,  // UTF-16 offset in body
     pub length: usize, // Always 1 (U+FFFC)


### PR DESCRIPTION
## Summary

Closes #283. Messages with @mentions that arrived before the contact or group list was processed fell back to a truncated UUID (e.g. \`@abcdef12\`), and that fallback got baked into the DisplayMessage and DB permanently.

### Fix

Implemented option 1 + 2 hybrid from the issue discussion:

1. **Persist raw mention data**: DisplayMessage now carries the raw body (with U+FFFC placeholders) and raw mentions alongside the resolved body. DB schema v13 adds \`body_raw\` and \`mentions_json\` columns.
2. **Re-resolve on contact/group list arrival**: \`ConversationStore::rebuild_mention_display\` walks stored messages and re-resolves any with now-known UUIDs, updating both the in-memory \`DisplayMessage\` and the DB body column.
3. **Cross-session fix**: because raw body and mentions are persisted, the re-resolution also fires after restarts - no forever-stuck truncated UUIDs.

### Scope

- **Incoming** 1:1 and group messages with mentions: full lifecycle support.
- **Outgoing** messages: raw body and mentions stored, so if you mention someone and your own client hasn't yet synced their name, the mention updates when contacts arrive.
- **Legacy messages** (pre-v13, both columns NULL) are left alone; they cannot be recovered after the fact, but any new message is self-healing.

### Testing

Added \`mention_reresolves_when_contact_arrives_after_message\` regression test. It:
1. Delivers a message with a mention to an unknown UUID.
2. Asserts body contains the truncated UUID fallback.
3. Fires a ContactList event with the UUID.
4. Asserts body now contains \`@Bob\`.

All 473 tests pass (was 472 +1 new).

## Test plan

- [x] \`cargo fmt --check\` passes.
- [x] \`cargo clippy --tests -- -D warnings\` passes.
- [x] \`cargo test\` passes (473 passed).
- [ ] CI green.
- [ ] Manual smoke on a group chat (tested by requester).

🤖 Generated with [Claude Code](https://claude.com/claude-code)