### PR TITLE
docs: document Shift+Enter for newline input (closes #334)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Press `Esc` to enter Normal mode.
 |---|---|
 | `Esc` | Switch to Normal mode |
 | `Enter` | Send message / execute command |
+| `Shift+Enter` / `Alt+Enter` | Insert newline (for multi-line messages) |
 | `Backspace` / `Delete` | Delete characters |
 | `Up` / `Down` | Recall input history |
 | `Left` / `Right` | Move cursor |

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -141,6 +141,17 @@ impl KeyBindings {
                 result.push((BindingMode::Insert, combo.clone()));
             }
         }
+        // Sort for deterministic ordering so `display_key` and help-overlay
+        // snapshots aren't flaky when an action has multiple bindings.
+        // Prefer simpler modifiers first (SHIFT < CONTROL < ALT by bit value),
+        // breaking ties with the KeyCode's debug form.
+        result.sort_by(|a, b| {
+            let a_mod = a.1.modifiers.bits();
+            let b_mod = b.1.modifiers.bits();
+            a_mod
+                .cmp(&b_mod)
+                .then_with(|| format!("{:?}", a.1.code).cmp(&format!("{:?}", b.1.code)))
+        });
         result
     }
 

--- a/src/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: src/ui.rs
+assertion_line: 5062
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
@@ -28,7 +29,7 @@ expression: output
                      │││  Keybindings [Default]                             │                      │
                      │││  Esc                 Normal mode                   │                      │
                      │╰│  i / a / I / A / o   Insert mode                   │──────────────────────╯
-                     │╭│  Ctrl+e / Ctrl+y     Scroll up / down              │──────────────────────╮
-                     │││  j / k               Prev / next message           │                      │
+                     │╭│  Shift+Enter         Insert newline in input       │──────────────────────╮
+                     │││  Ctrl+e / Ctrl+y     Scroll up / down              │                      │
                      │╰╰────────────────────────────────────────────────────╯──────────────────────╯
  [INSERT] │  ● connected │ Alice │ 7 chats

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3051,6 +3051,7 @@ fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
     let vim: Vec<(String, &str)> = vec![
         (exit_key, "Normal mode"),
         (insert_keys, "Insert mode"),
+        (dk(KeyAction::InsertNewline), "Insert newline in input"),
         (scroll_ud, "Scroll up / down"),
         (focus_ud, "Prev / next message"),
         (top_bottom, "Top / bottom of messages"),


### PR DESCRIPTION
## Summary

Closes #334. Follows up on #318/#333 (which made newlines render correctly). Now users can discover how to type newlines.

### Changes

- **README.md**: new row in the Insert mode keybindings table for \`Shift+Enter\` / \`Alt+Enter\` -> insert newline.
- **\`/help\` overlay** (\`src/ui.rs\`): new row in the keybindings section, using \`dk(KeyAction::InsertNewline)\` to show the currently-bound key.
- **Determinism fix** (\`src/keybindings.rs\`): \`keys_for_action\` now sorts its results before returning, so \`display_key\` is stable when an action has multiple bindings. Without this the help-overlay snapshot test flakes on HashMap iteration order. Sort order: modifier bits ascending (SHIFT < CONTROL < ALT), then KeyCode debug form. This makes Shift+Enter display in preference to Alt+Enter, which matches the common chat-app convention.
- **Snapshot updated** to reflect the new row.

### Rationale for the sort

\`HashMap<KeyCombo, KeyAction>\` has non-deterministic iteration. Previously any action with a single binding was displayed correctly, and \`InsertNewline\` was the only action with two user-visible bindings so nothing had flaked yet. Rather than hardcode \"Shift+Enter\" into the help overlay, sort the underlying lookup deterministically so any future multi-bound action stays stable too.

## Test plan

- [x] \`cargo fmt --check\` passes.
- [x] \`cargo clippy --tests -- -D warnings\` passes.
- [x] \`cargo test\` passes (474 passed).
- [x] Ran the help overlay snapshot test 3x in a row - stable.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)