### PR TITLE
chore: release v1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/src/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: src/ui.rs
+assertion_line: 5128
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
@@ -13,7 +14,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.6.0                                  │t too                   │
+                     ││[0│  siggy v1.7.0                                  │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

Version bump and snapshot refresh for the v1.7.0 release.

### What's in v1.7.0

**Features:**
- Newlines render correctly in message bodies (#333, closes #318)
- Multiple concurrent typing indicators per group (#293, closes #218)
- Sixel image protocol support for Windows Terminal (#280, closes #272)
- Viewport stabilization during initial message sync (#313, closes #310)
- Pre-encode PNG in background for all native image protocols (#322)
- Native image placement aligns with Paragraph word wrap (#324)
- Settings grouped by category with section headers (#301, closes #207)
- Persist sidebar width in config (#285, closes #264)
- Filter stale groups and unresolvable contacts from sidebar (#286, closes #256)
- Open attachments and URLs from action menu (#287, closes #188)
- Preserve native image caches across conversation switches (#271, closes #242)
- Enhanced emoji support (#269)

**Bug fixes:**
- Re-resolve @mentions when contact/group list arrives (#332, closes #283)
- Route messages to UUID-only contacts (#336, closes #315)
- Vim normal-mode keybinding fixes (#292, closes #288-#291)
- Clippy lints for Rust 1.95 (#323)
- Skip redundant redraws on mouse move events (#282, closes #281)
- Eliminate redundant JVM spawn on startup (#270, closes #268)

**Docs:**
- Document Shift+Enter / Alt+Enter for newline input (#335, closes #334)

**Infra:**
- Pinned Rust toolchain to 1.95.0 (#327)
- Enforce \`cargo fmt\` in CI (#328)
- Required status check on master ruleset
- Bumped \`softprops/action-gh-release\` to v3 (#325)
- Bumped \`actions/upload-pages-artifact\` to v5 (#321)
- Bumped various cargo dependencies (#303-#306, #316, #317)
- Refactors: extract ConversationStore, AutocompleteState (#302, #307, #309)

### Roadmap change

Moved #257, #258, #259, #267, and #190 from v1.7.0 / v1.6.0 milestones to a new **v1.8.0** milestone, since those features aren't ready yet. v1.7.0's actual deliverables reflect what shipped rather than what was originally planned.

## Test plan

- [x] \`cargo test\` passes (475 tests).
- [x] \`cargo fmt --check\` and \`cargo clippy --tests -- -D warnings\` pass.
- [x] About overlay snapshot updated to show \`siggy v1.7.0\`.
- [x] CI green.

## Post-merge

After this merges:
\`\`\`bash
git tag v1.7.0
git push origin v1.7.0
cargo publish
\`\`\`

The \`release.yml\` workflow fires on tag push and builds binaries + GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)