### PR TITLE
ci: install cross-compile target explicitly in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,11 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Ensure cross-compile target is installed
+        # dtolnay/rust-toolchain ignores its `targets:` input when a
+        # rust-toolchain.toml is present; install explicitly as a fallback.
+        run: rustup target add ${{ matrix.target }}
+
       - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.target }}


### PR DESCRIPTION
## Summary

The v1.7.0 release workflow failed on all 4 target builds with:

\`\`\`
error[E0463]: can't find crate for \`core\`
note: the \`x86_64-apple-darwin\` target may not be installed
help: consider downloading the target with \`rustup target add x86_64-apple-darwin\`
\`\`\`

### Root cause

\`dtolnay/rust-toolchain@stable\` ignores its \`targets:\` input when a \`rust-toolchain.toml\` is present in the repo. We added that file in #327 to pin the toolchain, inadvertently breaking the release workflow's cross-compile path.

### Fix

Add an explicit \`rustup target add \${{ matrix.target }}\` step between the toolchain install and the build. Safe because \`rustup\` is already on PATH after the dtolnay action, and adding an already-installed target is a no-op.

### Scope

- \`ci.yml\` is unaffected: it only builds for the host target.
- \`release.yml\` gets one new step per matrix entry.

## Test plan

- [x] \`cargo fmt --check\`, \`cargo clippy\`, \`cargo test\` unchanged (this only touches a workflow file).
- [ ] After merge: delete + re-push the v1.7.0 tag to re-trigger the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)