### PR TITLE
chore: release v1.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2429,7 +2429,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/src/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -1,6 +1,5 @@
 ---
 source: src/ui.rs
-assertion_line: 5128
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
@@ -14,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.7.0                                  │t too                   │
+                     ││[0│  siggy v1.7.1                                  │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

Patch release for the signal-cli Windows detection bug.

- Fixes #339: setup wizard detected signal-cli in step 1 but rejected it in step 3 with "not in PATH" on Windows installs where the executable is a .bat/.cmd (scoop, manual wrapper scripts) rather than a .exe. Fixed in #340.

## Test plan

- [x] cargo clippy --tests -- -D warnings
- [x] cargo fmt --check
- [x] cargo test (479 + 148)
- [x] about overlay snapshot regenerated for version bump

After merge: tag v1.7.1, push tag, and the release workflow will build and publish artifacts.

Generated with Claude Code.