### PR TITLE
chore: upgrade to Rust 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "siggy"
 version = "1.7.1"
-edition = "2021"
+edition = "2024"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"
 repository = "https://github.com/johnsideserf/siggy"

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,8 +9,8 @@ use std::time::Instant;
 
 pub use crate::autocomplete::AutocompleteMode;
 use crate::autocomplete::AutocompleteState;
-use crate::conversation_store::{db_warn, short_name, ConversationStore};
 pub use crate::conversation_store::{Conversation, DisplayMessage, Quote};
+use crate::conversation_store::{ConversationStore, db_warn, short_name};
 use crate::db::Database;
 use crate::domain::{
     ActionMenuState, ContactsOverlayState, EmojiPickerAction, EmojiPickerSource, EmojiPickerState,
@@ -21,9 +21,9 @@ use crate::domain::{
 };
 use crate::image_render;
 use crate::image_render::ImageProtocol;
-use crate::input::{self, InputAction, COMMANDS};
+use crate::input::{self, COMMANDS, InputAction};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
-use crate::list_overlay::{self, classify_list_key, ListKeyAction};
+use crate::list_overlay::{self, ListKeyAction, classify_list_key};
 use crate::signal::types::{
     Contact, Group, IdentityInfo, Mention, MessageStatus, PollData, PollOption, PollVote, Reaction,
     SignalEvent, SignalMessage, StyleType, TrustLevel,
@@ -785,30 +785,29 @@ impl App {
                 result.timestamp_ms,
                 result.is_preview,
             ));
-            if let Some(conv) = self.store.conversations.get_mut(&result.conv_id) {
-                if let Some(idx) = conv.find_msg_idx(result.timestamp_ms) {
-                    if result.is_preview {
-                        // Store empty vec on None to prevent infinite retry for broken images
-                        conv.messages[idx].preview_image_lines =
-                            Some(result.lines.unwrap_or_default());
-                        if let Some(p) = result.image_path {
-                            conv.messages[idx].preview_image_path = Some(p);
-                        }
-                    } else {
-                        conv.messages[idx].image_lines = Some(result.lines.unwrap_or_default());
+            if let Some(conv) = self.store.conversations.get_mut(&result.conv_id)
+                && let Some(idx) = conv.find_msg_idx(result.timestamp_ms)
+            {
+                if result.is_preview {
+                    // Store empty vec on None to prevent infinite retry for broken images
+                    conv.messages[idx].preview_image_lines = Some(result.lines.unwrap_or_default());
+                    if let Some(p) = result.image_path {
+                        conv.messages[idx].preview_image_path = Some(p);
                     }
-                    // Pre-populate native image caches from background task
-                    if let Some((path, b64, pw, ph)) = result.pre_native_png {
-                        self.image
-                            .native_image_cache
-                            .entry(path)
-                            .or_insert((b64, pw, ph));
-                    }
-                    if let Some((path, sixel)) = result.pre_sixel {
-                        self.image.sixel_cache.entry(path).or_insert(sixel);
-                    }
-                    drained = true;
+                } else {
+                    conv.messages[idx].image_lines = Some(result.lines.unwrap_or_default());
                 }
+                // Pre-populate native image caches from background task
+                if let Some((path, b64, pw, ph)) = result.pre_native_png {
+                    self.image
+                        .native_image_cache
+                        .entry(path)
+                        .or_insert((b64, pw, ph));
+                }
+                if let Some((path, sixel)) = result.pre_sixel {
+                    self.image.sixel_cache.entry(path).or_insert(sixel);
+                }
+                drained = true;
             }
         }
 
@@ -837,22 +836,23 @@ impl App {
             if self.image.image_render_in_flight.len() + work.len() >= 4 {
                 break;
             }
-            if msg.body.starts_with("[image:") && msg.image_lines.is_none() {
-                if let Some(ref p) = msg.image_path {
-                    let key = (id.clone(), msg.timestamp_ms, false);
-                    if !self.image.image_render_in_flight.contains(&key) {
-                        work.push((msg.timestamp_ms, p.clone(), 40, false));
-                    }
+            if msg.body.starts_with("[image:")
+                && msg.image_lines.is_none()
+                && let Some(ref p) = msg.image_path
+            {
+                let key = (id.clone(), msg.timestamp_ms, false);
+                if !self.image.image_render_in_flight.contains(&key) {
+                    work.push((msg.timestamp_ms, p.clone(), 40, false));
                 }
             }
-            if self.image.show_link_previews && msg.preview_image_lines.is_none() {
-                if let Some(ref preview) = msg.preview {
-                    if let Some(ref p) = preview.image_path {
-                        let key = (id.clone(), msg.timestamp_ms, true);
-                        if !self.image.image_render_in_flight.contains(&key) {
-                            work.push((msg.timestamp_ms, p.clone(), 30, true));
-                        }
-                    }
+            if self.image.show_link_previews
+                && msg.preview_image_lines.is_none()
+                && let Some(ref preview) = msg.preview
+                && let Some(ref p) = preview.image_path
+            {
+                let key = (id.clone(), msg.timestamp_ms, true);
+                if !self.image.image_render_in_flight.contains(&key) {
+                    work.push((msg.timestamp_ms, p.clone(), 30, true));
                 }
             }
         }
@@ -1392,16 +1392,16 @@ impl App {
         let displaced = self.keybindings.rebind(mode, action, combo.clone());
         self.keybindings_overlay.capturing = false;
 
-        if let Some(displaced_action) = displaced {
-            if displaced_action != action {
-                self.status_message = format!(
-                    "'{}' was bound to {}. Accept? (y/n)",
-                    keybindings::format_key_combo(&combo),
-                    keybindings::action_label(displaced_action)
-                );
-                self.keybindings_overlay.conflict = Some((displaced_action, combo));
-                return;
-            }
+        if let Some(displaced_action) = displaced
+            && displaced_action != action
+        {
+            self.status_message = format!(
+                "'{}' was bound to {}. Accept? (y/n)",
+                keybindings::format_key_combo(&combo),
+                keybindings::action_label(displaced_action)
+            );
+            self.keybindings_overlay.conflict = Some((displaced_action, combo));
+            return;
         }
         self.status_message = format!(
             "{} → {}",
@@ -2019,21 +2019,21 @@ impl App {
             .any(|r| r.sender == "you" && r.emoji == emoji);
 
         // Optimistic local update
-        if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-            if let Some(msg) = conv.messages.get_mut(index) {
-                if is_remove {
-                    msg.reactions
-                        .retain(|r| !(r.sender == "you" && r.emoji == emoji));
+        if let Some(conv) = self.store.conversations.get_mut(&conv_id)
+            && let Some(msg) = conv.messages.get_mut(index)
+        {
+            if is_remove {
+                msg.reactions
+                    .retain(|r| !(r.sender == "you" && r.emoji == emoji));
+            } else {
+                // One reaction per user — replace or push
+                if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == "you") {
+                    existing.emoji = emoji.to_string();
                 } else {
-                    // One reaction per user — replace or push
-                    if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == "you") {
-                        existing.emoji = emoji.to_string();
-                    } else {
-                        msg.reactions.push(Reaction {
-                            emoji: emoji.to_string(),
-                            sender: "you".to_string(),
-                        });
-                    }
+                    msg.reactions.push(Reaction {
+                        emoji: emoji.to_string(),
+                        sender: "you".to_string(),
+                    });
                 }
             }
         }
@@ -2224,39 +2224,42 @@ impl App {
         match hint {
             "q" => {
                 // Reply — same as Normal 'q'
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        let author_phone = msg.sender_id.clone();
-                        let snippet: String = if msg.body.chars().count() > 50 {
-                            format!("{}…", msg.body.chars().take(50).collect::<String>())
-                        } else {
-                            msg.body.clone()
-                        };
-                        let ts = msg.timestamp_ms;
-                        let phone = if author_phone.is_empty() || author_phone == "you" {
-                            self.account.clone()
-                        } else {
-                            author_phone
-                        };
-                        self.reply_target = Some((phone, snippet, ts));
-                        self.mode = InputMode::Insert;
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    let author_phone = msg.sender_id.clone();
+                    let snippet: String = if msg.body.chars().count() > 50 {
+                        format!("{}…", msg.body.chars().take(50).collect::<String>())
+                    } else {
+                        msg.body.clone()
+                    };
+                    let ts = msg.timestamp_ms;
+                    let phone = if author_phone.is_empty() || author_phone == "you" {
+                        self.account.clone()
+                    } else {
+                        author_phone
+                    };
+                    self.reply_target = Some((phone, snippet, ts));
+                    self.mode = InputMode::Insert;
                 }
                 None
             }
             "e" => {
                 // Edit — same as Normal 'e'
-                if let Some(msg) = self.selected_message() {
-                    if msg.sender == "you" && !msg.is_deleted && !msg.is_system {
-                        let ts = msg.timestamp_ms;
-                        let body = msg.body.clone();
-                        if let Some(ref conv_id) = self.active_conversation {
-                            let conv_id = conv_id.clone();
-                            self.editing_message = Some((ts, conv_id));
-                            self.input_buffer = body;
-                            self.input_cursor = self.input_buffer.len();
-                            self.mode = InputMode::Insert;
-                        }
+                if let Some(msg) = self.selected_message()
+                    && msg.sender == "you"
+                    && !msg.is_deleted
+                    && !msg.is_system
+                {
+                    let ts = msg.timestamp_ms;
+                    let body = msg.body.clone();
+                    if let Some(ref conv_id) = self.active_conversation {
+                        let conv_id = conv_id.clone();
+                        self.editing_message = Some((ts, conv_id));
+                        self.input_buffer = body;
+                        self.input_cursor = self.input_buffer.len();
+                        self.mode = InputMode::Insert;
                     }
                 }
                 None
@@ -2271,11 +2274,12 @@ impl App {
             }
             "f" => {
                 // Forward — open conversation picker
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        self.forward.body = msg.body.clone();
-                        self.open_forward_picker();
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    self.forward.body = msg.body.clone();
+                    self.open_forward_picker();
                 }
                 None
             }
@@ -2286,10 +2290,11 @@ impl App {
             }
             "d" => {
                 // Delete — open delete confirm
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        self.show_delete_confirm = true;
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    self.show_delete_confirm = true;
                 }
                 None
             }
@@ -2299,90 +2304,88 @@ impl App {
             }
             "v" => {
                 // Vote on poll
-                if let Some(msg) = self.selected_message() {
-                    if let Some(ref poll) = msg.poll_data {
-                        if !poll.closed {
-                            let conv_id = self.active_conversation.clone().unwrap_or_default();
-                            let is_group = self
-                                .store
-                                .conversations
-                                .get(&conv_id)
-                                .map(|c| c.is_group)
-                                .unwrap_or(false);
-                            let poll_author = if msg.sender_id.is_empty() || msg.sender_id == "you"
-                            {
-                                self.account.clone()
-                            } else {
-                                msg.sender_id.clone()
-                            };
-                            let options = poll.options.clone();
-                            let allow_multiple = poll.allow_multiple;
-                            let poll_timestamp = msg.timestamp_ms;
-                            let option_count = options.len();
-                            self.poll_vote.pending = Some(PollVotePending {
-                                conv_id,
-                                is_group,
-                                poll_author,
-                                poll_timestamp,
-                                allow_multiple,
-                                options,
-                            });
-                            self.poll_vote.selections = vec![false; option_count];
-                            self.poll_vote.index = 0;
-                            self.poll_vote.show = true;
-                        }
-                    }
+                if let Some(msg) = self.selected_message()
+                    && let Some(ref poll) = msg.poll_data
+                    && !poll.closed
+                {
+                    let conv_id = self.active_conversation.clone().unwrap_or_default();
+                    let is_group = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.is_group)
+                        .unwrap_or(false);
+                    let poll_author = if msg.sender_id.is_empty() || msg.sender_id == "you" {
+                        self.account.clone()
+                    } else {
+                        msg.sender_id.clone()
+                    };
+                    let options = poll.options.clone();
+                    let allow_multiple = poll.allow_multiple;
+                    let poll_timestamp = msg.timestamp_ms;
+                    let option_count = options.len();
+                    self.poll_vote.pending = Some(PollVotePending {
+                        conv_id,
+                        is_group,
+                        poll_author,
+                        poll_timestamp,
+                        allow_multiple,
+                        options,
+                    });
+                    self.poll_vote.selections = vec![false; option_count];
+                    self.poll_vote.index = 0;
+                    self.poll_vote.show = true;
                 }
                 None
             }
             "x" => {
                 // End poll
-                if let Some(msg) = self.selected_message() {
-                    if msg.sender == "you" && msg.poll_data.as_ref().is_some_and(|p| !p.closed) {
-                        let conv_id = self.active_conversation.clone()?;
-                        let is_group = self
-                            .store
-                            .conversations
-                            .get(&conv_id)
-                            .map(|c| c.is_group)
-                            .unwrap_or(false);
-                        let poll_timestamp = msg.timestamp_ms;
-                        // Optimistic close
-                        if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                            if let Some(idx) = conv.find_msg_idx(poll_timestamp) {
-                                if let Some(ref mut poll) = conv.messages[idx].poll_data {
-                                    poll.closed = true;
-                                }
-                            }
-                        }
-                        self.db_warn_visible(
-                            self.db.close_poll(&conv_id, poll_timestamp),
-                            "close_poll",
-                        );
-                        return Some(SendRequest::PollTerminate {
-                            recipient: conv_id,
-                            is_group,
-                            poll_timestamp,
-                        });
+                if let Some(msg) = self.selected_message()
+                    && msg.sender == "you"
+                    && msg.poll_data.as_ref().is_some_and(|p| !p.closed)
+                {
+                    let conv_id = self.active_conversation.clone()?;
+                    let is_group = self
+                        .store
+                        .conversations
+                        .get(&conv_id)
+                        .map(|c| c.is_group)
+                        .unwrap_or(false);
+                    let poll_timestamp = msg.timestamp_ms;
+                    // Optimistic close
+                    if let Some(conv) = self.store.conversations.get_mut(&conv_id)
+                        && let Some(idx) = conv.find_msg_idx(poll_timestamp)
+                        && let Some(ref mut poll) = conv.messages[idx].poll_data
+                    {
+                        poll.closed = true;
                     }
+                    self.db_warn_visible(
+                        self.db.close_poll(&conv_id, poll_timestamp),
+                        "close_poll",
+                    );
+                    return Some(SendRequest::PollTerminate {
+                        recipient: conv_id,
+                        is_group,
+                        poll_timestamp,
+                    });
                 }
                 None
             }
             "o" => {
                 // Open attachment
-                if let Some(msg) = self.selected_message() {
-                    if let Some(uri) = extract_file_uri(&msg.body) {
-                        self.open_file(&uri);
-                    }
+                if let Some(msg) = self.selected_message()
+                    && let Some(uri) = extract_file_uri(&msg.body)
+                {
+                    self.open_file(&uri);
                 }
                 None
             }
             "l" => {
                 // Open link
-                if let Some(msg) = self.selected_message() {
-                    if let Some(url) = extract_http_url(&msg.body) {
-                        self.open_url(&url);
-                    }
+                if let Some(msg) = self.selected_message()
+                    && let Some(url) = extract_http_url(&msg.body)
+                {
+                    self.open_url(&url);
                 }
                 None
             }
@@ -2895,10 +2898,10 @@ impl App {
                     } else {
                         None
                     };
-                    if let Some(p) = path_str {
-                        if Path::new(&p).exists() {
-                            msg.image_path = Some(p);
-                        }
+                    if let Some(p) = path_str
+                        && Path::new(&p).exists()
+                    {
+                        msg.image_path = Some(p);
                     }
                 }
             }
@@ -2994,10 +2997,10 @@ impl App {
                     } else {
                         None
                     };
-                    if let Some(p) = path_str {
-                        if Path::new(&p).exists() {
-                            msg.image_path = Some(p);
-                        }
+                    if let Some(p) = path_str
+                        && Path::new(&p).exists()
+                    {
+                        msg.image_path = Some(p);
                     }
                 }
                 msg
@@ -3014,10 +3017,10 @@ impl App {
         if let Some(read_idx) = self.store.last_read_index.get_mut(&conv_id) {
             *read_idx += prepend_count;
         }
-        if self.active_conversation.as_ref() == Some(&conv_id) {
-            if let Some(ref mut fi) = self.focused_msg_index {
-                *fi += prepend_count;
-            }
+        if self.active_conversation.as_ref() == Some(&conv_id)
+            && let Some(ref mut fi) = self.focused_msg_index
+        {
+            *fi += prepend_count;
         }
     }
 
@@ -3454,20 +3457,21 @@ impl App {
             match (prev, code) {
                 ('g', KeyCode::Char('g')) => {
                     // gg = scroll to top
-                    if let Some(ref id) = self.active_conversation {
-                        if let Some(conv) = self.store.conversations.get(id) {
-                            self.scroll_offset = conv.messages.len();
-                        }
+                    if let Some(ref id) = self.active_conversation
+                        && let Some(conv) = self.store.conversations.get(id)
+                    {
+                        self.scroll_offset = conv.messages.len();
                     }
                     self.focused_msg_index = None;
                     return None;
                 }
                 ('d', KeyCode::Char('d')) => {
                     // dd = delete message
-                    if let Some(msg) = self.selected_message() {
-                        if !msg.is_system && !msg.is_deleted {
-                            self.show_delete_confirm = true;
-                        }
+                    if let Some(msg) = self.selected_message()
+                        && !msg.is_system
+                        && !msg.is_deleted
+                    {
+                        self.show_delete_confirm = true;
                     }
                     return None;
                 }
@@ -3664,48 +3668,52 @@ impl App {
                 None
             }
             Some(KeyAction::Quote) => {
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        let author_phone = msg.sender_id.clone();
-                        let snippet: String = if msg.body.chars().count() > 50 {
-                            format!("{}…", msg.body.chars().take(50).collect::<String>())
-                        } else {
-                            msg.body.clone()
-                        };
-                        let ts = msg.timestamp_ms;
-                        let phone = if author_phone.is_empty() || author_phone == "you" {
-                            self.account.clone()
-                        } else {
-                            author_phone
-                        };
-                        self.reply_target = Some((phone, snippet, ts));
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    let author_phone = msg.sender_id.clone();
+                    let snippet: String = if msg.body.chars().count() > 50 {
+                        format!("{}…", msg.body.chars().take(50).collect::<String>())
+                    } else {
+                        msg.body.clone()
+                    };
+                    let ts = msg.timestamp_ms;
+                    let phone = if author_phone.is_empty() || author_phone == "you" {
+                        self.account.clone()
+                    } else {
+                        author_phone
+                    };
+                    self.reply_target = Some((phone, snippet, ts));
+                    self.mode = InputMode::Insert;
+                }
+                None
+            }
+            Some(KeyAction::EditMessage) => {
+                if let Some(msg) = self.selected_message()
+                    && msg.sender == "you"
+                    && !msg.is_deleted
+                    && !msg.is_system
+                {
+                    let ts = msg.timestamp_ms;
+                    let body = msg.body.clone();
+                    if let Some(ref conv_id) = self.active_conversation {
+                        let conv_id = conv_id.clone();
+                        self.editing_message = Some((ts, conv_id));
+                        self.input_buffer = body;
+                        self.input_cursor = self.input_buffer.len();
                         self.mode = InputMode::Insert;
                     }
                 }
                 None
             }
-            Some(KeyAction::EditMessage) => {
-                if let Some(msg) = self.selected_message() {
-                    if msg.sender == "you" && !msg.is_deleted && !msg.is_system {
-                        let ts = msg.timestamp_ms;
-                        let body = msg.body.clone();
-                        if let Some(ref conv_id) = self.active_conversation {
-                            let conv_id = conv_id.clone();
-                            self.editing_message = Some((ts, conv_id));
-                            self.input_buffer = body;
-                            self.input_cursor = self.input_buffer.len();
-                            self.mode = InputMode::Insert;
-                        }
-                    }
-                }
-                None
-            }
             Some(KeyAction::ForwardMessage) => {
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        self.forward.body = msg.body.clone();
-                        self.open_forward_picker();
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    self.forward.body = msg.body.clone();
+                    self.open_forward_picker();
                 }
                 None
             }
@@ -3739,10 +3747,10 @@ impl App {
             }
             _ => {
                 // Handle prefix keys that aren't in the binding map
-                if let KeyCode::Char(c @ ('g' | 'd')) = code {
-                    if modifiers.is_empty() {
-                        self.pending_normal_key = Some(c);
-                    }
+                if let KeyCode::Char(c @ ('g' | 'd')) = code
+                    && modifiers.is_empty()
+                {
+                    self.pending_normal_key = Some(c);
                 }
                 None
             }
@@ -3859,54 +3867,59 @@ impl App {
                 None
             }
             Some(KeyAction::Quote) => {
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        let author_phone = msg.sender_id.clone();
-                        let snippet: String = if msg.body.chars().count() > 50 {
-                            format!("{}…", msg.body.chars().take(50).collect::<String>())
-                        } else {
-                            msg.body.clone()
-                        };
-                        let ts = msg.timestamp_ms;
-                        let phone = if author_phone.is_empty() || author_phone == "you" {
-                            self.account.clone()
-                        } else {
-                            author_phone
-                        };
-                        self.reply_target = Some((phone, snippet, ts));
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    let author_phone = msg.sender_id.clone();
+                    let snippet: String = if msg.body.chars().count() > 50 {
+                        format!("{}…", msg.body.chars().take(50).collect::<String>())
+                    } else {
+                        msg.body.clone()
+                    };
+                    let ts = msg.timestamp_ms;
+                    let phone = if author_phone.is_empty() || author_phone == "you" {
+                        self.account.clone()
+                    } else {
+                        author_phone
+                    };
+                    self.reply_target = Some((phone, snippet, ts));
                 }
                 None
             }
             Some(KeyAction::EditMessage) => {
-                if let Some(msg) = self.selected_message() {
-                    if msg.sender == "you" && !msg.is_deleted && !msg.is_system {
-                        let ts = msg.timestamp_ms;
-                        let body = msg.body.clone();
-                        if let Some(ref conv_id) = self.active_conversation {
-                            let conv_id = conv_id.clone();
-                            self.editing_message = Some((ts, conv_id));
-                            self.input_buffer = body;
-                            self.input_cursor = self.input_buffer.len();
-                        }
+                if let Some(msg) = self.selected_message()
+                    && msg.sender == "you"
+                    && !msg.is_deleted
+                    && !msg.is_system
+                {
+                    let ts = msg.timestamp_ms;
+                    let body = msg.body.clone();
+                    if let Some(ref conv_id) = self.active_conversation {
+                        let conv_id = conv_id.clone();
+                        self.editing_message = Some((ts, conv_id));
+                        self.input_buffer = body;
+                        self.input_cursor = self.input_buffer.len();
                     }
                 }
                 None
             }
             Some(KeyAction::ForwardMessage) => {
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        self.forward.body = msg.body.clone();
-                        self.open_forward_picker();
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    self.forward.body = msg.body.clone();
+                    self.open_forward_picker();
                 }
                 None
             }
             Some(KeyAction::DeleteMessage) => {
-                if let Some(msg) = self.selected_message() {
-                    if !msg.is_system && !msg.is_deleted {
-                        self.show_delete_confirm = true;
-                    }
+                if let Some(msg) = self.selected_message()
+                    && !msg.is_system
+                    && !msg.is_deleted
+                {
+                    self.show_delete_confirm = true;
                 }
                 None
             }
@@ -4215,13 +4228,13 @@ impl App {
                     .or_insert_with(|| name.clone());
             }
             // Populate UUID->name for @mention resolution
-            if let (Some(ref uuid), Some(ref name)) = (&msg.source_uuid, &msg.source_name) {
-                if !name.is_empty() {
-                    self.store
-                        .uuid_to_name
-                        .entry(uuid.clone())
-                        .or_insert_with(|| name.clone());
-                }
+            if let (Some(uuid), Some(name)) = (&msg.source_uuid, &msg.source_name)
+                && !name.is_empty()
+            {
+                self.store
+                    .uuid_to_name
+                    .entry(uuid.clone())
+                    .or_insert_with(|| name.clone());
             }
         }
 
@@ -4298,14 +4311,14 @@ impl App {
         };
 
         // Keep conversation's expiration_timer in sync with incoming messages
-        if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-            if conv.expiration_timer != msg_expires_in {
-                conv.expiration_timer = msg_expires_in;
-                db_warn(
-                    self.db.update_expiration_timer(&conv_id, msg_expires_in),
-                    "update_expiration_timer",
-                );
-            }
+        if let Some(conv) = self.store.conversations.get_mut(&conv_id)
+            && conv.expiration_timer != msg_expires_in
+        {
+            conv.expiration_timer = msg_expires_in;
+            db_warn(
+                self.db.update_expiration_timer(&conv_id, msg_expires_in),
+                "update_expiration_timer",
+            );
         }
 
         // Resolve @mentions before the push closure borrows self mutably
@@ -4403,10 +4416,10 @@ impl App {
                     },
                 );
                 // Bump last_read_index if we inserted before the read marker
-                if let Some(read_idx) = self.store.last_read_index.get_mut(&conv_id) {
-                    if pos <= *read_idx {
-                        *read_idx += 1;
-                    }
+                if let Some(read_idx) = self.store.last_read_index.get_mut(&conv_id)
+                    && pos <= *read_idx
+                {
+                    *read_idx += 1;
                 }
                 if msg_expires_in > 0 {
                     self.expiring_msg_count += 1;
@@ -4498,42 +4511,39 @@ impl App {
 
         // Persist raw body + mentions so the display body can be re-resolved
         // later when the contact list or group list fills in unknown UUIDs.
-        if had_mentions {
-            if let Some(ref raw) = msg.body {
-                db_warn(
-                    self.db
-                        .upsert_message_mentions(&conv_id, msg_ts_ms, raw, &msg.mentions),
-                    "upsert_message_mentions",
-                );
-            }
+        if had_mentions && let Some(ref raw) = msg.body {
+            db_warn(
+                self.db
+                    .upsert_message_mentions(&conv_id, msg_ts_ms, raw, &msg.mentions),
+                "upsert_message_mentions",
+            );
         }
 
         // Attach first link preview to the body message (not attachment messages)
         if let Some(preview) = msg.previews.into_iter().next() {
-            if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                if let Some(dm) = conv
+            if let Some(conv) = self.store.conversations.get_mut(&conv_id)
+                && let Some(dm) = conv
                     .messages
                     .iter_mut()
                     .rev()
                     .find(|m| m.timestamp_ms == msg_ts_ms && !m.body.starts_with('['))
-                {
-                    let (img_lines, img_path) =
-                        if self.image.show_link_previews && self.image.image_mode != "none" {
-                            if let Some(ref p) = preview.image_path {
-                                (
-                                    image_render::render_image(Path::new(p), 30),
-                                    Some(p.clone()),
-                                )
-                            } else {
-                                (None, None)
-                            }
+            {
+                let (img_lines, img_path) =
+                    if self.image.show_link_previews && self.image.image_mode != "none" {
+                        if let Some(ref p) = preview.image_path {
+                            (
+                                image_render::render_image(Path::new(p), 30),
+                                Some(p.clone()),
+                            )
                         } else {
                             (None, None)
-                        };
-                    dm.preview = Some(preview.clone());
-                    dm.preview_image_lines = img_lines;
-                    dm.preview_image_path = img_path;
-                }
+                        }
+                    } else {
+                        (None, None)
+                    };
+                dm.preview = Some(preview.clone());
+                dm.preview_image_lines = img_lines;
+                dm.preview_image_path = img_path;
             }
             db_warn(
                 self.db.upsert_link_preview(&conv_id, msg_ts_ms, &preview),
@@ -4693,10 +4703,10 @@ impl App {
                 },
             );
             // Bump last_read_index if we inserted before the read marker
-            if let Some(read_idx) = self.store.last_read_index.get_mut(conv_id) {
-                if pos <= *read_idx {
-                    *read_idx += 1;
-                }
+            if let Some(read_idx) = self.store.last_read_index.get_mut(conv_id)
+                && pos <= *read_idx
+            {
+                *read_idx += 1;
             }
         }
         let ts_rfc3339 = timestamp.to_rfc3339();
@@ -4734,10 +4744,10 @@ impl App {
 
         // Clean up DB
         let removed = removed_count > 0;
-        if let Ok(n) = self.db.delete_expired_messages(now_ms) {
-            if n > 0 {
-                return true;
-            }
+        if let Ok(n) = self.db.delete_expired_messages(now_ms)
+            && n > 0
+        {
+            return true;
         }
 
         removed
@@ -4776,11 +4786,7 @@ impl App {
                     m.sender == target_author
                         || target_display.as_deref() == Some(m.sender.as_str())
                 };
-                if matches {
-                    Some(idx)
-                } else {
-                    None
-                }
+                if matches { Some(idx) } else { None }
             });
             if let Some(msg) = found.map(|idx| &mut conv.messages[idx]) {
                 if is_remove {
@@ -4888,11 +4894,11 @@ impl App {
     }
 
     fn handle_edit_received(&mut self, conv_id: &str, target_timestamp: i64, new_body: &str) {
-        if let Some(conv) = self.store.conversations.get_mut(conv_id) {
-            if let Some(idx) = conv.find_msg_idx(target_timestamp) {
-                conv.messages[idx].body = new_body.to_string();
-                conv.messages[idx].is_edited = true;
-            }
+        if let Some(conv) = self.store.conversations.get_mut(conv_id)
+            && let Some(idx) = conv.find_msg_idx(target_timestamp)
+        {
+            conv.messages[idx].body = new_body.to_string();
+            conv.messages[idx].is_edited = true;
         }
         self.db_warn_visible(
             self.db
@@ -4902,12 +4908,12 @@ impl App {
     }
 
     fn handle_remote_delete(&mut self, conv_id: &str, target_timestamp: i64) {
-        if let Some(conv) = self.store.conversations.get_mut(conv_id) {
-            if let Some(idx) = conv.find_msg_idx(target_timestamp) {
-                conv.messages[idx].is_deleted = true;
-                conv.messages[idx].body = "[deleted]".to_string();
-                conv.messages[idx].reactions.clear();
-            }
+        if let Some(conv) = self.store.conversations.get_mut(conv_id)
+            && let Some(idx) = conv.find_msg_idx(target_timestamp)
+        {
+            conv.messages[idx].is_deleted = true;
+            conv.messages[idx].body = "[deleted]".to_string();
+            conv.messages[idx].reactions.clear();
         }
         self.db_warn_visible(
             self.db.mark_message_deleted(conv_id, target_timestamp),
@@ -4922,10 +4928,10 @@ impl App {
         target_timestamp: i64,
         pinned: bool,
     ) {
-        if let Some(conv) = self.store.conversations.get_mut(conv_id) {
-            if let Some(idx) = conv.find_msg_idx(target_timestamp) {
-                conv.messages[idx].is_pinned = pinned;
-            }
+        if let Some(conv) = self.store.conversations.get_mut(conv_id)
+            && let Some(idx) = conv.find_msg_idx(target_timestamp)
+        {
+            conv.messages[idx].is_pinned = pinned;
         }
         self.db_warn_visible(
             self.db
@@ -4977,22 +4983,22 @@ impl App {
         option_indexes: &[i64],
         vote_count: i64,
     ) {
-        if let Some(conv) = self.store.conversations.get_mut(conv_id) {
-            if let Some(idx) = conv.find_msg_idx(target_timestamp) {
-                let msg = &mut conv.messages[idx];
-                // Upsert vote in memory
-                if let Some(existing) = msg.poll_votes.iter_mut().find(|v| v.voter == voter) {
-                    existing.option_indexes = option_indexes.to_vec();
-                    existing.vote_count = vote_count;
-                    existing.voter_name = voter_name.map(|s| s.to_string());
-                } else {
-                    msg.poll_votes.push(PollVote {
-                        voter: voter.to_string(),
-                        voter_name: voter_name.map(|s| s.to_string()),
-                        option_indexes: option_indexes.to_vec(),
-                        vote_count,
-                    });
-                }
+        if let Some(conv) = self.store.conversations.get_mut(conv_id)
+            && let Some(idx) = conv.find_msg_idx(target_timestamp)
+        {
+            let msg = &mut conv.messages[idx];
+            // Upsert vote in memory
+            if let Some(existing) = msg.poll_votes.iter_mut().find(|v| v.voter == voter) {
+                existing.option_indexes = option_indexes.to_vec();
+                existing.vote_count = vote_count;
+                existing.voter_name = voter_name.map(|s| s.to_string());
+            } else {
+                msg.poll_votes.push(PollVote {
+                    voter: voter.to_string(),
+                    voter_name: voter_name.map(|s| s.to_string()),
+                    option_indexes: option_indexes.to_vec(),
+                    vote_count,
+                });
             }
         }
         self.db_warn_visible(
@@ -5009,12 +5015,11 @@ impl App {
     }
 
     fn handle_poll_terminated(&mut self, conv_id: &str, target_timestamp: i64) {
-        if let Some(conv) = self.store.conversations.get_mut(conv_id) {
-            if let Some(idx) = conv.find_msg_idx(target_timestamp) {
-                if let Some(ref mut poll) = conv.messages[idx].poll_data {
-                    poll.closed = true;
-                }
-            }
+        if let Some(conv) = self.store.conversations.get_mut(conv_id)
+            && let Some(idx) = conv.find_msg_idx(target_timestamp)
+            && let Some(ref mut poll) = conv.messages[idx].poll_data
+        {
+            poll.closed = true;
         }
         self.db_warn_visible(self.db.close_poll(conv_id, target_timestamp), "close_poll");
     }
@@ -5043,10 +5048,10 @@ impl App {
 
         if was_pinned {
             // Unpin immediately — no duration needed
-            if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                if let Some(idx) = conv.find_msg_idx(target_timestamp) {
-                    conv.messages[idx].is_pinned = false;
-                }
+            if let Some(conv) = self.store.conversations.get_mut(&conv_id)
+                && let Some(idx) = conv.find_msg_idx(target_timestamp)
+            {
+                conv.messages[idx].is_pinned = false;
             }
             self.db_warn_visible(
                 self.db
@@ -5098,10 +5103,10 @@ impl App {
                 let pending = self.pin_duration.pending.take()?;
 
                 // Optimistically pin
-                if let Some(conv) = self.store.conversations.get_mut(&pending.conv_id) {
-                    if let Some(idx) = conv.find_msg_idx(pending.target_timestamp) {
-                        conv.messages[idx].is_pinned = true;
-                    }
+                if let Some(conv) = self.store.conversations.get_mut(&pending.conv_id)
+                    && let Some(idx) = conv.find_msg_idx(pending.target_timestamp)
+                {
+                    conv.messages[idx].is_pinned = true;
                 }
                 self.db_warn_visible(
                     self.db
@@ -5234,7 +5239,7 @@ impl App {
                     .selections
                     .iter()
                     .enumerate()
-                    .filter(|(_, &sel)| sel)
+                    .filter(|&(_, &sel)| sel)
                     .map(|(i, _)| i as i64)
                     .collect();
                 if selected.is_empty() {
@@ -5352,36 +5357,36 @@ impl App {
         self.startup_status.clear();
         for contact in contacts {
             // Store name in lookup for future message resolution
-            if let Some(ref name) = contact.name {
-                if !name.is_empty() {
-                    self.store
-                        .contact_names
-                        .insert(contact.number.clone(), name.clone());
-                }
+            if let Some(ref name) = contact.name
+                && !name.is_empty()
+            {
+                self.store
+                    .contact_names
+                    .insert(contact.number.clone(), name.clone());
             }
             // Build UUID maps for @mention resolution
             if let Some(ref uuid) = contact.uuid {
-                if let Some(ref name) = contact.name {
-                    if !name.is_empty() {
-                        self.store.uuid_to_name.insert(uuid.clone(), name.clone());
-                    }
+                if let Some(ref name) = contact.name
+                    && !name.is_empty()
+                {
+                    self.store.uuid_to_name.insert(uuid.clone(), name.clone());
                 }
                 self.store
                     .number_to_uuid
                     .insert(contact.number.clone(), uuid.clone());
             }
             // Update name on existing conversations only — don't create new ones
-            if let Some(conv) = self.store.conversations.get_mut(&contact.number) {
-                if let Some(ref contact_name) = contact.name {
-                    if !contact_name.is_empty() && conv.name != *contact_name {
-                        conv.name = contact_name.clone();
-                        db_warn(
-                            self.db
-                                .upsert_conversation(&contact.number, contact_name, false),
-                            "upsert_conversation",
-                        );
-                    }
-                }
+            if let Some(conv) = self.store.conversations.get_mut(&contact.number)
+                && let Some(ref contact_name) = contact.name
+                && !contact_name.is_empty()
+                && conv.name != *contact_name
+            {
+                conv.name = contact_name.clone();
+                db_warn(
+                    self.db
+                        .upsert_conversation(&contact.number, contact_name, false),
+                    "upsert_conversation",
+                );
             }
         }
         // Auto-accept unaccepted 1:1 conversations whose sender is now a known contact
@@ -5427,13 +5432,13 @@ impl App {
             }
             // Populate UUID->name from group members (phone->uuid + phone->name)
             for (phone, uuid) in &group.member_uuids {
-                if let Some(name) = self.store.contact_names.get(phone) {
-                    if !name.is_empty() {
-                        self.store
-                            .uuid_to_name
-                            .entry(uuid.clone())
-                            .or_insert_with(|| name.clone());
-                    }
+                if let Some(name) = self.store.contact_names.get(phone)
+                    && !name.is_empty()
+                {
+                    self.store
+                        .uuid_to_name
+                        .entry(uuid.clone())
+                        .or_insert_with(|| name.clone());
                 }
             }
             // Store group for @mention member lookup
@@ -5467,42 +5472,41 @@ impl App {
             }
         }
         // If verify overlay is open, refresh the displayed identities
-        if self.verify.show {
-            if let Some(ref conv_id) = self.active_conversation {
-                let conv_id = conv_id.clone();
-                let is_group = self
-                    .store
-                    .conversations
-                    .get(&conv_id)
-                    .map(|c| c.is_group)
-                    .unwrap_or(false);
-                if is_group {
-                    if let Some(group) = self.store.groups.get(&conv_id) {
-                        let members: HashSet<&str> =
-                            group.members.iter().map(|s| s.as_str()).collect();
-                        self.verify.identities = identities
-                            .iter()
-                            .filter(|id| {
-                                id.number
-                                    .as_ref()
-                                    .is_some_and(|n| members.contains(n.as_str()))
-                            })
-                            .cloned()
-                            .collect();
-                    }
-                } else {
+        if self.verify.show
+            && let Some(ref conv_id) = self.active_conversation
+        {
+            let conv_id = conv_id.clone();
+            let is_group = self
+                .store
+                .conversations
+                .get(&conv_id)
+                .map(|c| c.is_group)
+                .unwrap_or(false);
+            if is_group {
+                if let Some(group) = self.store.groups.get(&conv_id) {
+                    let members: HashSet<&str> = group.members.iter().map(|s| s.as_str()).collect();
                     self.verify.identities = identities
                         .iter()
-                        .filter(|id| id.number.as_deref() == Some(conv_id.as_str()))
+                        .filter(|id| {
+                            id.number
+                                .as_ref()
+                                .is_some_and(|n| members.contains(n.as_str()))
+                        })
                         .cloned()
                         .collect();
                 }
-                // Clamp index
-                if !self.verify.identities.is_empty()
-                    && self.verify.index >= self.verify.identities.len()
-                {
-                    self.verify.index = self.verify.identities.len() - 1;
-                }
+            } else {
+                self.verify.identities = identities
+                    .iter()
+                    .filter(|id| id.number.as_deref() == Some(conv_id.as_str()))
+                    .cloned()
+                    .collect();
+            }
+            // Clamp index
+            if !self.verify.identities.is_empty()
+                && self.verify.index >= self.verify.identities.len()
+            {
+                self.verify.index = self.verify.identities.len() - 1;
             }
         }
     }
@@ -5522,10 +5526,10 @@ impl App {
         let mut found: Vec<(usize, usize, String)> = Vec::new(); // (byte_start, byte_end, uuid)
         for (name, uuid) in &self.autocomplete.pending_mentions {
             let pattern = format!("@{name}");
-            if let Some(uuid) = uuid {
-                if let Some(pos) = wire.find(&pattern) {
-                    found.push((pos, pos + pattern.len(), uuid.clone()));
-                }
+            if let Some(uuid) = uuid
+                && let Some(pos) = wire.find(&pattern)
+            {
+                found.push((pos, pos + pattern.len(), uuid.clone()));
             }
         }
         found.sort_by_key(|b| std::cmp::Reverse(b.0)); // reverse order
@@ -5608,14 +5612,13 @@ impl App {
         }
         if let Some((conv_id, local_ts)) = self.pending_sends.remove(rpc_id) {
             let mut found = false;
-            if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                if let Some(idx) = conv
+            if let Some(conv) = self.store.conversations.get_mut(&conv_id)
+                && let Some(idx) = conv
                     .find_msg_idx(local_ts)
                     .filter(|&idx| conv.messages[idx].sender == "you")
-                {
-                    conv.messages[idx].status = Some(MessageStatus::Failed);
-                    found = true;
-                }
+            {
+                conv.messages[idx].status = Some(MessageStatus::Failed);
+                found = true;
             }
             if found {
                 self.db_warn_visible(
@@ -5643,14 +5646,14 @@ impl App {
             .find_msg_idx(ts)
             .filter(|&idx| conv.messages[idx].sender == "you")
         {
-            if let Some(current) = conv.messages[idx].status {
-                if new_status > current {
-                    conv.messages[idx].status = Some(new_status);
-                    db_warn(
-                        db.update_message_status(conv_id, ts, new_status.to_i32()),
-                        "update_message_status",
-                    );
-                }
+            if let Some(current) = conv.messages[idx].status
+                && new_status > current
+            {
+                conv.messages[idx].status = Some(new_status);
+                db_warn(
+                    db.update_message_status(conv_id, ts, new_status.to_i32()),
+                    "update_message_status",
+                );
             }
             return true;
         }
@@ -6464,61 +6467,60 @@ impl App {
         }
 
         // Try @mention autocomplete
-        if let Some(ref conv_id) = self.active_conversation {
-            if let Some(conv) = self.store.conversations.get(conv_id) {
-                if let Some(trigger_pos) = self.find_mention_trigger() {
-                    let after_at = &self.input_buffer[trigger_pos + 1..self.input_cursor];
-                    let filter_lower = after_at.to_lowercase();
+        if let Some(ref conv_id) = self.active_conversation
+            && let Some(conv) = self.store.conversations.get(conv_id)
+            && let Some(trigger_pos) = self.find_mention_trigger()
+        {
+            let after_at = &self.input_buffer[trigger_pos + 1..self.input_cursor];
+            let filter_lower = after_at.to_lowercase();
 
-                    let mut candidates: Vec<(String, String, Option<String>)> = Vec::new();
-                    if conv.is_group {
-                        // Group: offer all group members
-                        if let Some(group) = self.store.groups.get(conv_id) {
-                            for member_phone in &group.members {
-                                let name = self
-                                    .store
-                                    .contact_names
-                                    .get(member_phone)
-                                    .cloned()
-                                    .unwrap_or_else(|| member_phone.clone());
-                                let uuid = self.store.number_to_uuid.get(member_phone).cloned();
-                                if filter_lower.is_empty()
-                                    || name.to_lowercase().contains(&filter_lower)
-                                    || member_phone.contains(&filter_lower)
-                                {
-                                    candidates.push((member_phone.clone(), name, uuid));
-                                }
-                            }
-                        }
-                    } else {
-                        // 1:1 chat: offer the contact as a mention candidate
+            let mut candidates: Vec<(String, String, Option<String>)> = Vec::new();
+            if conv.is_group {
+                // Group: offer all group members
+                if let Some(group) = self.store.groups.get(conv_id) {
+                    for member_phone in &group.members {
                         let name = self
                             .store
                             .contact_names
-                            .get(conv_id)
+                            .get(member_phone)
                             .cloned()
-                            .unwrap_or_else(|| conv_id.clone());
-                        let uuid = self.store.number_to_uuid.get(conv_id).cloned();
+                            .unwrap_or_else(|| member_phone.clone());
+                        let uuid = self.store.number_to_uuid.get(member_phone).cloned();
                         if filter_lower.is_empty()
                             || name.to_lowercase().contains(&filter_lower)
-                            || conv_id.contains(&filter_lower)
+                            || member_phone.contains(&filter_lower)
                         {
-                            candidates.push((conv_id.clone(), name, uuid));
+                            candidates.push((member_phone.clone(), name, uuid));
                         }
-                    }
-                    candidates.sort_by_key(|a| a.1.to_lowercase());
-
-                    if !candidates.is_empty() {
-                        self.autocomplete.visible = true;
-                        self.autocomplete.mode = AutocompleteMode::Mention;
-                        self.autocomplete.mention_candidates = candidates;
-                        self.autocomplete.mention_trigger_pos = trigger_pos;
-                        if self.autocomplete.index >= self.autocomplete.mention_candidates.len() {
-                            self.autocomplete.index = 0;
-                        }
-                        return;
                     }
                 }
+            } else {
+                // 1:1 chat: offer the contact as a mention candidate
+                let name = self
+                    .store
+                    .contact_names
+                    .get(conv_id)
+                    .cloned()
+                    .unwrap_or_else(|| conv_id.clone());
+                let uuid = self.store.number_to_uuid.get(conv_id).cloned();
+                if filter_lower.is_empty()
+                    || name.to_lowercase().contains(&filter_lower)
+                    || conv_id.contains(&filter_lower)
+                {
+                    candidates.push((conv_id.clone(), name, uuid));
+                }
+            }
+            candidates.sort_by_key(|a| a.1.to_lowercase());
+
+            if !candidates.is_empty() {
+                self.autocomplete.visible = true;
+                self.autocomplete.mode = AutocompleteMode::Mention;
+                self.autocomplete.mention_candidates = candidates;
+                self.autocomplete.mention_trigger_pos = trigger_pos;
+                if self.autocomplete.index >= self.autocomplete.mention_candidates.len() {
+                    self.autocomplete.index = 0;
+                }
+                return;
             }
         }
 
@@ -7154,12 +7156,12 @@ impl App {
 
     /// Clear the clipboard if auto-clear timer has expired.
     pub fn check_clipboard_clear(&mut self) {
-        if let Some(set_at) = self.notifications.clipboard_set_at {
-            if set_at.elapsed().as_secs() >= self.notifications.clipboard_clear_seconds {
-                self.notifications.clipboard_set_at = None;
-                if let Ok(mut clipboard) = arboard::Clipboard::new() {
-                    let _ = clipboard.set_text("");
-                }
+        if let Some(set_at) = self.notifications.clipboard_set_at
+            && set_at.elapsed().as_secs() >= self.notifications.clipboard_clear_seconds
+        {
+            self.notifications.clipboard_set_at = None;
+            if let Ok(mut clipboard) = arboard::Clipboard::new() {
+                let _ = clipboard.set_text("");
             }
         }
     }
@@ -7254,22 +7256,21 @@ impl App {
         }
 
         // 2. Sidebar click — switch conversation
-        if let Some(inner) = self.mouse_sidebar_inner {
-            if is_in_rect(col, row, inner) {
-                let index = (row - inner.y) as usize;
-                let sidebar_list =
-                    if self.sidebar_filter_active && !self.sidebar_filtered.is_empty() {
-                        &self.sidebar_filtered
-                    } else {
-                        &self.store.conversation_order
-                    };
-                if index < sidebar_list.len() {
-                    let conv_id = sidebar_list[index].clone();
-                    self.clear_sidebar_filter();
-                    self.join_conversation(&conv_id);
-                }
-                return;
+        if let Some(inner) = self.mouse_sidebar_inner
+            && is_in_rect(col, row, inner)
+        {
+            let index = (row - inner.y) as usize;
+            let sidebar_list = if self.sidebar_filter_active && !self.sidebar_filtered.is_empty() {
+                &self.sidebar_filtered
+            } else {
+                &self.store.conversation_order
+            };
+            if index < sidebar_list.len() {
+                let conv_id = sidebar_list[index].clone();
+                self.clear_sidebar_filter();
+                self.join_conversation(&conv_id);
             }
+            return;
         }
 
         // 3. Input area click — position cursor and enter Insert mode
@@ -7465,10 +7466,10 @@ fn extract_file_uri(body: &str) -> Option<String> {
 fn extract_http_url(body: &str) -> Option<String> {
     let mut best: Option<(usize, &str)> = None;
     for scheme in &["https://", "http://"] {
-        if let Some(pos) = body.find(scheme) {
-            if best.is_none() || pos < best.unwrap().0 {
-                best = Some((pos, scheme));
-            }
+        if let Some(pos) = body.find(scheme)
+            && (best.is_none() || pos < best.unwrap().0)
+        {
+            best = Some((pos, scheme));
         }
     }
     let (pos, _) = best?;
@@ -7663,7 +7664,11 @@ impl App {
         );
         bob_reply.status = Some(MessageStatus::Read);
 
-        let bob_thanks = dm("Bob", ts(10, 15), "Thanks! I'll address those. Also the migration is backwards-compatible so no rush on deploy");
+        let bob_thanks = dm(
+            "Bob",
+            ts(10, 15),
+            "Thanks! I'll address those. Also the migration is backwards-compatible so no rush on deploy",
+        );
 
         // Quote reply: Bob quotes the review comment
         let mut bob_followup = dm("Bob", ts(10, 20), "Fixed those error handling bits, PTAL");
@@ -11171,10 +11176,11 @@ mod tests {
         }];
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let conv = &app.store.conversations["+1"];
-        assert!(conv
-            .messages
-            .iter()
-            .any(|m| m.body.contains("[image: photo.jpg]")));
+        assert!(
+            conv.messages
+                .iter()
+                .any(|m| m.body.contains("[image: photo.jpg]"))
+        );
     }
 
     #[rstest]
@@ -11188,10 +11194,11 @@ mod tests {
         }];
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let conv = &app.store.conversations["+1"];
-        assert!(conv
-            .messages
-            .iter()
-            .any(|m| m.body.contains("[attachment: doc.pdf]")));
+        assert!(
+            conv.messages
+                .iter()
+                .any(|m| m.body.contains("[attachment: doc.pdf]"))
+        );
     }
 
     #[rstest]
@@ -11222,10 +11229,11 @@ mod tests {
         }];
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
         let conv = &app.store.conversations["+1"];
-        assert!(conv
-            .messages
-            .iter()
-            .any(|m| m.body.contains("[attachment: audio/ogg]")));
+        assert!(
+            conv.messages
+                .iter()
+                .any(|m| m.body.contains("[attachment: audio/ogg]"))
+        );
     }
 
     // --- Bell / notification tests ---

--- a/src/db.rs
+++ b/src/db.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Result;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::app::{Conversation, DisplayMessage};
 use crate::signal::types::{LinkPreview, Mention, MessageStatus, PollData, PollVote, Reaction};
@@ -440,10 +440,10 @@ impl Database {
 
         // Attach poll votes
         for msg in &mut messages {
-            if msg.poll_data.is_some() {
-                if let Ok(votes) = self.load_poll_votes(conv_id, msg.timestamp_ms) {
-                    msg.poll_votes = votes;
-                }
+            if msg.poll_data.is_some()
+                && let Ok(votes) = self.load_poll_votes(conv_id, msg.timestamp_ms)
+            {
+                msg.poll_votes = votes;
             }
         }
 
@@ -967,16 +967,16 @@ impl Database {
             )
             .ok()
             .flatten();
-        if let Some(json_str) = poll_json {
-            if let Ok(mut poll_data) = serde_json::from_str::<PollData>(&json_str) {
-                poll_data.closed = true;
-                let updated = serde_json::to_string(&poll_data)?;
-                self.conn.execute(
-                    "UPDATE messages SET poll_data = ?3
+        if let Some(json_str) = poll_json
+            && let Ok(mut poll_data) = serde_json::from_str::<PollData>(&json_str)
+        {
+            poll_data.closed = true;
+            let updated = serde_json::to_string(&poll_data)?;
+            self.conn.execute(
+                "UPDATE messages SET poll_data = ?3
                      WHERE conversation_id = ?1 AND timestamp_ms = ?2",
-                    params![conv_id, poll_timestamp, updated],
-                )?;
-            }
+                params![conv_id, poll_timestamp, updated],
+            )?;
         }
         Ok(())
     }

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -6,8 +6,8 @@
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 static ENABLED: AtomicBool = AtomicBool::new(false);
 static REDACT: AtomicBool = AtomicBool::new(true);
@@ -34,13 +34,12 @@ fn setup_file() {
         }
     }
     // Rotate if existing log exceeds size limit
-    if path.exists() {
-        if let Ok(meta) = std::fs::metadata(&path) {
-            if meta.len() > MAX_LOG_SIZE {
-                let backup = path.with_extension("log.old");
-                let _ = std::fs::rename(&path, &backup);
-            }
-        }
+    if path.exists()
+        && let Ok(meta) = std::fs::metadata(&path)
+        && meta.len() > MAX_LOG_SIZE
+    {
+        let backup = path.with_extension("log.old");
+        let _ = std::fs::rename(&path, &backup);
     }
     if let Ok(f) = OpenOptions::new().create(true).append(true).open(&path) {
         #[cfg(unix)]
@@ -105,11 +104,11 @@ pub fn log(msg: &str) {
     if !ENABLED.load(Ordering::Relaxed) {
         return;
     }
-    if let Ok(mut guard) = FILE.lock() {
-        if let Some(ref mut f) = *guard {
-            let now = chrono::Local::now().format("%H:%M:%S%.3f");
-            let _ = writeln!(f, "[{now}] {msg}");
-        }
+    if let Ok(mut guard) = FILE.lock()
+        && let Some(ref mut f) = *guard
+    {
+        let now = chrono::Local::now().format("%H:%M:%S%.3f");
+        let _ = writeln!(f, "[{now}] {msg}");
     }
 }
 

--- a/src/domain/emoji_picker.rs
+++ b/src/domain/emoji_picker.rs
@@ -123,10 +123,10 @@ impl EmojiPickerState {
             }
 
             // Category filter
-            if let Some(ref g) = group {
-                if emoji.group() != *g {
-                    continue;
-                }
+            if let Some(ref g) = group
+                && emoji.group() != *g
+            {
+                continue;
             }
 
             // Text filter (match against name and shortcode)
@@ -285,10 +285,12 @@ mod tests {
         state.refresh_filter();
 
         // Should find smiley emojis even though category is Flags
-        assert!(state
-            .filtered
-            .iter()
-            .any(|e| e.name.to_lowercase().contains("smile")));
+        assert!(
+            state
+                .filtered
+                .iter()
+                .any(|e| e.name.to_lowercase().contains("smile"))
+        );
     }
 
     #[test]

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -19,7 +19,7 @@ mod verify_overlay;
 
 pub use action_menu::ActionMenuState;
 pub use contacts_overlay::ContactsOverlayState;
-pub use emoji_picker::{EmojiPickerAction, EmojiPickerSource, EmojiPickerState, CATEGORIES};
+pub use emoji_picker::{CATEGORIES, EmojiPickerAction, EmojiPickerSource, EmojiPickerState};
 pub use file_picker::FilePickerState;
 pub use forward_overlay::ForwardOverlayState;
 pub use group_menu_overlay::GroupMenuOverlayState;

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -85,10 +85,13 @@ pub fn encode_native_png(
 /// Falls back to a platform-specific default: 10×20 for Windows Terminal
 /// (typical Cascadia Code at default DPI), 8×16 elsewhere.
 pub fn detect_cell_pixel_size() -> (u16, u16) {
-    if let Ok(ws) = crossterm::terminal::window_size() {
-        if ws.width > 0 && ws.height > 0 && ws.columns > 0 && ws.rows > 0 {
-            return (ws.width / ws.columns, ws.height / ws.rows);
-        }
+    if let Ok(ws) = crossterm::terminal::window_size()
+        && ws.width > 0
+        && ws.height > 0
+        && ws.columns > 0
+        && ws.rows > 0
+    {
+        return (ws.width / ws.columns, ws.height / ws.rows);
     }
     if std::env::var("WT_SESSION").is_ok() {
         (10, 20) // Windows Terminal with Cascadia Code at typical DPI

--- a/src/input.rs
+++ b/src/input.rs
@@ -419,12 +419,11 @@ pub fn replace_shortcodes(input: &str) -> String {
                 && candidate
                     .chars()
                     .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '+')
+                && let Some(emoji) = emojis::get_by_shortcode(candidate)
             {
-                if let Some(emoji) = emojis::get_by_shortcode(candidate) {
-                    result.push_str(emoji.as_str());
-                    rest = &after_colon[end + 1..];
-                    continue;
-                }
+                result.push_str(emoji.as_str());
+                rest = &after_colon[end + 1..];
+                continue;
             }
             // Not a valid shortcode — emit the colon and continue
             result.push(':');

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -189,25 +189,25 @@ impl KeyBindings {
         // Conflicts only exist when global + mode overlap.
         let mut result = Vec::new();
         for (combo, &global_action) in &self.global {
-            if let Some(&normal_action) = self.normal.get(combo) {
-                if global_action != normal_action {
-                    result.push((
-                        BindingMode::Normal,
-                        combo.clone(),
-                        global_action,
-                        normal_action,
-                    ));
-                }
+            if let Some(&normal_action) = self.normal.get(combo)
+                && global_action != normal_action
+            {
+                result.push((
+                    BindingMode::Normal,
+                    combo.clone(),
+                    global_action,
+                    normal_action,
+                ));
             }
-            if let Some(&insert_action) = self.insert.get(combo) {
-                if global_action != insert_action {
-                    result.push((
-                        BindingMode::Insert,
-                        combo.clone(),
-                        global_action,
-                        insert_action,
-                    ));
-                }
+            if let Some(&insert_action) = self.insert.get(combo)
+                && global_action != insert_action
+            {
+                result.push((
+                    BindingMode::Insert,
+                    combo.clone(),
+                    global_action,
+                    insert_action,
+                ));
             }
         }
         result

--- a/src/link.rs
+++ b/src/link.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{
+    Terminal,
     backend::CrosstermBackend,
     layout::{Alignment, Constraint, Flex, Layout},
     style::{Color, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
-    Terminal,
 };
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 use tokio::process::Command;
@@ -218,18 +218,18 @@ async fn show_qr_and_wait(
         }
 
         // Poll for keyboard input
-        if event::poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind != KeyEventKind::Press {
-                    continue;
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+        {
+            if key.kind != KeyEventKind::Press {
+                continue;
+            }
+            match (key.modifiers, key.code) {
+                (_, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+                    let _ = child.kill().await;
+                    return Ok(LinkResult::Cancelled);
                 }
-                match (key.modifiers, key.code) {
-                    (_, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                        let _ = child.kill().await;
-                        return Ok(LinkResult::Cancelled);
-                    }
-                    _ => {}
-                }
+                _ => {}
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,17 +30,17 @@ use crossterm::{
     execute, queue,
     style::{Print, ResetColor, SetForegroundColor},
     terminal::{
-        disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, EndSynchronizedUpdate,
-        EnterAlternateScreen, LeaveAlternateScreen,
+        BeginSynchronizedUpdate, EndSynchronizedUpdate, EnterAlternateScreen, LeaveAlternateScreen,
+        disable_raw_mode, enable_raw_mode,
     },
 };
 use ratatui::{
+    Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Flex, Layout},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Paragraph, Wrap},
-    Terminal,
 };
 
 use app::{App, InputMode, SendRequest};
@@ -77,7 +77,7 @@ async fn main() -> Result<()> {
     // key event in raw mode, so the OS handler just causes a noisy exit code.
     #[cfg(windows)]
     unsafe {
-        extern "system" {
+        unsafe extern "system" {
             fn SetConsoleCtrlHandler(handler: usize, add: i32) -> i32;
         }
         SetConsoleCtrlHandler(0, 1);
@@ -437,12 +437,11 @@ async fn show_error_screen(
             frame.render_widget(paragraph, inner);
         })?;
 
-        if event::poll(Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
-                if key.kind == KeyEventKind::Press {
-                    return Ok(());
-                }
-            }
+        if event::poll(Duration::from_millis(100))?
+            && let Event::Key(key) = event::read()?
+            && key.kind == KeyEventKind::Press
+        {
+            return Ok(());
         }
     }
 }
@@ -873,72 +872,83 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
                 );
             }
         }
-        SendRequest::CreateGroup { name } => {
-            if let Err(e) = signal_client.create_group(&name, &[]).await {
+        SendRequest::CreateGroup { name } => match signal_client.create_group(&name, &[]).await {
+            Err(e) => {
                 app.status_message = format!("create group error: {e}");
-            } else {
+            }
+            _ => {
                 app.status_message = format!("Created group \"{}\"", name);
                 let _ = signal_client.list_groups().await;
             }
-        }
+        },
         SendRequest::AddGroupMembers { group_id, members } => {
-            if let Err(e) = signal_client.add_group_members(&group_id, &members).await {
-                app.status_message = format!("add member error: {e}");
-            } else {
-                let names: Vec<String> = members
-                    .iter()
-                    .map(|m| {
-                        app.store
-                            .contact_names
-                            .get(m)
-                            .cloned()
-                            .unwrap_or_else(|| m.clone())
-                    })
-                    .collect();
-                app.status_message = format!("Added {}", names.join(", "));
-                let _ = signal_client.list_groups().await;
+            match signal_client.add_group_members(&group_id, &members).await {
+                Err(e) => {
+                    app.status_message = format!("add member error: {e}");
+                }
+                _ => {
+                    let names: Vec<String> = members
+                        .iter()
+                        .map(|m| {
+                            app.store
+                                .contact_names
+                                .get(m)
+                                .cloned()
+                                .unwrap_or_else(|| m.clone())
+                        })
+                        .collect();
+                    app.status_message = format!("Added {}", names.join(", "));
+                    let _ = signal_client.list_groups().await;
+                }
             }
         }
         SendRequest::RemoveGroupMembers { group_id, members } => {
-            if let Err(e) = signal_client
+            match signal_client
                 .remove_group_members(&group_id, &members)
                 .await
             {
-                app.status_message = format!("remove member error: {e}");
-            } else {
-                let names: Vec<String> = members
-                    .iter()
-                    .map(|m| {
-                        app.store
-                            .contact_names
-                            .get(m)
-                            .cloned()
-                            .unwrap_or_else(|| m.clone())
-                    })
-                    .collect();
-                app.status_message = format!("Removed {}", names.join(", "));
-                let _ = signal_client.list_groups().await;
+                Err(e) => {
+                    app.status_message = format!("remove member error: {e}");
+                }
+                _ => {
+                    let names: Vec<String> = members
+                        .iter()
+                        .map(|m| {
+                            app.store
+                                .contact_names
+                                .get(m)
+                                .cloned()
+                                .unwrap_or_else(|| m.clone())
+                        })
+                        .collect();
+                    app.status_message = format!("Removed {}", names.join(", "));
+                    let _ = signal_client.list_groups().await;
+                }
             }
         }
         SendRequest::RenameGroup { group_id, name } => {
-            if let Err(e) = signal_client.rename_group(&group_id, &name).await {
-                app.status_message = format!("rename group error: {e}");
-            } else {
-                // Update locally for instant visual feedback
-                if let Some(conv) = app.store.conversations.get_mut(&group_id) {
-                    conv.name = name.clone();
+            match signal_client.rename_group(&group_id, &name).await {
+                Err(e) => {
+                    app.status_message = format!("rename group error: {e}");
                 }
-                app.store
-                    .contact_names
-                    .insert(group_id.clone(), name.clone());
-                app.status_message = format!("Renamed group to \"{}\"", name);
-                let _ = signal_client.list_groups().await;
+                _ => {
+                    // Update locally for instant visual feedback
+                    if let Some(conv) = app.store.conversations.get_mut(&group_id) {
+                        conv.name = name.clone();
+                    }
+                    app.store
+                        .contact_names
+                        .insert(group_id.clone(), name.clone());
+                    app.status_message = format!("Renamed group to \"{}\"", name);
+                    let _ = signal_client.list_groups().await;
+                }
             }
         }
-        SendRequest::LeaveGroup { group_id } => {
-            if let Err(e) = signal_client.quit_group(&group_id).await {
+        SendRequest::LeaveGroup { group_id } => match signal_client.quit_group(&group_id).await {
+            Err(e) => {
                 app.status_message = format!("leave group error: {e}");
-            } else {
+            }
+            _ => {
                 let name = app
                     .store
                     .conversations
@@ -953,7 +963,7 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
                 }
                 app.status_message = format!("Left group \"{}\"", name);
             }
-        }
+        },
         SendRequest::Block {
             recipient,
             is_group,
@@ -1062,17 +1072,20 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
             is_group,
             response_type,
         } => {
-            if let Err(e) = signal_client
+            match signal_client
                 .send_message_request_response(&recipient, is_group, &response_type)
                 .await
             {
-                app.status_message = format!("message request error: {e}");
-            } else {
-                app.status_message = match response_type.as_str() {
-                    "accept" => "Message request accepted".to_string(),
-                    "delete" => "Message request deleted".to_string(),
-                    _ => String::new(),
-                };
+                Err(e) => {
+                    app.status_message = format!("message request error: {e}");
+                }
+                _ => {
+                    app.status_message = match response_type.as_str() {
+                        "accept" => "Message request accepted".to_string(),
+                        "delete" => "Message request deleted".to_string(),
+                        _ => String::new(),
+                    };
+                }
             }
         }
         SendRequest::ListIdentities => {
@@ -1082,21 +1095,24 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
             recipient,
             safety_number,
         } => {
-            if let Err(e) = signal_client
+            match signal_client
                 .trust_identity(&recipient, &safety_number)
                 .await
             {
-                app.status_message = format!("trust error: {e}");
-            } else {
-                app.status_message = format!(
-                    "Verified {}",
-                    app.store
-                        .contact_names
-                        .get(&recipient)
-                        .unwrap_or(&recipient)
-                );
-                // Re-fetch identities to update trust levels
-                let _ = signal_client.list_identities().await;
+                Err(e) => {
+                    app.status_message = format!("trust error: {e}");
+                }
+                _ => {
+                    app.status_message = format!(
+                        "Verified {}",
+                        app.store
+                            .contact_names
+                            .get(&recipient)
+                            .unwrap_or(&recipient)
+                    );
+                    // Re-fetch identities to update trust levels
+                    let _ = signal_client.list_identities().await;
+                }
             }
         }
         SendRequest::UpdateProfile {
@@ -1105,13 +1121,16 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
             about,
             about_emoji,
         } => {
-            if let Err(e) = signal_client
+            match signal_client
                 .update_profile(&given_name, &family_name, &about, &about_emoji)
                 .await
             {
-                app.status_message = format!("profile error: {e}");
-            } else {
-                app.status_message = "Profile updated".to_string();
+                Err(e) => {
+                    app.status_message = format!("profile error: {e}");
+                }
+                _ => {
+                    app.status_message = "Profile updated".to_string();
+                }
             }
         }
     }

--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -195,13 +195,12 @@ pub fn delete_custom_profile(name: &str) -> Result<(), String> {
         if path.extension().and_then(|e| e.to_str()) != Some("toml") {
             continue;
         }
-        if let Ok(contents) = std::fs::read_to_string(&path) {
-            if let Ok(p) = toml::from_str::<SettingsProfile>(&contents) {
-                if p.name == name {
-                    std::fs::remove_file(&path).map_err(|e| format!("delete: {e}"))?;
-                    return Ok(());
-                }
-            }
+        if let Ok(contents) = std::fs::read_to_string(&path)
+            && let Ok(p) = toml::from_str::<SettingsProfile>(&contents)
+            && p.name == name
+        {
+            std::fs::remove_file(&path).map_err(|e| format!("delete: {e}"))?;
+            return Ok(());
         }
     }
     Err(format!("profile '{name}' not found"))

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 use ratatui::{
+    Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Flex, Layout},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, BorderType, Borders, Paragraph, Wrap},
-    Terminal,
 };
 use tokio::process::Command;
 
@@ -91,56 +91,56 @@ pub async fn run_setup(
                 }
 
                 // Wait for user input
-                if event::poll(Duration::from_millis(50))? {
-                    if let Event::Key(key) = event::read()? {
-                        if key.kind != KeyEventKind::Press {
-                            continue;
+                if event::poll(Duration::from_millis(50))?
+                    && let Event::Key(key) = event::read()?
+                {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    match (key.modifiers, key.code) {
+                        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+                            return Ok(SetupResult::Cancelled);
                         }
-                        match (key.modifiers, key.code) {
-                            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                                return Ok(SetupResult::Cancelled);
-                            }
-                            (_, KeyCode::Esc) if custom_path_mode => {
-                                custom_path_mode = false;
-                            }
-                            (_, KeyCode::Esc) => {
-                                return Ok(SetupResult::Cancelled);
-                            }
-                            _ if custom_path_mode => match key.code {
-                                KeyCode::Enter if !custom_path_input.is_empty() => {
-                                    signal_cli_path = custom_path_input.clone();
-                                    signal_cli_found = false;
-                                    custom_path_mode = false;
-                                    // Will re-check on next loop
-                                }
-                                KeyCode::Backspace if custom_path_cursor > 0 => {
-                                    custom_path_cursor -= 1;
-                                    custom_path_input.remove(custom_path_cursor);
-                                }
-                                KeyCode::Left => {
-                                    custom_path_cursor = custom_path_cursor.saturating_sub(1);
-                                }
-                                KeyCode::Right if custom_path_cursor < custom_path_input.len() => {
-                                    custom_path_cursor += 1;
-                                }
-                                KeyCode::Char(c) => {
-                                    custom_path_input.insert(custom_path_cursor, c);
-                                    custom_path_cursor += 1;
-                                }
-                                _ => {}
-                            },
-                            (_, KeyCode::Enter) => {
-                                // Retry check
+                        (_, KeyCode::Esc) if custom_path_mode => {
+                            custom_path_mode = false;
+                        }
+                        (_, KeyCode::Esc) => {
+                            return Ok(SetupResult::Cancelled);
+                        }
+                        _ if custom_path_mode => match key.code {
+                            KeyCode::Enter if !custom_path_input.is_empty() => {
+                                signal_cli_path = custom_path_input.clone();
                                 signal_cli_found = false;
+                                custom_path_mode = false;
+                                // Will re-check on next loop
                             }
-                            (_, KeyCode::Char('p')) => {
-                                // Enter custom path mode
-                                custom_path_mode = true;
-                                custom_path_input.clear();
-                                custom_path_cursor = 0;
+                            KeyCode::Backspace if custom_path_cursor > 0 => {
+                                custom_path_cursor -= 1;
+                                custom_path_input.remove(custom_path_cursor);
+                            }
+                            KeyCode::Left => {
+                                custom_path_cursor = custom_path_cursor.saturating_sub(1);
+                            }
+                            KeyCode::Right if custom_path_cursor < custom_path_input.len() => {
+                                custom_path_cursor += 1;
+                            }
+                            KeyCode::Char(c) => {
+                                custom_path_input.insert(custom_path_cursor, c);
+                                custom_path_cursor += 1;
                             }
                             _ => {}
+                        },
+                        (_, KeyCode::Enter) => {
+                            // Retry check
+                            signal_cli_found = false;
                         }
+                        (_, KeyCode::Char('p')) => {
+                            // Enter custom path mode
+                            custom_path_mode = true;
+                            custom_path_input.clear();
+                            custom_path_cursor = 0;
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -150,53 +150,53 @@ pub async fn run_setup(
                     draw_account_step(frame, &phone_input, phone_cursor, phone_error.as_deref());
                 })?;
 
-                if event::poll(Duration::from_millis(50))? {
-                    if let Event::Key(key) = event::read()? {
-                        if key.kind != KeyEventKind::Press {
-                            continue;
+                if event::poll(Duration::from_millis(50))?
+                    && let Event::Key(key) = event::read()?
+                {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    match (key.modifiers, key.code) {
+                        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+                            return Ok(SetupResult::Cancelled);
                         }
-                        match (key.modifiers, key.code) {
-                            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                                return Ok(SetupResult::Cancelled);
-                            }
-                            (_, KeyCode::Esc) => {
-                                step = Step::SignalCli;
-                                signal_cli_found = false;
-                                custom_path_mode = false;
-                                phone_input.clear();
-                                phone_cursor = 0;
-                                phone_error = None;
-                            }
-                            (_, KeyCode::Enter) => match validate_phone(&phone_input) {
-                                Ok(()) => {
-                                    working_config.account = phone_input.clone();
-                                    phone_error = None;
-                                    step = Step::Linking;
-                                }
-                                Err(msg) => {
-                                    phone_error = Some(msg);
-                                }
-                            },
-                            (_, KeyCode::Backspace) => {
-                                if phone_cursor > 0 {
-                                    phone_cursor -= 1;
-                                    phone_input.remove(phone_cursor);
-                                }
-                                phone_error = None;
-                            }
-                            (_, KeyCode::Left) => {
-                                phone_cursor = phone_cursor.saturating_sub(1);
-                            }
-                            (_, KeyCode::Right) if phone_cursor < phone_input.len() => {
-                                phone_cursor += 1;
-                            }
-                            (_, KeyCode::Char(c)) => {
-                                phone_input.insert(phone_cursor, c);
-                                phone_cursor += 1;
-                                phone_error = None;
-                            }
-                            _ => {}
+                        (_, KeyCode::Esc) => {
+                            step = Step::SignalCli;
+                            signal_cli_found = false;
+                            custom_path_mode = false;
+                            phone_input.clear();
+                            phone_cursor = 0;
+                            phone_error = None;
                         }
+                        (_, KeyCode::Enter) => match validate_phone(&phone_input) {
+                            Ok(()) => {
+                                working_config.account = phone_input.clone();
+                                phone_error = None;
+                                step = Step::Linking;
+                            }
+                            Err(msg) => {
+                                phone_error = Some(msg);
+                            }
+                        },
+                        (_, KeyCode::Backspace) => {
+                            if phone_cursor > 0 {
+                                phone_cursor -= 1;
+                                phone_input.remove(phone_cursor);
+                            }
+                            phone_error = None;
+                        }
+                        (_, KeyCode::Left) => {
+                            phone_cursor = phone_cursor.saturating_sub(1);
+                        }
+                        (_, KeyCode::Right) if phone_cursor < phone_input.len() => {
+                            phone_cursor += 1;
+                        }
+                        (_, KeyCode::Char(c)) => {
+                            phone_input.insert(phone_cursor, c);
+                            phone_cursor += 1;
+                            phone_error = None;
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -232,22 +232,22 @@ pub async fn run_setup(
                                 draw_link_error(frame, &msg);
                             })?;
                             loop {
-                                if event::poll(Duration::from_millis(50))? {
-                                    if let Event::Key(key) = event::read()? {
-                                        if key.kind != KeyEventKind::Press {
-                                            continue;
+                                if event::poll(Duration::from_millis(50))?
+                                    && let Event::Key(key) = event::read()?
+                                {
+                                    if key.kind != KeyEventKind::Press {
+                                        continue;
+                                    }
+                                    match key.code {
+                                        KeyCode::Enter => {
+                                            // Retry linking
+                                            break;
                                         }
-                                        match key.code {
-                                            KeyCode::Enter => {
-                                                // Retry linking
-                                                break;
-                                            }
-                                            KeyCode::Esc => {
-                                                step = Step::Account;
-                                                break;
-                                            }
-                                            _ => {}
+                                        KeyCode::Esc => {
+                                            step = Step::Account;
+                                            break;
                                         }
+                                        _ => {}
                                     }
                                 }
                             }
@@ -261,30 +261,30 @@ pub async fn run_setup(
                     draw_preferences_step(frame, &working_config);
                 })?;
 
-                if event::poll(Duration::from_millis(50))? {
-                    if let Event::Key(key) = event::read()? {
-                        if key.kind != KeyEventKind::Press {
-                            continue;
+                if event::poll(Duration::from_millis(50))?
+                    && let Event::Key(key) = event::read()?
+                {
+                    if key.kind != KeyEventKind::Press {
+                        continue;
+                    }
+                    match (key.modifiers, key.code) {
+                        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+                            return Ok(SetupResult::Cancelled);
                         }
-                        match (key.modifiers, key.code) {
-                            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                                return Ok(SetupResult::Cancelled);
-                            }
-                            (_, KeyCode::Char('1')) => {
-                                working_config.notify_direct = !working_config.notify_direct;
-                            }
-                            (_, KeyCode::Char('2')) => {
-                                working_config.notify_group = !working_config.notify_group;
-                            }
-                            (_, KeyCode::Enter) => {
-                                step = Step::Done;
-                            }
-                            (_, KeyCode::Esc) => {
-                                // Skip preferences and proceed with defaults
-                                step = Step::Done;
-                            }
-                            _ => {}
+                        (_, KeyCode::Char('1')) => {
+                            working_config.notify_direct = !working_config.notify_direct;
                         }
+                        (_, KeyCode::Char('2')) => {
+                            working_config.notify_group = !working_config.notify_group;
+                        }
+                        (_, KeyCode::Enter) => {
+                            step = Step::Done;
+                        }
+                        (_, KeyCode::Esc) => {
+                            // Skip preferences and proceed with defaults
+                            step = Step::Done;
+                        }
+                        _ => {}
                     }
                 }
             }
@@ -345,17 +345,16 @@ async fn check_signal_cli(path: &str) -> (bool, String, String) {
         .stderr(std::process::Stdio::null())
         .output()
         .await
+        && output.status.success()
     {
-        if output.status.success() {
-            let raw = String::from_utf8_lossy(&output.stdout);
-            for candidate in raw.lines() {
-                let candidate = candidate.trim();
-                if candidate.is_empty() {
-                    continue;
-                }
-                if let Some(display) = try_spawn_version(candidate).await {
-                    return (true, display, candidate.to_string());
-                }
+        let raw = String::from_utf8_lossy(&output.stdout);
+        for candidate in raw.lines() {
+            let candidate = candidate.trim();
+            if candidate.is_empty() {
+                continue;
+            }
+            if let Some(display) = try_spawn_version(candidate).await {
+                return (true, display, candidate.to_string());
             }
         }
     }

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -115,10 +115,10 @@ impl SignalClient {
                             }
                         }
 
-                        if let Some(event) = event {
-                            if event_tx.send(event).await.is_err() {
-                                break;
-                            }
+                        if let Some(event) = event
+                            && event_tx.send(event).await.is_err()
+                        {
+                            break;
                         }
                     }
                     Err(e) => {

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -222,62 +222,105 @@ impl SignalEvent {
                 msg.attachments.len(),
                 msg.group_id.is_some(),
             ),
-            Self::ReceiptReceived { sender, receipt_type, timestamps } => format!(
+            Self::ReceiptReceived {
+                sender,
+                receipt_type,
+                timestamps,
+            } => format!(
                 "ReceiptReceived({receipt_type} from={}, count={})",
-                mask_phone(sender), timestamps.len(),
+                mask_phone(sender),
+                timestamps.len(),
             ),
-            Self::SendTimestamp { rpc_id, server_ts } => format!(
-                "SendTimestamp(rpc={rpc_id}, ts={server_ts})",
-            ),
+            Self::SendTimestamp { rpc_id, server_ts } => {
+                format!("SendTimestamp(rpc={rpc_id}, ts={server_ts})",)
+            }
             Self::SendFailed { rpc_id } => format!("SendFailed(rpc={rpc_id})"),
-            Self::TypingIndicator { sender, is_typing, .. } => format!(
+            Self::TypingIndicator {
+                sender, is_typing, ..
+            } => format!(
                 "TypingIndicator(from={}, typing={is_typing})",
                 mask_phone(sender),
             ),
-            Self::ReactionReceived { conv_id, emoji, sender, target_timestamp, is_remove, .. } => format!(
+            Self::ReactionReceived {
+                conv_id,
+                emoji,
+                sender,
+                target_timestamp,
+                is_remove,
+                ..
+            } => format!(
                 "ReactionReceived(conv={}, from={}, emoji={emoji}, target_ts={target_timestamp}, remove={is_remove})",
-                mask_phone(conv_id), mask_phone(sender),
+                mask_phone(conv_id),
+                mask_phone(sender),
             ),
-            Self::EditReceived { conv_id, target_timestamp, new_body, .. } => format!(
+            Self::EditReceived {
+                conv_id,
+                target_timestamp,
+                new_body,
+                ..
+            } => format!(
                 "EditReceived(conv={}, target_ts={target_timestamp}, body={})",
-                mask_phone(conv_id), mask_body(new_body),
+                mask_phone(conv_id),
+                mask_body(new_body),
             ),
-            Self::RemoteDeleteReceived { conv_id, target_timestamp, .. } => format!(
+            Self::RemoteDeleteReceived {
+                conv_id,
+                target_timestamp,
+                ..
+            } => format!(
                 "RemoteDeleteReceived(conv={}, target_ts={target_timestamp})",
                 mask_phone(conv_id),
             ),
-            Self::PinReceived { conv_id, target_timestamp, .. } => format!(
+            Self::PinReceived {
+                conv_id,
+                target_timestamp,
+                ..
+            } => format!(
                 "PinReceived(conv={}, target_ts={target_timestamp})",
                 mask_phone(conv_id),
             ),
-            Self::UnpinReceived { conv_id, target_timestamp, .. } => format!(
+            Self::UnpinReceived {
+                conv_id,
+                target_timestamp,
+                ..
+            } => format!(
                 "UnpinReceived(conv={}, target_ts={target_timestamp})",
                 mask_phone(conv_id),
             ),
-            Self::PollCreated { conv_id, timestamp, .. } => format!(
-                "PollCreated(conv={}, ts={timestamp})",
-                mask_phone(conv_id),
-            ),
-            Self::PollVoteReceived { conv_id, target_timestamp, voter, .. } => format!(
+            Self::PollCreated {
+                conv_id, timestamp, ..
+            } => format!("PollCreated(conv={}, ts={timestamp})", mask_phone(conv_id),),
+            Self::PollVoteReceived {
+                conv_id,
+                target_timestamp,
+                voter,
+                ..
+            } => format!(
                 "PollVoteReceived(conv={}, target_ts={target_timestamp}, voter={})",
-                mask_phone(conv_id), mask_phone(voter),
+                mask_phone(conv_id),
+                mask_phone(voter),
             ),
-            Self::PollTerminated { conv_id, target_timestamp } => format!(
+            Self::PollTerminated {
+                conv_id,
+                target_timestamp,
+            } => format!(
                 "PollTerminated(conv={}, target_ts={target_timestamp})",
                 mask_phone(conv_id),
             ),
             Self::SystemMessage { conv_id, body, .. } => format!(
                 "SystemMessage(conv={}, body={})",
-                mask_phone(conv_id), mask_body(body),
+                mask_phone(conv_id),
+                mask_body(body),
             ),
-            Self::ExpirationTimerChanged { conv_id, seconds, .. } => format!(
+            Self::ExpirationTimerChanged {
+                conv_id, seconds, ..
+            } => format!(
                 "ExpirationTimerChanged(conv={}, seconds={seconds})",
                 mask_phone(conv_id),
             ),
-            Self::ReadSyncReceived { read_messages } => format!(
-                "ReadSyncReceived(count={})",
-                read_messages.len(),
-            ),
+            Self::ReadSyncReceived { read_messages } => {
+                format!("ReadSyncReceived(count={})", read_messages.len(),)
+            }
             Self::ContactList(contacts) => format!("ContactList(count={})", contacts.len()),
             Self::GroupList(groups) => format!("GroupList(count={})", groups.len()),
             Self::IdentityList(ids) => format!("IdentityList(count={})", ids.len()),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,4 +1,5 @@
 use ratatui::{
+    Frame,
     buffer::Buffer,
     layout::{Alignment, Constraint, Direction, Layout, Position, Rect},
     style::{Color, Modifier, Style},
@@ -7,16 +8,15 @@ use ratatui::{
         Block, BorderType, Borders, Clear, List, ListItem, Paragraph, Scrollbar,
         ScrollbarOrientation, ScrollbarState, Wrap,
     },
-    Frame,
 };
 
 use crate::app::{
-    App, AutocompleteMode, GroupMenuState, InputMode, SettingDef, VisibleImage, PIN_DURATIONS,
-    QUICK_REACTIONS, SETTINGS,
+    App, AutocompleteMode, GroupMenuState, InputMode, PIN_DURATIONS, QUICK_REACTIONS, SETTINGS,
+    SettingDef, VisibleImage,
 };
 use crate::domain::CATEGORIES;
 use crate::image_render::{self, ImageProtocol};
-use crate::input::{format_compact_duration, COMMANDS};
+use crate::input::{COMMANDS, format_compact_duration};
 use crate::keybindings::{self, BindingMode, KeyAction};
 use crate::list_overlay;
 use crate::signal::types::{MessageStatus, PollData, PollVote, Reaction, StyleType, TrustLevel};
@@ -708,10 +708,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     // Resolve hidden URLs for attachment links (display text has no URI scheme)
     for link in &mut app.image.link_regions {
-        if !link.url.contains("://") {
-            if let Some(url) = app.image.link_url_map.get(&link.text) {
-                link.url = url.clone();
-            }
+        if !link.url.contains("://")
+            && let Some(url) = app.image.link_url_map.get(&link.text)
+        {
+            link.url = url.clone();
         }
     }
 }
@@ -899,23 +899,23 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             }
 
             // Trust level indicator (1:1 only)
-            if !conv.is_group {
-                if let Some(trust) = app.identity_trust.get(id) {
-                    match trust {
-                        TrustLevel::TrustedVerified => {
-                            spans.push(Span::styled(
-                                "\u{2713} verified ",
-                                Style::default().fg(theme.accent),
-                            ));
-                        }
-                        TrustLevel::Untrusted => {
-                            spans.push(Span::styled(
-                                "\u{26A0} untrusted ",
-                                Style::default().fg(theme.warning),
-                            ));
-                        }
-                        TrustLevel::TrustedUnverified => {} // normal state, no indicator
+            if !conv.is_group
+                && let Some(trust) = app.identity_trust.get(id)
+            {
+                match trust {
+                    TrustLevel::TrustedVerified => {
+                        spans.push(Span::styled(
+                            "\u{2713} verified ",
+                            Style::default().fg(theme.accent),
+                        ));
                     }
+                    TrustLevel::Untrusted => {
+                        spans.push(Span::styled(
+                            "\u{26A0} untrusted ",
+                            Style::default().fg(theme.warning),
+                        ));
+                    }
+                    TrustLevel::TrustedUnverified => {} // normal state, no indicator
                 }
             }
 
@@ -985,16 +985,16 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         (None, full_inner)
     };
 
-    if let Some(ref pin_text) = pinned_banner_text {
-        if let Some(banner) = banner_area {
-            let pin_line = Line::from(Span::styled(
-                truncate(pin_text, banner.width as usize),
-                Style::default()
-                    .fg(theme.warning)
-                    .add_modifier(Modifier::BOLD),
-            ));
-            frame.render_widget(Paragraph::new(pin_line), banner);
-        }
+    if let Some(ref pin_text) = pinned_banner_text
+        && let Some(banner) = banner_area
+    {
+        let pin_line = Line::from(Span::styled(
+            truncate(pin_text, banner.width as usize),
+            Style::default()
+                .fg(theme.warning)
+                .add_modifier(Modifier::BOLD),
+        ));
+        frame.render_widget(Paragraph::new(pin_line), banner);
     }
 
     app.mouse_messages_area = inner;
@@ -1125,12 +1125,11 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             let mut spans = Vec::new();
 
             // Status symbol for outgoing messages (before timestamp)
-            if app.show_receipts {
-                if let Some(status) = msg.status {
-                    let (sym, color) =
-                        status_symbol(status, app.nerd_fonts, app.color_receipts, theme);
-                    spans.push(Span::styled(format!("{sym} "), Style::default().fg(color)));
-                }
+            if app.show_receipts
+                && let Some(status) = msg.status
+            {
+                let (sym, color) = status_symbol(status, app.nerd_fonts, app.color_receipts, theme);
+                spans.push(Span::styled(format!("{sym} "), Style::default().fg(color)));
             }
 
             if msg.expires_in_seconds > 0 {
@@ -1224,83 +1223,81 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             }
 
             // Render inline image preview if available (skip for deleted, skip if images disabled)
-            if !msg.is_deleted && app.image.image_mode != "none" {
-                if let Some(ref image_lines) = msg.image_lines {
-                    let first_idx = lines.len();
-                    let count = image_lines.len();
-                    for line in image_lines {
-                        lines.push(line.clone());
-                        line_msg_idx.push(Some(msg_index));
-                    }
-                    // Record for native protocol overlay
-                    if use_native {
-                        if let Some(ref path) = msg.image_path {
-                            image_records.push((first_idx, count, path.clone()));
-                        }
-                    }
+            if !msg.is_deleted
+                && app.image.image_mode != "none"
+                && let Some(ref image_lines) = msg.image_lines
+            {
+                let first_idx = lines.len();
+                let count = image_lines.len();
+                for line in image_lines {
+                    lines.push(line.clone());
+                    line_msg_idx.push(Some(msg_index));
+                }
+                // Record for native protocol overlay
+                if use_native && let Some(ref path) = msg.image_path {
+                    image_records.push((first_idx, count, path.clone()));
                 }
             }
 
             // Render link preview block
-            if !msg.is_deleted && app.image.show_link_previews {
-                if let Some(ref preview) = msg.preview {
-                    if let Some(ref title) = preview.title {
-                        lines.push(Line::from(vec![
-                            Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
-                            Span::styled(
-                                truncate(title, 60),
-                                Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
-                            ),
-                        ]));
-                        line_msg_idx.push(Some(msg_index));
-                    }
-                    if let Some(ref desc) = preview.description {
-                        // Description is a middle line; URL always follows
-                        lines.push(Line::from(vec![
-                            Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
-                            Span::styled(truncate(desc, 60), Style::default().fg(theme.fg_muted)),
-                        ]));
-                        line_msg_idx.push(Some(msg_index));
-                    }
+            if !msg.is_deleted
+                && app.image.show_link_previews
+                && let Some(ref preview) = msg.preview
+            {
+                if let Some(ref title) = preview.title {
                     lines.push(Line::from(vec![
-                        Span::styled("  \u{2570} ", Style::default().fg(theme.link)),
+                        Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
                         Span::styled(
-                            truncate(&preview.url, 60),
-                            Style::default()
-                                .fg(theme.link)
-                                .add_modifier(Modifier::UNDERLINED),
+                            truncate(title, 60),
+                            Style::default().fg(theme.fg).add_modifier(Modifier::BOLD),
                         ),
                     ]));
                     line_msg_idx.push(Some(msg_index));
+                }
+                if let Some(ref desc) = preview.description {
+                    // Description is a middle line; URL always follows
+                    lines.push(Line::from(vec![
+                        Span::styled("  \u{251C} ", Style::default().fg(theme.link)),
+                        Span::styled(truncate(desc, 60), Style::default().fg(theme.fg_muted)),
+                    ]));
+                    line_msg_idx.push(Some(msg_index));
+                }
+                lines.push(Line::from(vec![
+                    Span::styled("  \u{2570} ", Style::default().fg(theme.link)),
+                    Span::styled(
+                        truncate(&preview.url, 60),
+                        Style::default()
+                            .fg(theme.link)
+                            .add_modifier(Modifier::UNDERLINED),
+                    ),
+                ]));
+                line_msg_idx.push(Some(msg_index));
 
-                    // Render link preview thumbnail (only when images enabled)
-                    if app.image.image_mode != "none" {
-                        if let Some(ref img_lines) = msg.preview_image_lines {
-                            let first_idx = lines.len();
-                            let count = img_lines.len();
-                            for line in img_lines {
-                                lines.push(line.clone());
-                                line_msg_idx.push(Some(msg_index));
-                            }
-                            if use_native {
-                                if let Some(ref path) = msg.preview_image_path {
-                                    image_records.push((first_idx, count, path.clone()));
-                                }
-                            }
-                        }
+                // Render link preview thumbnail (only when images enabled)
+                if app.image.image_mode != "none"
+                    && let Some(ref img_lines) = msg.preview_image_lines
+                {
+                    let first_idx = lines.len();
+                    let count = img_lines.len();
+                    for line in img_lines {
+                        lines.push(line.clone());
+                        line_msg_idx.push(Some(msg_index));
+                    }
+                    if use_native && let Some(ref path) = msg.preview_image_path {
+                        image_records.push((first_idx, count, path.clone()));
                     }
                 }
             }
 
             // Render inline poll display
-            if !msg.is_deleted {
-                if let Some(ref poll_data) = msg.poll_data {
-                    let poll_lines =
-                        build_poll_display(poll_data, &msg.poll_votes, &app.account, theme);
-                    for line in poll_lines {
-                        lines.push(line);
-                        line_msg_idx.push(Some(msg_index));
-                    }
+            if !msg.is_deleted
+                && let Some(ref poll_data) = msg.poll_data
+            {
+                let poll_lines =
+                    build_poll_display(poll_data, &msg.poll_votes, &app.account, theme);
+                for line in poll_lines {
+                    lines.push(line);
+                    line_msg_idx.push(Some(msg_index));
                 }
             }
 
@@ -4926,7 +4923,7 @@ mod snapshot_tests {
     use crate::domain::EmojiPickerSource;
     use crate::image_render::ImageProtocol;
     use chrono::NaiveDate;
-    use ratatui::{backend::TestBackend, Terminal};
+    use ratatui::{Terminal, backend::TestBackend};
 
     /// Fixed date for deterministic timestamps in snapshots.
     fn fixed_date() -> NaiveDate {


### PR DESCRIPTION
## Summary

Closes #330.

- Bumps `edition = "2024"` in Cargo.toml.
- `cargo fix --edition` + `cargo clippy --fix` handled the mechanical migration:
  - Collapsed nested `if let` into let-chains (stabilized in 2024) -- 80+ sites across app.rs, main.rs, ui.rs, db.rs, and others.
  - Sorted imports to match the new rustfmt defaults.
  - Applied 2024-style formatting.
- Three `cargo fix --edition` warnings about relative drop-order changes (signal/client.rs:158, link.rs:137, setup.rs:220) are benign: they shift mutex-guard releases and tokio task cleanups slightly earlier, but no logic in those blocks depends on the old ordering. All 627 tests pass under the new edition.

Diff size is large (+1021/-953) because the collapsible-if fix and import reordering touch many files, but each hunk is mechanical.

## Test plan

- [x] `cargo clippy --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` (479 + 148 + 0)
- [x] `cargo build --release`

Generated with Claude Code.