### PR TITLE
refactor: complete overlay migration onto current_overlay

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2659,11 +2659,7 @@ impl App {
                     let local_ts_ms = chrono::Utc::now().timestamp_millis();
                     self.close_overlay();
                     self.status_message = format!("Forwarded to {name}");
-                    if self.store.move_conversation_to_top(&conv_id)
-                        && self.is_overlay(OverlayKind::SidebarFilter)
-                    {
-                        self.refresh_sidebar_filter();
-                    }
+                    self.store.move_conversation_to_top(&conv_id);
                     return Some(SendRequest::Message {
                         recipient: conv_id,
                         body,
@@ -2897,6 +2893,9 @@ impl App {
             }
             KeyCode::Esc => {
                 self.autocomplete.clear();
+                if self.is_overlay(OverlayKind::Autocomplete) {
+                    self.close_overlay();
+                }
             }
             KeyCode::Enter => {
                 if self.autocomplete.mode == AutocompleteMode::Mention {
@@ -3525,13 +3524,7 @@ impl App {
         }
     }
 
-    /// Returns true if the given overlay kind is currently open via the
-    /// App-owned `current_overlay` field.
-    ///
-    /// Only meaningful for the overlays that have been migrated to
-    /// `current_overlay`; others report false here regardless of whether
-    /// their own `.show` flag is set. Use `active_overlay()` for the
-    /// unified check.
+    /// Returns true if the given overlay kind is currently active.
     pub fn is_overlay(&self, kind: OverlayKind) -> bool {
         self.current_overlay == Some(kind)
     }
@@ -6664,6 +6657,9 @@ impl App {
 
         // No autocomplete match
         self.autocomplete.clear();
+        if self.is_overlay(OverlayKind::Autocomplete) {
+            self.close_overlay();
+        }
     }
 
     /// Find the byte position of the `@` trigger for mention autocomplete.
@@ -10849,6 +10845,45 @@ mod tests {
     }
 
     #[rstest]
+    fn autocomplete_esc_closes_overlay(mut app: App) {
+        // Regression guard for PR #346: pre-fix, AutocompleteState::clear()
+        // no longer touched visibility, so Esc cleared candidates but left
+        // current_overlay = Some(Autocomplete), trapping subsequent input
+        // in the empty handler.
+        app.mode = InputMode::Insert;
+        app.input_buffer = "/j".to_string();
+        app.input_cursor = 2;
+        app.update_autocomplete();
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
+
+        app.handle_autocomplete_key(KeyCode::Esc);
+        assert!(
+            !app.is_overlay(OverlayKind::Autocomplete),
+            "Esc should close the autocomplete overlay"
+        );
+    }
+
+    #[rstest]
+    fn autocomplete_no_match_closes_overlay(mut app: App) {
+        // Regression guard for PR #346: typing past any candidate match
+        // should drop visibility, not leave the empty overlay open.
+        app.mode = InputMode::Insert;
+        app.input_buffer = "/j".to_string();
+        app.input_cursor = 2;
+        app.update_autocomplete();
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
+
+        // Type a string that matches no command/mention/join.
+        app.input_buffer = "/zzznothingmatches".to_string();
+        app.input_cursor = app.input_buffer.len();
+        app.update_autocomplete();
+        assert!(
+            !app.is_overlay(OverlayKind::Autocomplete),
+            "no-match autocomplete refresh should close the overlay"
+        );
+    }
+
+    #[rstest]
     fn bell_skipped_for_unaccepted_conversation(mut app: App) {
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         assert!(!app.notifications.pending_bell);
@@ -11114,10 +11149,10 @@ mod tests {
 
     #[rstest]
     fn active_overlay_covers_every_variant(mut app: App) {
-        // Tripwire: `toggle_overlay`'s match is compiler-enforced exhaustive,
-        // but `ALL_OVERLAYS` is a hand-maintained slice. Adding a variant
-        // without extending this slice would silently skip it; the length
-        // check turns that into a loud test failure.
+        // Tripwire: `ALL_OVERLAYS` is a hand-maintained slice because Rust has
+        // no stable way to enumerate enum variants. Adding a variant without
+        // extending this slice would silently skip it; the length check turns
+        // that into a loud test failure.
         assert_eq!(
             ALL_OVERLAYS.len(),
             23,

--- a/src/app.rs
+++ b/src/app.rs
@@ -2293,7 +2293,7 @@ impl App {
     pub fn handle_action_menu_key(&mut self, code: KeyCode) -> Option<SendRequest> {
         let item_count = self.action_menu_items().len();
         if item_count == 0 {
-            self.action_menu.show = false;
+            self.close_overlay();
             return None;
         }
         match classify_list_key(code, false) {
@@ -2311,15 +2311,15 @@ impl App {
                 let items = self.action_menu_items();
                 if let Some(action) = items.get(self.action_menu.index) {
                     let hint = action.key_hint;
-                    self.action_menu.show = false;
+                    self.close_overlay();
                     self.execute_action_by_hint(hint)
                 } else {
-                    self.action_menu.show = false;
+                    self.close_overlay();
                     None
                 }
             }
             ListKeyAction::Close => {
-                self.action_menu.show = false;
+                self.close_overlay();
                 None
             }
             ListKeyAction::None => {
@@ -2342,7 +2342,7 @@ impl App {
                     // Only execute if this action is available in the menu
                     let items = self.action_menu_items();
                     if items.iter().any(|a| a.key_hint == hint) {
-                        self.action_menu.show = false;
+                        self.close_overlay();
                         self.execute_action_by_hint(hint)
                     } else {
                         None
@@ -3473,10 +3473,10 @@ impl App {
         if self.current_overlay == Some(OverlayKind::PollVote) {
             return Some(OverlayKind::PollVote);
         }
-        if self.pin_duration.show {
+        if self.current_overlay == Some(OverlayKind::PinDuration) {
             return Some(OverlayKind::PinDuration);
         }
-        if self.action_menu.show {
+        if self.current_overlay == Some(OverlayKind::ActionMenu) {
             return Some(OverlayKind::ActionMenu);
         }
         if self.current_overlay == Some(OverlayKind::DeleteConfirm) {
@@ -3976,7 +3976,7 @@ impl App {
             }
             Some(KeyAction::OpenActionMenu) => {
                 if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.action_menu.show = true;
+                    self.open_overlay(OverlayKind::ActionMenu);
                     self.action_menu.index = 0;
                 }
                 None
@@ -4182,7 +4182,7 @@ impl App {
             }
             Some(KeyAction::OpenActionMenu) => {
                 if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.action_menu.show = true;
+                    self.open_overlay(OverlayKind::ActionMenu);
                     self.action_menu.index = 0;
                 }
                 None
@@ -5278,7 +5278,7 @@ impl App {
                 target_author,
                 target_timestamp,
             });
-            self.pin_duration.show = true;
+            self.open_overlay(OverlayKind::PinDuration);
             self.pin_duration.index = 0;
             None
         }
@@ -5299,7 +5299,7 @@ impl App {
             }
             ListKeyAction::Select => {
                 let duration = PIN_DURATIONS[self.pin_duration.index].0;
-                self.pin_duration.show = false;
+                self.close_overlay();
                 let pending = self.pin_duration.pending.take()?;
 
                 // Optimistically pin
@@ -5329,7 +5329,7 @@ impl App {
                 })
             }
             ListKeyAction::Close => {
-                self.pin_duration.show = false;
+                self.close_overlay();
                 self.pin_duration.pending = None;
                 None
             }
@@ -11117,8 +11117,8 @@ mod tests {
         match kind {
             OverlayKind::SidebarFilter => toggle_current_overlay(app, OverlayKind::SidebarFilter, on),
             OverlayKind::PollVote => toggle_current_overlay(app, OverlayKind::PollVote, on),
-            OverlayKind::PinDuration => app.pin_duration.show = on,
-            OverlayKind::ActionMenu => app.action_menu.show = on,
+            OverlayKind::PinDuration => toggle_current_overlay(app, OverlayKind::PinDuration, on),
+            OverlayKind::ActionMenu => toggle_current_overlay(app, OverlayKind::ActionMenu, on),
             OverlayKind::DeleteConfirm => {
                 toggle_current_overlay(app, OverlayKind::DeleteConfirm, on)
             }

--- a/src/app.rs
+++ b/src/app.rs
@@ -176,7 +176,7 @@ impl App {
 
         // Sidebar reorder (skip for system messages, which shouldn't bump
         // conversations to the top just because someone changed the group name).
-        if !is_system && self.store.move_conversation_to_top(conv_id) && self.sidebar_filter_active
+        if !is_system && self.store.move_conversation_to_top(conv_id) && self.is_overlay(OverlayKind::SidebarFilter)
         {
             self.refresh_sidebar_filter();
         }
@@ -411,8 +411,6 @@ pub struct App {
     pub sidebar_width: u16,
     /// Display sidebar on the right side instead of left
     pub sidebar_on_right: bool,
-    /// Sidebar filter mode active
-    pub sidebar_filter_active: bool,
     /// Current filter text for sidebar
     pub sidebar_filter: String,
     /// Filtered conversation IDs matching the filter
@@ -2643,7 +2641,7 @@ impl App {
                     let local_ts_ms = chrono::Utc::now().timestamp_millis();
                     self.forward.show = false;
                     self.status_message = format!("Forwarded to {name}");
-                    if self.store.move_conversation_to_top(&conv_id) && self.sidebar_filter_active {
+                    if self.store.move_conversation_to_top(&conv_id) && self.is_overlay(OverlayKind::SidebarFilter) {
                         self.refresh_sidebar_filter();
                     }
                     return Some(SendRequest::Message {
@@ -2905,7 +2903,6 @@ impl App {
             account,
             sidebar_width: 22,
             sidebar_on_right: false,
-            sidebar_filter_active: false,
             sidebar_filter: String::new(),
             sidebar_filtered: Vec::new(),
             typing: TypingState::default(),
@@ -3184,7 +3181,9 @@ impl App {
 
     /// Clear sidebar filter state and restore the full list.
     fn clear_sidebar_filter(&mut self) {
-        self.sidebar_filter_active = false;
+        if self.is_overlay(OverlayKind::SidebarFilter) {
+            self.close_overlay();
+        }
         self.sidebar_filter.clear();
         self.sidebar_filtered.clear();
     }
@@ -3447,7 +3446,7 @@ impl App {
             }
             Some(KeyAction::SidebarSearch) => {
                 self.sidebar_visible = true;
-                self.sidebar_filter_active = true;
+                self.open_overlay(OverlayKind::SidebarFilter);
                 self.sidebar_filter.clear();
                 self.sidebar_filtered.clear();
                 true
@@ -3468,7 +3467,7 @@ impl App {
     /// this method so dispatch, visibility checks, and any future per-overlay
     /// logic stay in sync automatically.
     pub fn active_overlay(&self) -> Option<OverlayKind> {
-        if self.sidebar_filter_active {
+        if self.current_overlay == Some(OverlayKind::SidebarFilter) {
             return Some(OverlayKind::SidebarFilter);
         }
         if self.poll_vote.show {
@@ -3884,7 +3883,7 @@ impl App {
             }
             Some(KeyAction::SidebarSearch) => {
                 self.sidebar_visible = true;
-                self.sidebar_filter_active = true;
+                self.open_overlay(OverlayKind::SidebarFilter);
                 self.sidebar_filter.clear();
                 self.sidebar_filtered.clear();
                 None
@@ -4453,7 +4452,7 @@ impl App {
             msg.source.clone()
         };
 
-        if self.store.move_conversation_to_top(&conv_id) && self.sidebar_filter_active {
+        if self.store.move_conversation_to_top(&conv_id) && self.is_overlay(OverlayKind::SidebarFilter) {
             self.refresh_sidebar_filter();
         }
 
@@ -7427,7 +7426,7 @@ impl App {
             && is_in_rect(col, row, inner)
         {
             let index = (row - inner.y) as usize;
-            let sidebar_list = if self.sidebar_filter_active && !self.sidebar_filtered.is_empty() {
+            let sidebar_list = if self.is_overlay(OverlayKind::SidebarFilter) && !self.sidebar_filtered.is_empty() {
                 &self.sidebar_filtered
             } else {
                 &self.store.conversation_order
@@ -11116,7 +11115,7 @@ mod tests {
     /// extending this test is a compile error.
     fn toggle_overlay(app: &mut App, kind: OverlayKind, on: bool) {
         match kind {
-            OverlayKind::SidebarFilter => app.sidebar_filter_active = on,
+            OverlayKind::SidebarFilter => toggle_current_overlay(app, OverlayKind::SidebarFilter, on),
             OverlayKind::PollVote => app.poll_vote.show = on,
             OverlayKind::PinDuration => app.pin_duration.show = on,
             OverlayKind::ActionMenu => app.action_menu.show = on,

--- a/src/app.rs
+++ b/src/app.rs
@@ -2471,7 +2471,7 @@ impl App {
                     });
                     self.poll_vote.selections = vec![false; option_count];
                     self.poll_vote.index = 0;
-                    self.poll_vote.show = true;
+                    self.open_overlay(OverlayKind::PollVote);
                 }
                 None
             }
@@ -3470,7 +3470,7 @@ impl App {
         if self.current_overlay == Some(OverlayKind::SidebarFilter) {
             return Some(OverlayKind::SidebarFilter);
         }
-        if self.poll_vote.show {
+        if self.current_overlay == Some(OverlayKind::PollVote) {
             return Some(OverlayKind::PollVote);
         }
         if self.pin_duration.show {
@@ -5446,7 +5446,7 @@ impl App {
                     return None;
                 }
                 let pending = self.poll_vote.pending.take()?;
-                self.poll_vote.show = false;
+                self.close_overlay();
 
                 // Optimistic local vote
                 let voter = self.account.clone();
@@ -5469,7 +5469,7 @@ impl App {
                 })
             }
             KeyCode::Esc => {
-                self.poll_vote.show = false;
+                self.close_overlay();
                 self.poll_vote.pending = None;
                 None
             }
@@ -11116,7 +11116,7 @@ mod tests {
     fn toggle_overlay(app: &mut App, kind: OverlayKind, on: bool) {
         match kind {
             OverlayKind::SidebarFilter => toggle_current_overlay(app, OverlayKind::SidebarFilter, on),
-            OverlayKind::PollVote => app.poll_vote.show = on,
+            OverlayKind::PollVote => toggle_current_overlay(app, OverlayKind::PollVote, on),
             OverlayKind::PinDuration => app.pin_duration.show = on,
             OverlayKind::ActionMenu => app.action_menu.show = on,
             OverlayKind::DeleteConfirm => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -176,7 +176,9 @@ impl App {
 
         // Sidebar reorder (skip for system messages, which shouldn't bump
         // conversations to the top just because someone changed the group name).
-        if !is_system && self.store.move_conversation_to_top(conv_id) && self.is_overlay(OverlayKind::SidebarFilter)
+        if !is_system
+            && self.store.move_conversation_to_top(conv_id)
+            && self.is_overlay(OverlayKind::SidebarFilter)
         {
             self.refresh_sidebar_filter();
         }
@@ -231,11 +233,10 @@ fn show_desktop_notification(
 
 /// Tag identifying which overlay is currently active.
 ///
-/// Variants are declared in priority order, matching `App::active_overlay`:
-/// when multiple overlay flags are set, the first variant listed here wins
-/// input dispatch. Adding a new overlay requires adding a variant here and
-/// handling it in both `App::active_overlay` and `App::handle_overlay_key`,
-/// which the compiler enforces via the exhaustive match.
+/// Stored on `App.current_overlay` as the single source of truth for overlay
+/// visibility. Adding a new overlay requires adding a variant here and
+/// handling it in `App::handle_overlay_key`, which the compiler enforces
+/// via the exhaustive match.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OverlayKind {
     SidebarFilter,
@@ -551,14 +552,13 @@ pub struct App {
     pub settings_mouse_snapshot: bool,
     /// Sync state: tracks the initial message burst on startup.
     pub sync: SyncState,
-    /// Currently active App-owned overlay, when one is open.
+    /// Currently active overlay, when one is open.
     ///
-    /// Migration in progress: this is the source of truth for the six
-    /// overlays that were previously standalone booleans (About, Help,
-    /// Customize, DeleteConfirm, Settings, MessageRequest). The remaining
-    /// overlays still live inside their own state structs with `.show` /
-    /// `.visible` flags. Once every overlay has been migrated, the per-overlay
-    /// flags can be removed and `active_overlay` becomes `self.current_overlay`.
+    /// Single source of truth for overlay visibility. Drive all writes
+    /// through `open_overlay`/`close_overlay`/`try_open_overlay` so callers
+    /// can't accidentally bypass the dispatch layer. Per-overlay state
+    /// (filter text, cursor index, candidate lists) lives on the per-overlay
+    /// state structs and persists across close/reopen.
     pub current_overlay: Option<OverlayKind>,
 }
 
@@ -1123,7 +1123,7 @@ impl App {
                 self.save_settings();
                 match self.customize_index {
                     0 => {
-                        self.theme_picker.show = true;
+                        self.open_overlay(OverlayKind::ThemePicker);
                         self.theme_picker.index = self
                             .theme_picker
                             .available_themes
@@ -1132,7 +1132,7 @@ impl App {
                             .unwrap_or(0);
                     }
                     1 => {
-                        self.keybindings_overlay.show = true;
+                        self.open_overlay(OverlayKind::Keybindings);
                         self.keybindings_overlay.index = 0;
                     }
                     2 => {
@@ -1174,7 +1174,7 @@ impl App {
             .iter()
             .position(|p| p.name == self.settings_profiles.name)
             .unwrap_or(0);
-        self.settings_profiles.show = true;
+        self.open_overlay(OverlayKind::SettingsProfiles);
         self.settings_profiles.save_as = false;
         self.settings_profiles.save_as_input.clear();
         // Don't overwrite settings_snapshot - keep the one from when /settings opened
@@ -1336,7 +1336,7 @@ impl App {
                 }
             }
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.settings_profiles.show = false;
+                self.close_overlay();
                 self.fire_deferred_settings_hooks();
             }
             _ => {}
@@ -1370,10 +1370,10 @@ impl App {
                     self.theme = selected.clone();
                     self.save_settings();
                 }
-                self.theme_picker.show = false;
+                self.close_overlay();
             }
             ListKeyAction::Close => {
-                self.theme_picker.show = false;
+                self.close_overlay();
             }
             _ => {}
         }
@@ -1498,7 +1498,7 @@ impl App {
                 }
             }
             KeyCode::Esc | KeyCode::Char('q') => {
-                self.keybindings_overlay.show = false;
+                self.close_overlay();
                 self.save_settings();
             }
             _ => {}
@@ -1780,6 +1780,7 @@ impl App {
                     }
                     KeyCode::Esc => {
                         self.group_menu.state = None;
+                        self.close_overlay();
                     }
                     _ => {}
                 }
@@ -1797,6 +1798,7 @@ impl App {
                         self.group_menu.index = self.group_menu.index.saturating_sub(1);
                     }
                     KeyCode::Esc => {
+                        self.open_overlay(OverlayKind::GroupMenu);
                         self.group_menu.state = Some(GroupMenuState::Menu);
                         self.group_menu.index = 0;
                     }
@@ -1822,6 +1824,7 @@ impl App {
                             let phone = phone.clone();
                             let group_id = self.active_conversation.clone()?;
                             self.group_menu.state = None;
+                            self.close_overlay();
                             self.group_menu.filter.clear();
                             return Some(SendRequest::AddGroupMembers {
                                 group_id,
@@ -1830,6 +1833,7 @@ impl App {
                         }
                     }
                     KeyCode::Esc => {
+                        self.open_overlay(OverlayKind::GroupMenu);
                         self.group_menu.state = Some(GroupMenuState::Menu);
                         self.group_menu.index = 0;
                         self.group_menu.filter.clear();
@@ -1866,6 +1870,7 @@ impl App {
                             let phone = phone.clone();
                             let group_id = self.active_conversation.clone()?;
                             self.group_menu.state = None;
+                            self.close_overlay();
                             self.group_menu.filter.clear();
                             return Some(SendRequest::RemoveGroupMembers {
                                 group_id,
@@ -1874,6 +1879,7 @@ impl App {
                         }
                     }
                     KeyCode::Esc => {
+                        self.open_overlay(OverlayKind::GroupMenu);
                         self.group_menu.state = Some(GroupMenuState::Menu);
                         self.group_menu.index = 0;
                         self.group_menu.filter.clear();
@@ -1899,11 +1905,13 @@ impl App {
                         if !name.is_empty() {
                             let group_id = self.active_conversation.clone()?;
                             self.group_menu.state = None;
+                            self.close_overlay();
                             self.group_menu.input.clear();
                             return Some(SendRequest::RenameGroup { group_id, name });
                         }
                     }
                     KeyCode::Esc => {
+                        self.open_overlay(OverlayKind::GroupMenu);
                         self.group_menu.state = Some(GroupMenuState::Menu);
                         self.group_menu.index = 0;
                         self.group_menu.input.clear();
@@ -1924,12 +1932,14 @@ impl App {
                         let name = self.group_menu.input.trim().to_string();
                         if !name.is_empty() {
                             self.group_menu.state = None;
+                            self.close_overlay();
                             self.group_menu.input.clear();
                             return Some(SendRequest::CreateGroup { name });
                         }
                     }
                     KeyCode::Esc => {
                         self.group_menu.state = None;
+                        self.close_overlay();
                         self.group_menu.input.clear();
                     }
                     KeyCode::Backspace => {
@@ -1947,9 +1957,11 @@ impl App {
                     KeyCode::Char('y') => {
                         let group_id = self.active_conversation.clone()?;
                         self.group_menu.state = None;
+                        self.close_overlay();
                         return Some(SendRequest::LeaveGroup { group_id });
                     }
                     KeyCode::Char('n') | KeyCode::Esc => {
+                        self.open_overlay(OverlayKind::GroupMenu);
                         self.group_menu.state = Some(GroupMenuState::Menu);
                         self.group_menu.index = 0;
                     }
@@ -1988,14 +2000,17 @@ impl App {
                     })
                     .unwrap_or_default();
                 self.group_menu.filtered = members;
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::Members);
             }
             "a" => {
                 self.refresh_group_add_filter();
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::AddMember);
             }
             "r" => {
                 self.refresh_group_remove_filter();
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::RemoveMember);
             }
             "n" => {
@@ -2007,12 +2022,15 @@ impl App {
                     .map(|c| c.name.clone())
                     .unwrap_or_default();
                 self.group_menu.input = name;
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::Rename);
             }
             "l" => {
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::LeaveConfirm);
             }
             "c" => {
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::Create);
             }
             _ => {}
@@ -2091,24 +2109,24 @@ impl App {
                 let idx = (c as u8 - b'1') as usize;
                 if idx < QUICK_REACTIONS.len() {
                     self.reactions.picker_index = idx;
-                    self.reactions.show_picker = false;
+                    self.close_overlay();
                     self.prepare_reaction_send()
                 } else {
                     None
                 }
             }
             KeyCode::Enter | KeyCode::Char(' ') => {
-                self.reactions.show_picker = false;
+                self.close_overlay();
                 self.prepare_reaction_send()
             }
             KeyCode::Char('e') | KeyCode::Char('/') => {
                 // Open full emoji picker from reaction context
-                self.reactions.show_picker = false;
                 self.emoji_picker.open(EmojiPickerSource::Reaction, None);
+                self.open_overlay(OverlayKind::EmojiPicker);
                 None
             }
             KeyCode::Esc => {
-                self.reactions.show_picker = false;
+                self.close_overlay();
                 None
             }
             _ => None,
@@ -2404,7 +2422,7 @@ impl App {
             "r" => {
                 // React — open reaction picker
                 if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.reactions.show_picker = true;
+                    self.open_overlay(OverlayKind::ReactionPicker);
                     self.reactions.picker_index = 0;
                 }
                 None
@@ -2573,7 +2591,7 @@ impl App {
             }
             KeyCode::Esc => {
                 self.verify.confirming = false;
-                self.verify.show = false;
+                self.close_overlay();
             }
             _ => {
                 self.verify.confirming = false;
@@ -2583,7 +2601,7 @@ impl App {
     }
 
     fn open_forward_picker(&mut self) {
-        self.forward.show = true;
+        self.open_overlay(OverlayKind::Forward);
         self.forward.index = 0;
         self.forward.filter.clear();
         self.update_forward_filter();
@@ -2639,9 +2657,11 @@ impl App {
                         .unwrap_or(false);
                     let body = format!("[Forwarded]\n{}", self.forward.body);
                     let local_ts_ms = chrono::Utc::now().timestamp_millis();
-                    self.forward.show = false;
+                    self.close_overlay();
                     self.status_message = format!("Forwarded to {name}");
-                    if self.store.move_conversation_to_top(&conv_id) && self.is_overlay(OverlayKind::SidebarFilter) {
+                    if self.store.move_conversation_to_top(&conv_id)
+                        && self.is_overlay(OverlayKind::SidebarFilter)
+                    {
                         self.refresh_sidebar_filter();
                     }
                     return Some(SendRequest::Message {
@@ -2658,7 +2678,7 @@ impl App {
                 }
             }
             ListKeyAction::Close => {
-                self.forward.show = false;
+                self.close_overlay();
             }
             ListKeyAction::FilterPush(c) => {
                 if !c.is_control() {
@@ -2694,13 +2714,13 @@ impl App {
                     .get(self.contacts_overlay.index)
                 {
                     let number = number.clone();
-                    self.contacts_overlay.show = false;
+                    self.close_overlay();
                     self.contacts_overlay.filter.clear();
                     self.join_conversation(&number);
                 }
             }
             ListKeyAction::Close => {
-                self.contacts_overlay.show = false;
+                self.close_overlay();
                 self.contacts_overlay.filter.clear();
             }
             ListKeyAction::FilterPush(c) => {
@@ -2811,6 +2831,7 @@ impl App {
                 timestamp_ms,
                 status,
             } => {
+                self.close_overlay();
                 self.join_conversation(&conv_id);
                 self.jump_to_message_timestamp(timestamp_ms);
                 if let Some(msg) = status {
@@ -2819,6 +2840,9 @@ impl App {
             }
             SearchAction::Status(msg) => {
                 self.status_message = msg;
+            }
+            SearchAction::Cancel => {
+                self.close_overlay();
             }
             SearchAction::None => {}
         }
@@ -2831,12 +2855,20 @@ impl App {
             return;
         }
         self.file_picker.open();
+        self.open_overlay(OverlayKind::FilePicker);
     }
 
     /// Handle a key press while the file browser overlay is open.
     pub fn handle_file_browser_key(&mut self, code: KeyCode) {
-        if let Some(path) = self.file_picker.handle_key(code) {
-            self.pending_attachment = Some(path);
+        match self.file_picker.handle_key(code) {
+            crate::domain::FilePickerOutcome::Continue => {}
+            crate::domain::FilePickerOutcome::Selected(path) => {
+                self.pending_attachment = Some(path);
+                self.close_overlay();
+            }
+            crate::domain::FilePickerOutcome::Cancelled => {
+                self.close_overlay();
+            }
         }
     }
 
@@ -3416,7 +3448,7 @@ impl App {
                 }
                 true
             }
-            Some(KeyAction::NextConversation) if !self.autocomplete.visible => {
+            Some(KeyAction::NextConversation) if !self.is_overlay(OverlayKind::Autocomplete) => {
                 self.next_conversation();
                 true
             }
@@ -3459,103 +3491,38 @@ impl App {
     /// Returns `Some((recipient, body, is_group, local_ts_ms))` if an autocomplete
     /// command triggers a message send. Returns `None` otherwise.
     /// Returns `Ok(true)` if the key was consumed by an overlay.
-    /// Returns the active overlay, if any, in priority order.
+    /// Returns the currently-active overlay, if any.
     ///
-    /// If multiple overlay flags are set simultaneously (which should not
-    /// happen under normal usage), the variant earliest in `OverlayKind`'s
-    /// declaration wins. Both `has_overlay` and `handle_overlay_key` defer to
-    /// this method so dispatch, visibility checks, and any future per-overlay
-    /// logic stay in sync automatically.
+    /// All 23 overlays are now backed by `current_overlay`, so this is just
+    /// a thin accessor. Both `has_overlay` and `handle_overlay_key` defer
+    /// to it so dispatch and visibility stay in sync automatically.
     pub fn active_overlay(&self) -> Option<OverlayKind> {
-        if self.current_overlay == Some(OverlayKind::SidebarFilter) {
-            return Some(OverlayKind::SidebarFilter);
-        }
-        if self.current_overlay == Some(OverlayKind::PollVote) {
-            return Some(OverlayKind::PollVote);
-        }
-        if self.current_overlay == Some(OverlayKind::PinDuration) {
-            return Some(OverlayKind::PinDuration);
-        }
-        if self.current_overlay == Some(OverlayKind::ActionMenu) {
-            return Some(OverlayKind::ActionMenu);
-        }
-        if self.current_overlay == Some(OverlayKind::DeleteConfirm) {
-            return Some(OverlayKind::DeleteConfirm);
-        }
-        if self.file_picker.visible {
-            return Some(OverlayKind::FilePicker);
-        }
-        if self.emoji_picker.visible {
-            return Some(OverlayKind::EmojiPicker);
-        }
-        if self.reactions.show_picker {
-            return Some(OverlayKind::ReactionPicker);
-        }
-        if self.current_overlay == Some(OverlayKind::MessageRequest) {
-            return Some(OverlayKind::MessageRequest);
-        }
-        if self.group_menu.state.is_some() {
-            return Some(OverlayKind::GroupMenu);
-        }
-        if self.current_overlay == Some(OverlayKind::About) {
-            return Some(OverlayKind::About);
-        }
-        if self.profile.show {
-            return Some(OverlayKind::Profile);
-        }
-        if self.current_overlay == Some(OverlayKind::Help) {
-            return Some(OverlayKind::Help);
-        }
-        if self.verify.show {
-            return Some(OverlayKind::Verify);
-        }
-        if self.forward.show {
-            return Some(OverlayKind::Forward);
-        }
-        if self.contacts_overlay.show {
-            return Some(OverlayKind::Contacts);
-        }
-        if self.search.visible {
-            return Some(OverlayKind::Search);
-        }
-        if self.settings_profiles.show {
-            return Some(OverlayKind::SettingsProfiles);
-        }
-        if self.theme_picker.show {
-            return Some(OverlayKind::ThemePicker);
-        }
-        if self.keybindings_overlay.show {
-            return Some(OverlayKind::Keybindings);
-        }
-        if self.current_overlay == Some(OverlayKind::Customize) {
-            return Some(OverlayKind::Customize);
-        }
-        if self.current_overlay == Some(OverlayKind::Settings) {
-            return Some(OverlayKind::Settings);
-        }
-        if self.autocomplete.visible {
-            return Some(OverlayKind::Autocomplete);
-        }
-        None
+        self.current_overlay
     }
 
-    /// Open an App-owned overlay.
+    /// Open an overlay.
     ///
-    /// Clobbers whichever App-owned overlay was previously active (at most
-    /// one at a time; the old bool-per-overlay model tolerated concurrent
-    /// visibility, the new single-field model does not).
+    /// Clobbers whichever overlay was previously active. Use `try_open_overlay`
+    /// if you need to defer to an existing higher-priority overlay (e.g.
+    /// auto-open paths called from `update_status` or `update_autocomplete`).
     pub fn open_overlay(&mut self, kind: OverlayKind) {
         self.current_overlay = Some(kind);
     }
 
     /// Clear `current_overlay`.
-    ///
-    /// Only closes overlays that have been migrated onto `current_overlay`.
-    /// It does not touch the per-struct `.show`/`.visible` fields that the
-    /// remaining 17 unmigrated overlays still use. After every overlay is
-    /// migrated, this becomes the only way to close any overlay.
     pub fn close_overlay(&mut self) {
         self.current_overlay = None;
+    }
+
+    /// Open `kind` only if no other App-owned overlay is currently active
+    /// (or if `kind` is already the active overlay). Use this for auto-open
+    /// paths that must not clobber a higher-priority overlay - e.g.
+    /// `update_autocomplete` firing on every keystroke, or `update_status`
+    /// auto-opening MessageRequest on conversation switches.
+    pub fn try_open_overlay(&mut self, kind: OverlayKind) {
+        if self.current_overlay.is_none() || self.current_overlay == Some(kind) {
+            self.open_overlay(kind);
+        }
     }
 
     /// Returns true if the given overlay kind is currently open via the
@@ -3618,7 +3585,7 @@ impl App {
                     let was_reaction = self.emoji_picker.source == EmojiPickerSource::Reaction;
                     self.emoji_picker.close();
                     if was_reaction {
-                        self.reactions.show_picker = true;
+                        self.open_overlay(OverlayKind::ReactionPicker);
                     }
                     (true, None)
                 }
@@ -3907,7 +3874,7 @@ impl App {
             }
             Some(KeyAction::React) => {
                 if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.reactions.show_picker = true;
+                    self.open_overlay(OverlayKind::ReactionPicker);
                     self.reactions.picker_index = 0;
                 }
                 None
@@ -4016,7 +3983,7 @@ impl App {
             Some(KeyAction::ExitInsert) => {
                 self.mode = InputMode::Normal;
                 self.pending_normal_key = None; // defensive reset
-                self.autocomplete.visible = false;
+                self.close_overlay();
                 self.reply_target = None;
                 self.editing_message = None;
                 if self.typing.reset() {
@@ -4027,7 +3994,7 @@ impl App {
             Some(KeyAction::InsertNewline) => {
                 self.input_buffer.insert(self.input_cursor, '\n');
                 self.input_cursor += 1;
-                self.autocomplete.visible = false;
+                self.close_overlay();
                 self.typing.last_keypress = Some(Instant::now());
                 if !self.typing.sent
                     && !self.input_buffer.starts_with('/')
@@ -4106,7 +4073,7 @@ impl App {
             }
             Some(KeyAction::React) => {
                 if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.reactions.show_picker = true;
+                    self.open_overlay(OverlayKind::ReactionPicker);
                     self.reactions.picker_index = 0;
                 }
                 None
@@ -4452,7 +4419,9 @@ impl App {
             msg.source.clone()
         };
 
-        if self.store.move_conversation_to_top(&conv_id) && self.is_overlay(OverlayKind::SidebarFilter) {
+        if self.store.move_conversation_to_top(&conv_id)
+            && self.is_overlay(OverlayKind::SidebarFilter)
+        {
             self.refresh_sidebar_filter();
         }
 
@@ -5385,7 +5354,7 @@ impl App {
                         self.status_message = "Given name is required".to_string();
                         return None;
                     }
-                    self.profile.show = false;
+                    self.close_overlay();
                     return Some(SendRequest::UpdateProfile {
                         given_name,
                         family_name,
@@ -5395,7 +5364,7 @@ impl App {
                 }
             }
             KeyCode::Esc => {
-                self.profile.show = false;
+                self.close_overlay();
             }
             _ => {}
         }
@@ -5672,7 +5641,7 @@ impl App {
             }
         }
         // If verify overlay is open, refresh the displayed identities
-        if self.verify.show
+        if self.is_overlay(OverlayKind::Verify)
             && let Some(ref conv_id) = self.active_conversation
         {
             let conv_id = conv_id.clone();
@@ -6312,9 +6281,10 @@ impl App {
             InputAction::Search(query) => {
                 self.search
                     .open(query, self.active_conversation.as_deref(), &self.db);
+                self.open_overlay(OverlayKind::Search);
             }
             InputAction::Contacts => {
-                self.contacts_overlay.show = true;
+                self.open_overlay(OverlayKind::Contacts);
                 self.contacts_overlay.index = 0;
                 self.contacts_overlay.filter.clear();
                 self.refresh_contacts_filter();
@@ -6322,9 +6292,10 @@ impl App {
             InputAction::Emoji(query) => {
                 let filter = if query.is_empty() { None } else { Some(query) };
                 self.emoji_picker.open(EmojiPickerSource::Input, filter);
+                self.open_overlay(OverlayKind::EmojiPicker);
             }
             InputAction::Theme => {
-                self.theme_picker.show = true;
+                self.open_overlay(OverlayKind::ThemePicker);
                 self.theme_picker.index = self
                     .theme_picker
                     .available_themes
@@ -6333,6 +6304,7 @@ impl App {
                     .unwrap_or(0);
             }
             InputAction::Group => {
+                self.open_overlay(OverlayKind::GroupMenu);
                 self.group_menu.state = Some(GroupMenuState::Menu);
                 self.group_menu.index = 0;
                 self.group_menu.filter.clear();
@@ -6385,7 +6357,7 @@ impl App {
                             })
                             .unwrap_or_default();
                     }
-                    self.verify.show = true;
+                    self.open_overlay(OverlayKind::Verify);
                     self.verify.index = 0;
                     // Request fresh identity data
                     return Some(SendRequest::ListIdentities);
@@ -6394,7 +6366,7 @@ impl App {
                 }
             }
             InputAction::Profile => {
-                self.profile.show = true;
+                self.open_overlay(OverlayKind::Profile);
                 self.profile.index = 0;
                 self.profile.editing = false;
             }
@@ -6402,7 +6374,7 @@ impl App {
                 self.open_overlay(OverlayKind::About);
             }
             InputAction::Keybindings => {
-                self.keybindings_overlay.show = true;
+                self.open_overlay(OverlayKind::Keybindings);
                 self.keybindings_overlay.index = 0;
             }
             InputAction::Help => {
@@ -6554,7 +6526,7 @@ impl App {
             }
 
             if !candidates.is_empty() {
-                self.autocomplete.visible = true;
+                self.try_open_overlay(OverlayKind::Autocomplete);
                 self.autocomplete.mode = AutocompleteMode::Command;
                 self.autocomplete.command_candidates = candidates;
                 if self.autocomplete.index >= self.autocomplete.command_candidates.len() {
@@ -6622,7 +6594,7 @@ impl App {
             candidates.sort_by_key(|a| a.0.to_lowercase());
 
             if !candidates.is_empty() {
-                self.autocomplete.visible = true;
+                self.try_open_overlay(OverlayKind::Autocomplete);
                 self.autocomplete.mode = AutocompleteMode::Join;
                 self.autocomplete.join_candidates = candidates;
                 if self.autocomplete.index >= self.autocomplete.join_candidates.len() {
@@ -6679,7 +6651,7 @@ impl App {
             candidates.sort_by_key(|a| a.1.to_lowercase());
 
             if !candidates.is_empty() {
-                self.autocomplete.visible = true;
+                self.try_open_overlay(OverlayKind::Autocomplete);
                 self.autocomplete.mode = AutocompleteMode::Mention;
                 self.autocomplete.mention_candidates = candidates;
                 self.autocomplete.mention_trigger_pos = trigger_pos;
@@ -7016,7 +6988,7 @@ impl App {
                         self.input_buffer = format!("{} ", cmd.name);
                     }
                     self.input_cursor = self.input_buffer.len();
-                    self.autocomplete.visible = false;
+                    self.close_overlay();
                     self.autocomplete.command_candidates.clear();
                     self.autocomplete.index = 0;
                 }
@@ -7036,7 +7008,7 @@ impl App {
                     self.input_cursor = self.autocomplete.mention_trigger_pos + replacement.len();
                     // Record for outgoing mention
                     self.autocomplete.pending_mentions.push((name, uuid));
-                    self.autocomplete.visible = false;
+                    self.close_overlay();
                     self.autocomplete.mention_candidates.clear();
                     self.autocomplete.index = 0;
                 }
@@ -7050,7 +7022,7 @@ impl App {
                 {
                     self.input_buffer = format!("/join {value}");
                     self.input_cursor = self.input_buffer.len();
-                    self.autocomplete.visible = false;
+                    self.close_overlay();
                     self.autocomplete.join_candidates.clear();
                     self.autocomplete.index = 0;
                 }
@@ -7219,9 +7191,7 @@ impl App {
                 .and_then(|id| self.store.conversations.get(id))
                 .is_some_and(|c| !c.accepted);
             if should_show {
-                if self.current_overlay.is_none() || self.is_overlay(OverlayKind::MessageRequest) {
-                    self.open_overlay(OverlayKind::MessageRequest);
-                }
+                self.try_open_overlay(OverlayKind::MessageRequest);
             } else if self.is_overlay(OverlayKind::MessageRequest) {
                 self.close_overlay();
             }
@@ -7426,7 +7396,9 @@ impl App {
             && is_in_rect(col, row, inner)
         {
             let index = (row - inner.y) as usize;
-            let sidebar_list = if self.is_overlay(OverlayKind::SidebarFilter) && !self.sidebar_filtered.is_empty() {
+            let sidebar_list = if self.is_overlay(OverlayKind::SidebarFilter)
+                && !self.sidebar_filtered.is_empty()
+            {
                 &self.sidebar_filtered
             } else {
                 &self.store.conversation_order
@@ -8470,7 +8442,8 @@ mod tests {
         app.input_buffer = input.to_string();
         app.update_autocomplete();
         assert_eq!(
-            app.autocomplete.visible, expected_visible,
+            app.is_overlay(OverlayKind::Autocomplete),
+            expected_visible,
             "visibility for {input:?}"
         );
         if let Some(count) = expected_count {
@@ -8524,7 +8497,7 @@ mod tests {
             .insert("+2".to_string(), "Bob".to_string());
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.mode, AutocompleteMode::Join);
         assert_eq!(app.autocomplete.join_candidates.len(), 2);
     }
@@ -8542,7 +8515,7 @@ mod tests {
         );
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.mode, AutocompleteMode::Join);
         assert_eq!(app.autocomplete.join_candidates.len(), 1);
         assert!(app.autocomplete.join_candidates[0].0.starts_with('#'));
@@ -8558,7 +8531,7 @@ mod tests {
             .insert("+2".to_string(), "Bob".to_string());
         app.input_buffer = "/join al".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.join_candidates.len(), 1);
         assert!(app.autocomplete.join_candidates[0].0.contains("Alice"));
     }
@@ -8573,7 +8546,7 @@ mod tests {
             .insert("+5678".to_string(), "Bob".to_string());
         app.input_buffer = "/join +123".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.join_candidates.len(), 1);
         assert!(app.autocomplete.join_candidates[0].1 == "+1234");
     }
@@ -8585,7 +8558,7 @@ mod tests {
             .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/j ".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.mode, AutocompleteMode::Join);
         assert_eq!(app.autocomplete.join_candidates.len(), 1);
     }
@@ -8597,7 +8570,7 @@ mod tests {
             .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join zzz".to_string();
         app.update_autocomplete();
-        assert!(!app.autocomplete.visible);
+        assert!(!app.is_overlay(OverlayKind::Autocomplete));
     }
 
     #[rstest]
@@ -8607,11 +8580,11 @@ mod tests {
             .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join al".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         app.apply_autocomplete();
         assert_eq!(app.input_buffer, "/join +1");
         assert_eq!(app.input_cursor, 8);
-        assert!(!app.autocomplete.visible);
+        assert!(!app.is_overlay(OverlayKind::Autocomplete));
     }
 
     #[rstest]
@@ -8627,7 +8600,7 @@ mod tests {
         );
         app.input_buffer = "/join fam".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         app.apply_autocomplete();
         assert_eq!(app.input_buffer, "/join g1");
         assert_eq!(app.input_cursor, 8);
@@ -8640,7 +8613,7 @@ mod tests {
             .get_or_create_conversation("+9999", "+9999", false, &app.db);
         app.input_buffer = "/join +999".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.join_candidates.len(), 1);
     }
 
@@ -8655,7 +8628,7 @@ mod tests {
             .insert("+1".to_string(), "Alice".to_string());
         app.input_buffer = "/join ".to_string();
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         // Only Alice should appear from contact_names (g1 is skipped as non-phone)
         let contact_entries: Vec<_> = app
             .autocomplete
@@ -9979,7 +9952,7 @@ mod tests {
         app.update_autocomplete();
 
         // Should trigger mention autocomplete in 1:1 with the contact
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.mode, AutocompleteMode::Mention);
         assert_eq!(app.autocomplete.mention_candidates.len(), 1);
         assert_eq!(app.autocomplete.mention_candidates[0].1, "Alice");
@@ -10011,7 +9984,7 @@ mod tests {
         app.input_cursor = 3;
         app.update_autocomplete();
 
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
         assert_eq!(app.autocomplete.mode, AutocompleteMode::Mention);
         assert_eq!(app.autocomplete.mention_candidates.len(), 1);
         assert_eq!(app.autocomplete.mention_candidates[0].1, "Alice");
@@ -10042,7 +10015,7 @@ mod tests {
         app.input_buffer = "Hey @Al".to_string();
         app.input_cursor = 7;
         app.update_autocomplete();
-        assert!(app.autocomplete.visible);
+        assert!(app.is_overlay(OverlayKind::Autocomplete));
 
         app.apply_autocomplete();
         assert_eq!(app.input_buffer, "Hey @Alice ");
@@ -10161,7 +10134,7 @@ mod tests {
     fn attach_no_conversation_shows_error(mut app: App) {
         app.active_conversation = None;
         app.open_file_browser();
-        assert!(!app.file_picker.visible);
+        assert!(!app.is_overlay(OverlayKind::FilePicker));
         assert!(app.status_message.contains("No active conversation"));
     }
 
@@ -10212,7 +10185,7 @@ mod tests {
         app.input_cursor = 13;
         app.handle_input();
 
-        assert!(app.search.visible);
+        assert!(app.is_overlay(OverlayKind::Search));
         assert_eq!(app.search.query, "hello");
         assert!(!app.search.results.is_empty());
         assert_eq!(app.search.results[0].body, "hello world");
@@ -10224,18 +10197,18 @@ mod tests {
         app.input_cursor = 7;
         app.handle_input();
 
-        assert!(!app.search.visible);
+        assert!(!app.is_overlay(OverlayKind::Search));
         assert!(app.status_message.contains("requires"));
     }
 
     #[rstest]
     fn search_overlay_esc_closes(mut app: App) {
-        app.search.visible = true;
+        app.open_overlay(OverlayKind::Search);
         app.search.query = "test".to_string();
 
         app.handle_search_key(KeyCode::Esc);
 
-        assert!(!app.search.visible);
+        assert!(!app.is_overlay(OverlayKind::Search));
         assert!(app.search.query.is_empty());
     }
 
@@ -10267,7 +10240,7 @@ mod tests {
             )
             .unwrap();
 
-        app.search.visible = true;
+        app.open_overlay(OverlayKind::Search);
         app.search.query = "hello".to_string();
         app.search.run(app.active_conversation.as_deref(), &app.db);
         assert_eq!(app.search.results.len(), 1);
@@ -11096,54 +11069,20 @@ mod tests {
         assert_eq!(app.input_cursor, 5); // byte offset of space after "café"
     }
 
-    /// Toggle an App-owned overlay to the requested state. Used by
-    /// `toggle_overlay` for the variants that have been migrated to
-    /// `current_overlay`.
-    fn toggle_current_overlay(app: &mut App, kind: OverlayKind, on: bool) {
+    /// Toggle an overlay to the requested state. Routes through
+    /// `open_overlay`/`close_overlay` so the test mirrors production
+    /// callers, and special-cases GroupMenu's sub-state field.
+    fn toggle_overlay(app: &mut App, kind: OverlayKind, on: bool) {
         if on {
             app.open_overlay(kind);
         } else if app.is_overlay(kind) {
             app.close_overlay();
         }
-    }
-
-    /// Walk every `OverlayKind` variant by flipping the corresponding visibility
-    /// flag(s), asserting that `active_overlay` returns that variant and
-    /// `has_overlay` returns true, then clearing and asserting no overlay.
-    ///
-    /// The `match` is exhaustive so adding a new `OverlayKind` variant without
-    /// extending this test is a compile error.
-    fn toggle_overlay(app: &mut App, kind: OverlayKind, on: bool) {
-        match kind {
-            OverlayKind::SidebarFilter => toggle_current_overlay(app, OverlayKind::SidebarFilter, on),
-            OverlayKind::PollVote => toggle_current_overlay(app, OverlayKind::PollVote, on),
-            OverlayKind::PinDuration => toggle_current_overlay(app, OverlayKind::PinDuration, on),
-            OverlayKind::ActionMenu => toggle_current_overlay(app, OverlayKind::ActionMenu, on),
-            OverlayKind::DeleteConfirm => {
-                toggle_current_overlay(app, OverlayKind::DeleteConfirm, on)
-            }
-            OverlayKind::FilePicker => app.file_picker.visible = on,
-            OverlayKind::EmojiPicker => app.emoji_picker.visible = on,
-            OverlayKind::ReactionPicker => app.reactions.show_picker = on,
-            OverlayKind::MessageRequest => {
-                toggle_current_overlay(app, OverlayKind::MessageRequest, on)
-            }
-            OverlayKind::GroupMenu => {
-                app.group_menu.state = if on { Some(GroupMenuState::Menu) } else { None }
-            }
-            OverlayKind::About => toggle_current_overlay(app, OverlayKind::About, on),
-            OverlayKind::Profile => app.profile.show = on,
-            OverlayKind::Help => toggle_current_overlay(app, OverlayKind::Help, on),
-            OverlayKind::Verify => app.verify.show = on,
-            OverlayKind::Forward => app.forward.show = on,
-            OverlayKind::Contacts => app.contacts_overlay.show = on,
-            OverlayKind::Search => app.search.visible = on,
-            OverlayKind::SettingsProfiles => app.settings_profiles.show = on,
-            OverlayKind::ThemePicker => app.theme_picker.show = on,
-            OverlayKind::Keybindings => app.keybindings_overlay.show = on,
-            OverlayKind::Customize => toggle_current_overlay(app, OverlayKind::Customize, on),
-            OverlayKind::Settings => toggle_current_overlay(app, OverlayKind::Settings, on),
-            OverlayKind::Autocomplete => app.autocomplete.visible = on,
+        // GroupMenu carries an extra Option<GroupMenuState> sub-state that
+        // historically also encoded visibility. Keep it in sync so tests
+        // exercising group-menu rendering still see Some(Menu) when open.
+        if matches!(kind, OverlayKind::GroupMenu) {
+            app.group_menu.state = if on { Some(GroupMenuState::Menu) } else { None };
         }
     }
 

--- a/src/autocomplete.rs
+++ b/src/autocomplete.rs
@@ -9,8 +9,6 @@ pub enum AutocompleteMode {
 
 /// Autocomplete popup state: candidates, selection index, and pending mentions.
 pub struct AutocompleteState {
-    /// Autocomplete popup visible
-    pub visible: bool,
     /// Indices into COMMANDS for current matches
     pub command_candidates: Vec<usize>,
     /// Selected item in autocomplete popup
@@ -36,7 +34,6 @@ impl Default for AutocompleteState {
 impl AutocompleteState {
     pub fn new() -> Self {
         Self {
-            visible: false,
             command_candidates: Vec::new(),
             index: 0,
             mode: AutocompleteMode::Command,
@@ -61,9 +58,9 @@ impl AutocompleteState {
         }
     }
 
-    /// Clear all candidates and hide the popup.
+    /// Clear all candidates. Caller must also call `App::close_overlay`
+    /// if the autocomplete overlay was open.
     pub fn clear(&mut self) {
-        self.visible = false;
         self.command_candidates.clear();
         self.mention_candidates.clear();
         self.join_candidates.clear();

--- a/src/domain/action_menu.rs
+++ b/src/domain/action_menu.rs
@@ -1,8 +1,6 @@
 /// State for the message action menu overlay.
 #[derive(Default)]
 pub struct ActionMenuState {
-    /// Action menu overlay visible
-    pub show: bool,
     /// Cursor position in action menu
     pub index: usize,
 }

--- a/src/domain/contacts_overlay.rs
+++ b/src/domain/contacts_overlay.rs
@@ -1,8 +1,6 @@
 /// State for the contacts list overlay.
 #[derive(Default)]
 pub struct ContactsOverlayState {
-    /// Contacts overlay visible
-    pub show: bool,
     /// Cursor position in contacts list
     pub index: usize,
     /// Type-to-filter text for contacts overlay

--- a/src/domain/emoji_picker.rs
+++ b/src/domain/emoji_picker.rs
@@ -60,7 +60,6 @@ fn category_to_group(index: usize) -> Option<emojis::Group> {
 
 /// State for the emoji picker overlay.
 pub struct EmojiPickerState {
-    pub visible: bool,
     pub source: EmojiPickerSource,
     pub filter: String,
     pub selected_index: usize,
@@ -73,7 +72,6 @@ pub struct EmojiPickerState {
 impl Default for EmojiPickerState {
     fn default() -> Self {
         Self {
-            visible: false,
             source: EmojiPickerSource::Input,
             filter: String::new(),
             selected_index: 0,
@@ -85,9 +83,10 @@ impl Default for EmojiPickerState {
 }
 
 impl EmojiPickerState {
-    /// Open the picker for a given source context, with an optional initial search filter.
+    /// Configure the picker for a given source context, with an optional
+    /// initial search filter. Caller must also call `App::open_overlay`
+    /// to make the picker visible.
     pub fn open(&mut self, source: EmojiPickerSource, filter: Option<String>) {
-        self.visible = true;
         self.source = source;
         self.filter = filter.unwrap_or_default();
         self.selected_index = 0;
@@ -95,9 +94,9 @@ impl EmojiPickerState {
         self.refresh_filter();
     }
 
-    /// Close the picker and reset state.
+    /// Reset picker state. Caller must also call `App::close_overlay`
+    /// to dismiss the overlay.
     pub fn close(&mut self) {
-        self.visible = false;
         self.filter.clear();
         self.selected_index = 0;
         self.category_index = 0;
@@ -239,7 +238,8 @@ mod tests {
     fn open_populates_filtered_list() {
         let mut state = EmojiPickerState::default();
         state.open(EmojiPickerSource::Input, None);
-        assert!(state.visible);
+        // Visibility now lives on App.current_overlay; this struct test
+        // only verifies the state-mutation side of `open`.
         assert!(!state.filtered.is_empty());
         assert_eq!(state.selected_index, 0);
         assert_eq!(state.category_index, 0);
@@ -395,7 +395,8 @@ mod tests {
         state.category_index = 3;
 
         state.close();
-        assert!(!state.visible);
+        // Visibility now lives on App.current_overlay; this struct test
+        // only verifies the state-clearing side of `close`.
         assert!(state.filter.is_empty());
         assert_eq!(state.selected_index, 0);
         assert_eq!(state.category_index, 0);

--- a/src/domain/file_picker.rs
+++ b/src/domain/file_picker.rs
@@ -2,10 +2,18 @@ use std::path::PathBuf;
 
 use crossterm::event::KeyCode;
 
+/// Outcome of a key press inside the file browser overlay.
+pub enum FilePickerOutcome {
+    /// Picker should stay open for further navigation.
+    Continue,
+    /// User selected a file; caller should consume the path and close the overlay.
+    Selected(PathBuf),
+    /// User cancelled (Esc); caller should close the overlay.
+    Cancelled,
+}
+
 /// State for the file browser overlay used to select attachments.
 pub struct FilePickerState {
-    /// File browser overlay visible
-    pub visible: bool,
     /// Current directory in file browser
     pub dir: PathBuf,
     /// Directory entries: (name, is_dir, size_bytes)
@@ -23,7 +31,6 @@ pub struct FilePickerState {
 impl Default for FilePickerState {
     fn default() -> Self {
         Self {
-            visible: false,
             dir: dirs::home_dir().unwrap_or_else(|| PathBuf::from(".")),
             entries: Vec::new(),
             index: 0,
@@ -35,9 +42,9 @@ impl Default for FilePickerState {
 }
 
 impl FilePickerState {
-    /// Reset state and open the file browser.
+    /// Reset state for a fresh browse. Caller must also call
+    /// `App::open_overlay` to make the picker visible.
     pub fn open(&mut self) {
-        self.visible = true;
         self.dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
         self.index = 0;
         self.filter.clear();
@@ -96,8 +103,7 @@ impl FilePickerState {
     }
 
     /// Handle a key press while the file browser overlay is open.
-    /// Returns `Some(path)` when the user selects a file.
-    pub fn handle_key(&mut self, code: KeyCode) -> Option<PathBuf> {
+    pub fn handle_key(&mut self, code: KeyCode) -> FilePickerOutcome {
         match code {
             KeyCode::Char('j') | KeyCode::Down
                 if !self.filtered.is_empty() && self.index < self.filtered.len() - 1 =>
@@ -116,9 +122,7 @@ impl FilePickerState {
                         self.filter.clear();
                         self.refresh_entries();
                     } else {
-                        let path = self.dir.join(&name);
-                        self.visible = false;
-                        return Some(path);
+                        return FilePickerOutcome::Selected(self.dir.join(&name));
                     }
                 }
             }
@@ -133,16 +137,14 @@ impl FilePickerState {
             KeyCode::Char('-') => {
                 self.navigate_up();
             }
-            KeyCode::Esc => {
-                self.visible = false;
-            }
+            KeyCode::Esc => return FilePickerOutcome::Cancelled,
             KeyCode::Char(c) => {
                 self.filter.push(c);
                 self.refresh_filter();
             }
             _ => {}
         }
-        None
+        FilePickerOutcome::Continue
     }
 
     /// Navigate to the parent directory in the file browser.

--- a/src/domain/forward_overlay.rs
+++ b/src/domain/forward_overlay.rs
@@ -1,8 +1,6 @@
 /// State for the forward message picker overlay.
 #[derive(Default)]
 pub struct ForwardOverlayState {
-    /// Forward message picker overlay visible
-    pub show: bool,
     /// Cursor position in forward picker
     pub index: usize,
     /// Type-to-filter text for forward picker

--- a/src/domain/keybindings_overlay.rs
+++ b/src/domain/keybindings_overlay.rs
@@ -3,8 +3,6 @@ use crate::keybindings::{KeyAction, KeyCombo};
 /// State for the keybindings configuration overlay.
 #[derive(Default)]
 pub struct KeybindingsOverlayState {
-    /// Keybindings overlay visible
-    pub show: bool,
     /// Cursor position in keybindings overlay
     pub index: usize,
     /// Whether capturing a new key binding

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -20,7 +20,7 @@ mod verify_overlay;
 pub use action_menu::ActionMenuState;
 pub use contacts_overlay::ContactsOverlayState;
 pub use emoji_picker::{CATEGORIES, EmojiPickerAction, EmojiPickerSource, EmojiPickerState};
-pub use file_picker::FilePickerState;
+pub use file_picker::{FilePickerOutcome, FilePickerState};
 pub use forward_overlay::ForwardOverlayState;
 pub use group_menu_overlay::GroupMenuOverlayState;
 pub use image::ImageState;

--- a/src/domain/pin_duration_overlay.rs
+++ b/src/domain/pin_duration_overlay.rs
@@ -3,8 +3,6 @@ use crate::app::PinPending;
 /// State for the pin duration picker overlay.
 #[derive(Default)]
 pub struct PinDurationOverlayState {
-    /// Pin duration picker overlay visible
-    pub show: bool,
     /// Cursor position in pin duration picker
     pub index: usize,
     /// Pending pin context (conversation, target message)

--- a/src/domain/poll_vote_overlay.rs
+++ b/src/domain/poll_vote_overlay.rs
@@ -6,8 +6,6 @@ use crate::signal::types::PollData;
 /// State for the poll vote overlay and pending poll data.
 #[derive(Default)]
 pub struct PollVoteOverlayState {
-    /// Poll vote overlay visible
-    pub show: bool,
     /// Cursor position in poll vote overlay
     pub index: usize,
     /// Multi-select tracking for poll vote options

--- a/src/domain/profile_overlay.rs
+++ b/src/domain/profile_overlay.rs
@@ -1,8 +1,6 @@
 /// State for the profile editor overlay.
 #[derive(Default)]
 pub struct ProfileOverlayState {
-    /// Profile editor overlay visible
-    pub show: bool,
     /// Cursor position in profile editor
     pub index: usize,
     /// Whether currently editing a profile field

--- a/src/domain/reaction.rs
+++ b/src/domain/reaction.rs
@@ -1,8 +1,6 @@
 /// State for reaction display preferences and the reaction picker overlay.
 #[derive(Default)]
 pub struct ReactionState {
-    /// Reaction picker overlay visible
-    pub show_picker: bool,
     /// Selected index in the reaction picker
     pub picker_index: usize,
     /// Convert emoji to text emoticons/shortcodes in display

--- a/src/domain/search.rs
+++ b/src/domain/search.rs
@@ -22,6 +22,8 @@ pub enum SearchAction {
     },
     /// Status message to display.
     Status(String),
+    /// User cancelled the overlay (Esc) - caller should close it.
+    Cancel,
     /// No action needed.
     None,
 }
@@ -29,19 +31,18 @@ pub enum SearchAction {
 /// State for the search overlay.
 #[derive(Default)]
 pub struct SearchState {
-    pub visible: bool,
     pub query: String,
     pub results: Vec<SearchResult>,
     pub index: usize,
 }
 
 impl SearchState {
-    /// Open the search overlay with an initial query.
+    /// Configure the search overlay with an initial query and run the query.
+    /// Caller must also call `App::open_overlay` to make the overlay visible.
     pub fn open(&mut self, query: String, active_conversation: Option<&str>, db: &Database) {
         self.query = query;
         self.index = 0;
         self.run(active_conversation, db);
-        self.visible = true;
     }
 
     /// Handle a key press while the search overlay is open.
@@ -64,8 +65,8 @@ impl SearchState {
                 if let Some(result) = self.results.get(self.index) {
                     let conv_id = result.conv_id.clone();
                     let target_ts = result.timestamp_ms;
-                    self.visible = false;
-                    // Keep query for n/N navigation status display
+                    // Keep query for n/N navigation status display.
+                    // Caller closes the overlay on Select.
                     return SearchAction::Select {
                         conv_id,
                         timestamp_ms: target_ts,
@@ -74,8 +75,8 @@ impl SearchState {
                 }
             }
             KeyCode::Esc => {
-                self.visible = false;
                 self.query.clear();
+                return SearchAction::Cancel;
             }
             KeyCode::Backspace if !self.query.is_empty() => {
                 self.query.pop();

--- a/src/domain/settings_profile_overlay.rs
+++ b/src/domain/settings_profile_overlay.rs
@@ -4,8 +4,6 @@ use crate::settings_profile::SettingsProfile;
 pub struct SettingsProfileOverlayState {
     /// Current settings profile name
     pub name: String,
-    /// Settings profile manager overlay visible
-    pub show: bool,
     /// Cursor position in settings profile manager
     pub index: usize,
     /// All available settings profiles
@@ -20,7 +18,6 @@ impl Default for SettingsProfileOverlayState {
     fn default() -> Self {
         Self {
             name: "Default".to_string(),
-            show: false,
             index: 0,
             available: Vec::new(),
             save_as: false,

--- a/src/domain/theme_picker.rs
+++ b/src/domain/theme_picker.rs
@@ -3,8 +3,6 @@ use crate::theme::Theme;
 /// State for the theme picker overlay.
 #[derive(Default)]
 pub struct ThemePickerState {
-    /// Theme picker overlay visible
-    pub show: bool,
     /// Cursor position in theme picker
     pub index: usize,
     /// All available themes (built-in + custom)

--- a/src/domain/verify_overlay.rs
+++ b/src/domain/verify_overlay.rs
@@ -3,8 +3,6 @@ use crate::signal::types::IdentityInfo;
 /// State for the identity verification overlay.
 #[derive(Default)]
 pub struct VerifyOverlayState {
-    /// Verify identity overlay visible
-    pub show: bool,
     /// Cursor position in verify overlay (for group member list)
     pub index: usize,
     /// Identity info entries filtered for the current overlay

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -683,7 +683,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Poll vote overlay
-    if app.poll_vote.show {
+    if app.is_overlay(OverlayKind::PollVote) {
         draw_poll_vote_overlay(frame, app, size);
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -723,7 +723,7 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
     // Use filtered list when sidebar filter is active.
     // When filtering, show everything (so users can find hidden conversations).
     // In normal view, hide stale conversations (empty groups, unresolvable contacts).
-    let display_order: Vec<String> = if app.sidebar_filter_active {
+    let display_order: Vec<String> = if app.is_overlay(OverlayKind::SidebarFilter) {
         if app.sidebar_filter.is_empty() {
             app.store.conversation_order.clone()
         } else {
@@ -822,7 +822,7 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         Borders::RIGHT
     };
-    let title = if app.sidebar_filter_active {
+    let title = if app.is_overlay(OverlayKind::SidebarFilter) {
         if app.sidebar_filter.is_empty() {
             " /_ ".to_string()
         } else {
@@ -831,7 +831,7 @@ fn draw_sidebar(frame: &mut Frame, app: &mut App, area: Rect) {
     } else {
         " Chats ".to_string()
     };
-    let title_style = if app.sidebar_filter_active {
+    let title_style = if app.is_overlay(OverlayKind::SidebarFilter) {
         Style::default()
             .fg(theme.warning)
             .add_modifier(Modifier::BOLD)
@@ -5171,7 +5171,7 @@ mod snapshot_tests {
     #[test]
     fn test_sidebar_filter() {
         let mut app = demo_app();
-        app.sidebar_filter_active = true;
+        app.open_overlay(OverlayKind::SidebarFilter);
         app.sidebar_filter = "ali".to_string();
         app.refresh_sidebar_filter();
         let output = render_to_string(&mut app, 100, 30);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -590,7 +590,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     draw_status_bar(frame, app, status_area, sidebar_auto_hidden);
 
     // Autocomplete popup (overlays everything)
-    if app.autocomplete.visible {
+    if app.is_overlay(OverlayKind::Autocomplete) {
         let has_items = !app.autocomplete.is_empty();
         if has_items {
             draw_autocomplete(frame, app, input_area);
@@ -613,27 +613,27 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Contacts overlay (overlays everything)
-    if app.contacts_overlay.show {
+    if app.is_overlay(OverlayKind::Contacts) {
         draw_contacts(frame, app, size);
     }
 
     // Verify identity overlay
-    if app.verify.show {
+    if app.is_overlay(OverlayKind::Verify) {
         draw_verify(frame, app, size);
     }
 
     // Search overlay
-    if app.search.visible {
+    if app.is_overlay(OverlayKind::Search) {
         draw_search(frame, app, size);
     }
 
     // File browser overlay
-    if app.file_picker.visible {
+    if app.is_overlay(OverlayKind::FilePicker) {
         draw_file_browser(frame, app, size);
     }
 
     // Group management menu overlay
-    if app.group_menu.state.is_some() {
+    if app.is_overlay(OverlayKind::GroupMenu) {
         draw_group_menu(frame, app, size);
     }
 
@@ -648,12 +648,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Reaction picker overlay
-    if app.reactions.show_picker {
+    if app.is_overlay(OverlayKind::ReactionPicker) {
         draw_reaction_picker(frame, app, size);
     }
 
     // Emoji picker overlay
-    if app.emoji_picker.visible {
+    if app.is_overlay(OverlayKind::EmojiPicker) {
         draw_emoji_picker(frame, app, size);
     }
 
@@ -663,17 +663,17 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Theme picker overlay
-    if app.theme_picker.show {
+    if app.is_overlay(OverlayKind::ThemePicker) {
         draw_theme_picker(frame, app, size);
     }
 
     // Keybindings overlay
-    if app.keybindings_overlay.show {
+    if app.is_overlay(OverlayKind::Keybindings) {
         draw_keybindings(frame, app, size);
     }
 
     // Settings profile manager overlay
-    if app.settings_profiles.show {
+    if app.is_overlay(OverlayKind::SettingsProfiles) {
         draw_settings_profile_manager(frame, app, size);
     }
 
@@ -693,12 +693,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Profile editor overlay
-    if app.profile.show {
+    if app.is_overlay(OverlayKind::Profile) {
         draw_profile(frame, app, size);
     }
 
     // Forward message picker overlay
-    if app.forward.show {
+    if app.is_overlay(OverlayKind::Forward) {
         draw_forward(frame, app, size);
     }
 
@@ -5181,7 +5181,7 @@ mod snapshot_tests {
     #[test]
     fn test_theme_picker_overlay() {
         let mut app = demo_app();
-        app.theme_picker.show = true;
+        app.open_overlay(OverlayKind::ThemePicker);
         app.theme_picker.index = 1;
         let output = render_to_string(&mut app, 100, 30);
         insta::assert_snapshot!(output);
@@ -5190,7 +5190,7 @@ mod snapshot_tests {
     #[test]
     fn test_pin_duration_overlay() {
         let mut app = demo_app();
-        app.pin_duration.show = true;
+        app.open_overlay(OverlayKind::PinDuration);
         app.pin_duration.index = 1;
         app.pin_duration.pending = Some(PinPending {
             conv_id: "+15551234567".to_string(),
@@ -5205,7 +5205,7 @@ mod snapshot_tests {
     #[test]
     fn test_action_menu_overlay() {
         let mut app = demo_app();
-        app.action_menu.show = true;
+        app.open_overlay(OverlayKind::ActionMenu);
         app.action_menu.index = 0;
         app.focused_msg_index = Some(0);
         let output = render_to_string(&mut app, 100, 30);
@@ -5215,7 +5215,7 @@ mod snapshot_tests {
     #[test]
     fn test_contacts_overlay() {
         let mut app = demo_app();
-        app.contacts_overlay.show = true;
+        app.open_overlay(OverlayKind::Contacts);
         app.contacts_overlay.index = 0;
         app.contacts_overlay.filtered = vec![
             ("+15551234567".to_string(), "Alice".to_string()),
@@ -5228,7 +5228,7 @@ mod snapshot_tests {
     #[test]
     fn test_forward_overlay() {
         let mut app = demo_app();
-        app.forward.show = true;
+        app.open_overlay(OverlayKind::Forward);
         app.forward.index = 0;
         app.forward.filtered = vec![
             ("+15551234567".to_string(), "Alice".to_string()),
@@ -5243,6 +5243,7 @@ mod snapshot_tests {
     fn test_emoji_picker_overlay() {
         let mut app = demo_app();
         app.emoji_picker.open(EmojiPickerSource::Input, None);
+        app.open_overlay(OverlayKind::EmojiPicker);
         let output = render_to_string(&mut app, 100, 30);
         insta::assert_snapshot!(output);
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -643,7 +643,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Action menu overlay
-    if app.action_menu.show {
+    if app.is_overlay(OverlayKind::ActionMenu) {
         draw_action_menu(frame, app, size);
     }
 
@@ -678,7 +678,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     }
 
     // Pin duration picker overlay
-    if app.pin_duration.show {
+    if app.is_overlay(OverlayKind::PinDuration) {
         draw_pin_duration_picker(frame, app, size);
     }
 


### PR DESCRIPTION
## Summary

Completes #209's overlay refactor. Migrates all 17 remaining overlays from per-struct `.show` / `.visible` / `show_picker` booleans onto the single `App.current_overlay` field. Together with #344 (foundation) and #345 (first batch of 6), this lands the full design discussed in the planning thread.

End state:
- 23/23 overlays now backed by `current_overlay`.
- `active_overlay()` collapses to a one-line accessor: `self.current_overlay`.
- Two overlays being visible at once is no longer representable.
- All visibility writes flow through `open_overlay` / `close_overlay` / `try_open_overlay`.

## Migrated overlays

Sidebar Filter, PollVote, PinDuration, ActionMenu, FilePicker, EmojiPicker, ReactionPicker, GroupMenu, Profile, Verify, Forward, Contacts, Search, SettingsProfiles, ThemePicker, Keybindings, Autocomplete.

GroupMenu retains its `state: Option<GroupMenuState>` sub-state (encoding which sub-menu - Menu / Members / Rename / etc.) but the Option is no longer treated as visibility.

## Auto-open guard

A new `try_open_overlay(kind)` helper opens only when no other overlay is already active (or when the same kind is already open). Used in `update_status` (MessageRequest auto-open on conversation switch) and `update_autocomplete` (Command / Mention / Join candidates firing on every keystroke). Mirrors the regression fix from #345 review.

## State-struct method changes

State-struct methods that previously toggled their own visibility now only mutate per-struct state (filter text, candidates, cursor index); the caller wraps them with `open_overlay`/`close_overlay`:

- `EmojiPickerState::open` / `close` - state mutation only
- `FilePickerState::open` - state mutation only
- `FilePickerState::handle_key` - returns new `FilePickerOutcome` enum (`Continue` / `Selected(PathBuf)` / `Cancelled`) instead of `Option<PathBuf>`; caller closes the overlay on either non-Continue outcome
- `SearchState::open` - state mutation only
- `SearchState::handle_key` - now returns `SearchAction::Cancel` on Esc; dispatcher closes on Select or Cancel
- `AutocompleteState::clear` - candidate clear only

## Test plan

- [x] `cargo clippy --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo test` - 480 + 148 + 0 = all 628 pass
- [x] `active_overlay_covers_every_variant` still exhaustively walks all 23 with the simplified `toggle_overlay` helper
- [x] `update_status_does_not_clobber_active_app_overlay` regression test still guards the MessageRequest case
- [ ] Manual sanity: open and close several overlays (Settings -> Customize -> ThemePicker chain, /search, /contacts, action menu via space, file browser)

Generated with Claude Code.