### PR TITLE
refactor: remove dead keybinding helpers (#209)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -406,7 +406,6 @@ pub struct App {
     /// Pending quit confirmation (unsent text in input buffer)
     pub quit_confirm: bool,
     /// Our own account number for identifying outgoing messages
-    #[allow(dead_code)]
     pub account: String,
     /// Resizable sidebar width (min 14, max 40)
     pub sidebar_width: u16,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -276,7 +276,6 @@ impl KeyBindings {
             insert: diff_mode(&self.insert, &defaults.insert),
         }
     }
-
 }
 
 /// User overrides loaded from / saved to `keybindings.toml`.

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -166,53 +166,6 @@ impl KeyBindings {
         }
     }
 
-    /// All bindings as a flat list for UI display.
-    #[allow(dead_code)]
-    pub fn all_bindings(&self) -> Vec<(BindingMode, KeyCombo, KeyAction)> {
-        let mut result = Vec::new();
-        for (combo, &action) in &self.global {
-            result.push((BindingMode::Global, combo.clone(), action));
-        }
-        for (combo, &action) in &self.normal {
-            result.push((BindingMode::Normal, combo.clone(), action));
-        }
-        for (combo, &action) in &self.insert {
-            result.push((BindingMode::Insert, combo.clone(), action));
-        }
-        result
-    }
-
-    /// Return pairs of conflicting bindings (same key bound to two actions in same mode).
-    #[allow(dead_code)]
-    pub fn conflicts(&self) -> Vec<(BindingMode, KeyCombo, KeyAction, KeyAction)> {
-        // Each mode map is a HashMap so there can't be duplicates.
-        // Conflicts only exist when global + mode overlap.
-        let mut result = Vec::new();
-        for (combo, &global_action) in &self.global {
-            if let Some(&normal_action) = self.normal.get(combo)
-                && global_action != normal_action
-            {
-                result.push((
-                    BindingMode::Normal,
-                    combo.clone(),
-                    global_action,
-                    normal_action,
-                ));
-            }
-            if let Some(&insert_action) = self.insert.get(combo)
-                && global_action != insert_action
-            {
-                result.push((
-                    BindingMode::Insert,
-                    combo.clone(),
-                    global_action,
-                    insert_action,
-                ));
-            }
-        }
-        result
-    }
-
     /// Apply user overrides on top of the current bindings.
     pub fn apply_overrides(&mut self, overrides: &KeyBindingOverrides) {
         for (action, combos) in &overrides.global {
@@ -324,21 +277,6 @@ impl KeyBindings {
         }
     }
 
-    /// Get the binding map for a specific mode.
-    #[allow(dead_code)]
-    fn map_for_mode(&self, mode: BindingMode) -> &HashMap<KeyCombo, KeyAction> {
-        match mode {
-            BindingMode::Global => &self.global,
-            BindingMode::Normal => &self.normal,
-            BindingMode::Insert => &self.insert,
-        }
-    }
-
-    /// Check what action a specific combo is bound to in a specific mode.
-    #[allow(dead_code)]
-    pub fn action_for_combo(&self, mode: BindingMode, combo: &KeyCombo) -> Option<KeyAction> {
-        self.map_for_mode(mode).get(combo).copied()
-    }
 }
 
 /// User overrides loaded from / saved to `keybindings.toml`.

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -63,7 +63,6 @@ impl TrustLevel {
 #[derive(Debug, Clone)]
 pub struct IdentityInfo {
     pub number: Option<String>,
-    #[allow(dead_code)]
     pub uuid: Option<String>,
     pub fingerprint: String,
     pub safety_number: String,


### PR DESCRIPTION
## Summary

Sweep of unreferenced helpers found while working through the #209 dead-code checklist.

- `KeyBindings::all_bindings`, `conflicts`, `action_for_combo`, `map_for_mode` were defined for a planned debug/diagnostics UI that never shipped. None are called anywhere (verified by grep across src/ and tests/). 62 lines gone.
- `App::account` had a stale `#[allow(dead_code)]` annotation; the field is read in 20+ places.

The image-rendering refactor item from #209 was reviewed at the same time and is clean: every public function in `image_render.rs` is called, every `ImageState` field is read, and the legacy `inline_images` / `native_images` config fields are still load-bearing migration code (introduced in v1.6.0, only two minors back).

## Test plan

- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (630 tests, same count as master)