### PR TITLE
test: cover legacy image_mode migration in config (#209)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -225,20 +225,27 @@ impl Config {
             let mut config: Config = toml::from_str(&contents).with_context(|| {
                 format!("Failed to parse config from {}", config_path.display())
             })?;
-            // Migrate legacy inline_images/native_images to image_mode
-            if config.image_mode.is_empty() {
-                config.image_mode = if config.native_images {
-                    "native".to_string()
-                } else if config.inline_images {
-                    "halfblock".to_string()
-                } else {
-                    "none".to_string()
-                };
-            }
+            config.migrate_legacy_image_mode();
             Ok(config)
         } else {
             Ok(Config::default())
         }
+    }
+
+    /// Backfill `image_mode` from the legacy `inline_images` / `native_images`
+    /// flags when upgrading from a config written by siggy < v1.6.0. No-op
+    /// once `image_mode` is set.
+    fn migrate_legacy_image_mode(&mut self) {
+        if !self.image_mode.is_empty() {
+            return;
+        }
+        self.image_mode = if self.native_images {
+            "native".to_string()
+        } else if self.inline_images {
+            "halfblock".to_string()
+        } else {
+            "none".to_string()
+        };
     }
 
     /// Serialize this config to TOML and write it to the default config path.
@@ -287,5 +294,52 @@ impl Config {
             .unwrap_or_else(|| PathBuf::from(".config"))
             .join("siggy")
             .join("config.toml")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn legacy_config(inline: bool, native: bool) -> Config {
+        Config {
+            image_mode: String::new(),
+            inline_images: inline,
+            native_images: native,
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn migrate_legacy_image_mode_native_wins() {
+        let mut c = legacy_config(true, true);
+        c.migrate_legacy_image_mode();
+        assert_eq!(c.image_mode, "native");
+    }
+
+    #[test]
+    fn migrate_legacy_image_mode_halfblock_when_only_inline() {
+        let mut c = legacy_config(true, false);
+        c.migrate_legacy_image_mode();
+        assert_eq!(c.image_mode, "halfblock");
+    }
+
+    #[test]
+    fn migrate_legacy_image_mode_none_when_both_disabled() {
+        let mut c = legacy_config(false, false);
+        c.migrate_legacy_image_mode();
+        assert_eq!(c.image_mode, "none");
+    }
+
+    #[test]
+    fn migrate_legacy_image_mode_preserves_existing() {
+        let mut c = Config {
+            image_mode: "native".to_string(),
+            inline_images: false,
+            native_images: false,
+            ..Config::default()
+        };
+        c.migrate_legacy_image_mode();
+        assert_eq!(c.image_mode, "native");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -302,6 +302,8 @@ mod tests {
     use super::*;
 
     fn legacy_config(inline: bool, native: bool) -> Config {
+        // image_mode MUST be explicitly empty here — Config::default()
+        // sets it to "halfblock", which would early-return the migration.
         Config {
             image_mode: String::new(),
             inline_images: inline,


### PR DESCRIPTION
## Summary

The `inline_images` / `native_images` -> `image_mode` migration in `Config::load` (introduced in v1.6.0 to upgrade old configs silently) had zero test coverage. A regression would only surface when an upgrading user noticed their image mode behavior changed, with no error or log line to point at the cause.

This PR:

1. Extracts the migration block from `Config::load` into `Config::migrate_legacy_image_mode(&mut self)` so it can be tested without touching the filesystem.
2. Adds four tests pinning each branch:
   - `native_images=true` wins (even when `inline_images=true`)
   - only `inline_images=true` -> `halfblock`
   - both flags false -> `none`
   - already-set `image_mode` is preserved (no clobber)

Found while working through the test-coverage-gaps checklist item under #209.

## Coverage audit notes

Files with zero tests today:
- `autocomplete.rs` - just a state container, no logic worth testing here (the autocomplete behavior lives in `app.rs`)
- `config.rs` - **fixed by this PR** for the migration path; the rest is mostly thin wrappers over toml/serde
- `link.rs` - async device-linking flow, hard to test without a running signal-cli
- `domain/*.rs` - state structs with default constructors

Files with strong coverage already: `db.rs` (21), `signal/client.rs` (74), `ui.rs` (60), `keybindings.rs` (50), `app.rs` (199).

## Test plan

- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (639 tests, +4 from master)
- [x] `cargo fmt --check` passes