### PR TITLE
docs: add module-level docstrings across the crate (closes #209)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,11 @@
+//! Central application state and event handling.
+//!
+//! [`App`] owns conversations, input buffer, mode (Normal/Insert), and every
+//! overlay state struct. [`App::handle_signal_event`] is the single entry point
+//! for all backend events from `signal::client`. Conversations are keyed by
+//! phone number (1:1) or group ID; the [`ConversationStore`] sub-struct holds
+//! the persistent map and ordered sidebar list.
+
 use chrono::{DateTime, Utc};
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;

--- a/src/autocomplete.rs
+++ b/src/autocomplete.rs
@@ -1,3 +1,9 @@
+//! Popup state for slash-command, @mention, and group-join autocomplete.
+//!
+//! Holds the current candidate list, selected index, and any pending
+//! `@mention` resolutions. The behavior (filter logic, key handling) lives
+//! in [`crate::app`]; this module owns only the data.
+
 /// Which autocomplete mode is active.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AutocompleteMode {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,10 @@
+//! TOML configuration at the platform-specific user config dir.
+//!
+//! Held as [`Config`]; persists account (E.164 phone), `signal_cli_path`,
+//! `download_dir`, and assorted UI preferences. Includes silent migrations:
+//! the legacy `~/.config/signal-tui/` -> `~/.config/siggy/` rename and the
+//! `inline_images` / `native_images` -> `image_mode` field collapse.
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,7 @@ pub struct Config {
     #[serde(default = "default_settings_profile")]
     pub settings_profile: String,
 
-    /// Signal TLS proxy URL passed through to signal-cli (e.g., "https://signal-proxy.example.com")
+    /// Signal TLS proxy URL passed through to signal-cli (e.g., `<https://signal-proxy.example.com>`)
     #[serde(default)]
     pub proxy: String,
 }

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -1,3 +1,9 @@
+//! Conversation, message, and contact storage extracted from [`crate::app::App`].
+//!
+//! [`ConversationStore`] owns the in-memory conversation map, ordered
+//! sidebar list, contact-name and UUID lookups, and per-conversation read
+//! markers. Mutations also persist via [`crate::db::Database`].
+
 use chrono::{DateTime, Local, Utc};
 use ratatui::text::Line;
 use std::collections::{HashMap, HashSet};

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,10 +1,11 @@
 //! SQLite persistence layer (WAL mode).
 //!
 //! Three core tables: `conversations`, `messages`, `read_markers`. Schema
-//! migrations are version-based ([`Database::run_migrations`]). Read paths
+//! migrations are version-based (see private `migrate`). Read paths
 //! propagate errors via `?`; write paths are logged via
-//! `App::db_warn_visible` so transient persistence failures don't break the
-//! UI.
+//! [`crate::conversation_store::db_warn`] (silent) or
+//! `App::db_warn_visible` (surfaces in the status bar) so transient
+//! persistence failures don't break the UI.
 
 use std::collections::HashMap;
 use std::path::Path;

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,3 +1,11 @@
+//! SQLite persistence layer (WAL mode).
+//!
+//! Three core tables: `conversations`, `messages`, `read_markers`. Schema
+//! migrations are version-based ([`Database::run_migrations`]). Read paths
+//! propagate errors via `?`; write paths are logged via
+//! `App::db_warn_visible` so transient persistence failures don't break the
+//! UI.
+
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,3 +1,10 @@
+//! Domain state structs extracted from [`crate::app::App`].
+//!
+//! Each submodule owns the fields and helpers for one logical concern
+//! (file picker, search, typing indicators, individual overlays). Keeping
+//! these grouped reduces merge conflicts and makes the App struct easier
+//! to navigate.
+
 mod action_menu;
 mod contacts_overlay;
 mod emoji_picker;

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -1,3 +1,10 @@
+//! Terminal image rendering across protocols.
+//!
+//! Detects the host terminal's image protocol ([`ImageProtocol`]: Kitty,
+//! iTerm2, Sixel, or Halfblock fallback) and provides encoders for each:
+//! [`encode_native_png`] for Kitty/iTerm2, [`encode_sixel`] for Sixel, and
+//! [`render_image`] for Unicode halfblock approximation.
+
 use std::io::Cursor;
 use std::path::Path;
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,3 +1,10 @@
+//! Slash-command parsing.
+//!
+//! Translates the user's typed input buffer into an [`InputAction`] enum
+//! consumed by the event loop. Slash commands (`/join`, `/part`, `/quit`,
+//! `/sidebar`, `/help`, ...) live in [`COMMANDS`] alongside their
+//! autocomplete metadata.
+
 /// Metadata for a slash command (used for autocomplete + help)
 pub struct CommandInfo {
     pub name: &'static str,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1,3 +1,10 @@
+//! Configurable key bindings.
+//!
+//! [`KeyBindings`] resolves a (`KeyModifiers`, `KeyCode`, [`BindingMode`])
+//! triple to a [`KeyAction`]. Built-in profiles ship with the binary;
+//! [`KeyBindingOverrides`] is loaded from / saved to `keybindings.toml` so
+//! users can rebind without recompiling.
+
 use crossterm::event::{KeyCode, KeyModifiers};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 //! Library entrypoint for fuzz testing and external consumers.
 //!
-//! The main binary ([`main`](../main/index.html)) has its own module tree;
-//! this surface re-exports only what fuzz harnesses need (`config`, `input`,
-//! `keybindings`, `signal`).
+//! The main binary has its own module tree; this surface re-exports only
+//! what fuzz harnesses need ([`config`], [`input`], [`keybindings`],
+//! [`signal`]).
 
 pub mod config;
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
-// Library entrypoint for fuzz testing and external consumers.
-// The main binary (main.rs) has its own module tree; this re-exports
-// only what fuzz harnesses need.
+//! Library entrypoint for fuzz testing and external consumers.
+//!
+//! The main binary ([`main`](../main/index.html)) has its own module tree;
+//! this surface re-exports only what fuzz harnesses need (`config`, `input`,
+//! `keybindings`, `signal`).
 
 pub mod config;
 #[allow(dead_code)]

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,3 +1,10 @@
+//! Device linking against an existing Signal account.
+//!
+//! Spawns `signal-cli link`, parses the linking URI from stdout, renders a
+//! QR code in the terminal, and waits for the user to scan it from their
+//! primary device. On success, polls account registration until signal-cli
+//! reports the new device is provisioned.
+
 use std::io;
 use std::time::Duration;
 

--- a/src/list_overlay.rs
+++ b/src/list_overlay.rs
@@ -1,3 +1,9 @@
+//! Shared helpers for j/k/Enter/Esc list overlays.
+//!
+//! Most overlays in [`crate::domain`] expose the same navigation pattern;
+//! this module centralizes key resolution ([`ListOverlayAction`]) and the
+//! styled-row rendering helpers used by the UI layer.
+
 use crossterm::event::KeyCode;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};

--- a/src/list_overlay.rs
+++ b/src/list_overlay.rs
@@ -1,7 +1,7 @@
 //! Shared helpers for j/k/Enter/Esc list overlays.
 //!
 //! Most overlays in [`crate::domain`] expose the same navigation pattern;
-//! this module centralizes key resolution ([`ListOverlayAction`]) and the
+//! this module centralizes key resolution ([`ListKeyAction`]) and the
 //! styled-row rendering helpers used by the UI layer.
 
 use crossterm::event::KeyCode;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+//! Binary entry point and event loop.
+//!
+//! Polls the keyboard at 50 ms, drains [`signal::SignalEvent`]s into the
+//! [`app::App`] state, and renders each frame via [`ui::draw`]. Orchestrates
+//! the first-run flow: setup wizard -> device linking -> app startup.
+
 mod app;
 mod autocomplete;
 mod config;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 //! Binary entry point and event loop.
 //!
-//! Polls the keyboard at 50 ms, drains [`signal::SignalEvent`]s into the
-//! [`app::App`] state, and renders each frame via [`ui::draw`]. Orchestrates
-//! the first-run flow: setup wizard -> device linking -> app startup.
+//! Polls the keyboard at 50 ms, drains [`signal::types::SignalEvent`]s into
+//! the [`app::App`] state, and renders each frame via [`ui::draw`].
+//! Orchestrates the first-run flow: setup wizard -> device linking -> app
+//! startup.
 
 mod app;
 mod autocomplete;

--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -1,3 +1,10 @@
+//! Named settings profiles.
+//!
+//! A [`SettingsProfile`] bundles display preferences (image mode, receipts,
+//! theme, etc.) so users can swap between configurations. Built-in profiles
+//! ship with the binary; user-defined profiles live in
+//! `settings_profiles.toml`.
+
 use serde::{Deserialize, Serialize};
 
 use crate::app::App;

--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -3,7 +3,7 @@
 //! A [`SettingsProfile`] bundles display preferences (image mode, receipts,
 //! theme, etc.) so users can swap between configurations. Built-in profiles
 //! ship with the binary; user-defined profiles live in
-//! `settings_profiles.toml`.
+//! `~/.config/siggy/profiles/*.toml`.
 
 use serde::{Deserialize, Serialize};
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,3 +1,10 @@
+//! First-run wizard.
+//!
+//! Multi-step flow that detects (or installs) signal-cli, prompts for the
+//! user's E.164 phone, and hands off to [`crate::link`] for QR-code device
+//! linking. Persists the resolved signal-cli path back to [`crate::config`]
+//! so subsequent launches skip detection.
+
 use std::io;
 use std::time::Duration;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1,7 +1,7 @@
 //! First-run wizard.
 //!
-//! Multi-step flow that detects (or installs) signal-cli, prompts for the
-//! user's E.164 phone, and hands off to [`crate::link`] for QR-code device
+//! Multi-step flow that detects signal-cli on PATH, prompts for the user's
+//! E.164 phone, and hands off to [`crate::link`] for QR-code device
 //! linking. Persists the resolved signal-cli path back to [`crate::config`]
 //! so subsequent launches skip detection.
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -1,3 +1,12 @@
+//! signal-cli child process bridge over JSON-RPC.
+//!
+//! [`SignalClient`] spawns signal-cli and runs two tokio tasks: a stdout
+//! reader that parses JSON-RPC frames into [`SignalEvent`]s, and a stdin
+//! writer that sends [`JsonRpcRequest`]s. The `pending_requests` map
+//! correlates response IDs with the originating method so the reader can
+//! emit the right event variant. Notifications (incoming messages, typing,
+//! receipts) and RPC results both flow through the same mpsc channel.
+
 use anyhow::{Context, Result};
 use chrono::DateTime;
 use std::collections::HashMap;

--- a/src/signal/mod.rs
+++ b/src/signal/mod.rs
@@ -1,2 +1,5 @@
+//! signal-cli integration: child process bridge ([`client`]) and wire types
+//! ([`types`]).
+
 pub mod client;
 pub mod types;

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -1,4 +1,4 @@
-//! Wire types shared between [`super::client`] and [`crate::app`].
+//! Wire types shared between [`super::client`] and the binary's `app` module.
 //!
 //! Defines [`SignalEvent`] (the channel payload), [`SignalMessage`],
 //! [`Contact`], [`Group`], JSON-RPC framing structs, and the per-message

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -1,3 +1,9 @@
+//! Wire types shared between [`super::client`] and [`crate::app`].
+//!
+//! Defines [`SignalEvent`] (the channel payload), [`SignalMessage`],
+//! [`Contact`], [`Group`], JSON-RPC framing structs, and the per-message
+//! status / trust / reaction value types.
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -63,6 +69,9 @@ impl TrustLevel {
 #[derive(Debug, Clone)]
 pub struct IdentityInfo {
     pub number: Option<String>,
+    /// Only read by tests today; kept on the wire type for parity with
+    /// signal-cli's identity payload.
+    #[allow(dead_code)]
     pub uuid: Option<String>,
     pub fingerprint: String,
     pub safety_number: String,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,8 +1,8 @@
 //! Color themes for the UI.
 //!
-//! Built-in themes plus user-defined themes loaded from / saved to
-//! `themes.toml`. The active theme is chosen by name in [`crate::config`]
-//! and applied wherever the UI renders styled text.
+//! Built-in themes plus user-defined themes loaded from
+//! `~/.config/siggy/themes/*.toml`. The active theme is chosen by name in
+//! [`crate::config`] and applied wherever the UI renders styled text.
 
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,3 +1,9 @@
+//! Color themes for the UI.
+//!
+//! Built-in themes plus user-defined themes loaded from / saved to
+//! `themes.toml`. The active theme is chosen by name in [`crate::config`]
+//! and applied wherever the UI renders styled text.
+
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,9 @@
 //! Stateless rendering layer.
 //!
-//! [`draw`] takes `&App` and renders sidebar + chat + status bar each frame.
-//! Sender colors are hash-based across an 8-color palette; groups are prefixed
-//! with `#`. OSC 8 hyperlinks are injected post-render to dodge ratatui width
-//! calculation bugs (see [`LinkRegion`]).
+//! [`draw`] takes the current [`App`] and renders sidebar + chat + status
+//! bar each frame. Sender colors are hash-based across an 8-color palette;
+//! groups are prefixed with `#`. OSC 8 hyperlinks are injected post-render
+//! to dodge ratatui width calculation bugs (see [`LinkRegion`]).
 
 use ratatui::{
     Frame,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,3 +1,10 @@
+//! Stateless rendering layer.
+//!
+//! [`draw`] takes `&App` and renders sidebar + chat + status bar each frame.
+//! Sender colors are hash-based across an 8-color palette; groups are prefixed
+//! with `#`. OSC 8 hyperlinks are injected post-render to dodge ratatui width
+//! calculation bugs (see [`LinkRegion`]).
+
 use ratatui::{
     Frame,
     buffer::Buffer,


### PR DESCRIPTION
## Summary

Only one of 38 source files had a module-level \`//!\` docstring. This adds concise (2-4 line) module docs to every top-level module that lacked one, so anyone opening a file in isolation can immediately tell what it's for and how it fits with its neighbors.

Modules touched: \`app\`, \`main\`, \`ui\`, \`db\`, \`config\`, \`conversation_store\`, \`signal/{mod,client,types}\`, \`setup\`, \`link\`, \`input\`, \`keybindings\`, \`theme\`, \`image_render\`, \`autocomplete\`, \`settings_profile\`, \`list_overlay\`, \`lib\`, \`domain/mod\`.

The small per-overlay state structs under \`domain/*\` (one struct per file, each already carrying a \`/// State for X overlay.\` doc on the struct itself) are left alone rather than duplicating the same sentence at the module level.

## Hitchhiker fix

Restores the \`#[allow(dead_code)]\` on \`IdentityInfo::uuid\` that #347 removed in error. The reviewer there noted the field is "reached by a test" so the annotation looked stale, but the non-test \`cargo build\` still warns because no production code reads it. CI didn't catch this because CI gates on \`cargo clippy --tests\` which sees the test reader. Restored with a one-line rationale comment.

## Closes

Last sub-item under #209's architecture-health-check checklist. With this merged the issue can close.

## Test plan

- [x] \`cargo build\` passes with no warnings
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (639 tests, same as master)
- [x] \`cargo fmt --check\` passes