### PR TITLE
docs: backfill //! module-level docstrings across src/domain/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ signal-tui-debug.log
 .claude/settings.local.json
 screenshots/
 .worktrees/
+.context/

--- a/src/domain/action_menu.rs
+++ b/src/domain/action_menu.rs
@@ -1,3 +1,8 @@
+//! Message action menu state.
+//!
+//! Tracks the cursor position in the per-message action menu (delete,
+//! copy, forward, react, reply, edit) opened from a focused message.
+
 /// State for the message action menu overlay.
 #[derive(Default)]
 pub struct ActionMenuState {

--- a/src/domain/contacts_overlay.rs
+++ b/src/domain/contacts_overlay.rs
@@ -1,3 +1,9 @@
+//! Contacts browser overlay state.
+//!
+//! Backs the `/contacts` overlay: tracks the cursor `index`, the
+//! type-to-`filter` query, and the `filtered` `(phone, display_name)`
+//! list rebuilt as the user types.
+
 /// State for the contacts list overlay.
 #[derive(Default)]
 pub struct ContactsOverlayState {

--- a/src/domain/emoji_picker.rs
+++ b/src/domain/emoji_picker.rs
@@ -1,3 +1,12 @@
+//! Emoji picker overlay: state, key handling, and category filtering.
+//!
+//! The picker can be opened from two contexts (`EmojiPickerSource`):
+//! `Input` to insert an emoji into the composer, or `Reaction` to apply
+//! one to the focused message. Navigation is grid-based using the
+//! configured `cols`; type-to-filter searches across name and shortcode
+//! and ignores the active category. Skin-tone variants are skipped to
+//! keep the grid manageable.
+
 use crossterm::event::KeyCode;
 
 /// Context the emoji picker was opened from.

--- a/src/domain/file_picker.rs
+++ b/src/domain/file_picker.rs
@@ -1,3 +1,11 @@
+//! File browser overlay used to pick attachments.
+//!
+//! Opens at the user's home directory and walks the filesystem with a
+//! sorted directory-first listing. Type-to-filter narrows the visible
+//! entries; Enter descends into a directory or selects a file (returned
+//! as `FilePickerOutcome::Selected`). Backspace pops the filter or
+//! navigates up when the filter is empty.
+
 use std::path::PathBuf;
 
 use crossterm::event::KeyCode;

--- a/src/domain/forward_overlay.rs
+++ b/src/domain/forward_overlay.rs
@@ -1,3 +1,9 @@
+//! Forward-message picker overlay state.
+//!
+//! Carries the message `body` being forwarded and a type-to-`filter`
+//! conversation picker (`filtered` `(conv_id, display_name)`) so the
+//! user can pick a destination conversation for the forwarded text.
+
 /// State for the forward message picker overlay.
 #[derive(Default)]
 pub struct ForwardOverlayState {

--- a/src/domain/group_menu_overlay.rs
+++ b/src/domain/group_menu_overlay.rs
@@ -1,3 +1,10 @@
+//! Group management menu overlay state.
+//!
+//! Backs the `/group` overlay across its sub-screens (`state`): main
+//! menu, add/remove member pickers (with type-to-`filter`), and the
+//! rename/create flow that uses `input` as a separate text buffer so
+//! the composer is not disturbed.
+
 use crate::app::GroupMenuState;
 
 /// State for the group management menu overlay.

--- a/src/domain/image.rs
+++ b/src/domain/image.rs
@@ -1,3 +1,14 @@
+//! Image rendering, caching, and link-region tracking.
+//!
+//! Cross-cuts every supported terminal image protocol (`image_protocol`):
+//! Kitty graphics (`kitty_*`), iTerm2 inline (`iterm2_crop_cache`),
+//! Sixel (`sixel_*`), and a Unicode halfblock fallback. Caches resized
+//! PNGs (`native_image_cache`), tracks frame-to-frame visibility for
+//! redraw skipping (`prev_visible_images`), and routes background
+//! decode work through `image_render_tx` / `image_render_rx`. Also
+//! holds the `LinkRegion` list and `link_url_map` used by the
+//! post-render OSC 8 hyperlink injector.
+
 use std::collections::{HashMap, HashSet};
 
 use std::sync::mpsc;

--- a/src/domain/keybindings_overlay.rs
+++ b/src/domain/keybindings_overlay.rs
@@ -1,3 +1,11 @@
+//! Keybindings configuration overlay state.
+//!
+//! Drives the binding editor: cursor (`index`), in-progress key capture
+//! (`capturing`) with conflict detection (`conflict`), and a nested
+//! profile sub-picker (`profile_picker`, `profile_index`,
+//! `available_profiles`) for switching between named keybinding profiles
+//! without leaving the overlay.
+
 use crate::keybindings::{KeyAction, KeyCombo};
 
 /// State for the keybindings configuration overlay.

--- a/src/domain/notification.rs
+++ b/src/domain/notification.rs
@@ -1,3 +1,11 @@
+//! Notification preferences and clipboard auto-clear timer.
+//!
+//! Holds the per-frame `pending_bell` flag plus user preferences for
+//! direct/group terminal bells, OS desktop notifications, and the
+//! `notification_preview` level. Also tracks the clipboard auto-clear
+//! window (`clipboard_clear_seconds`) and the `clipboard_set_at`
+//! timestamp used to scrub copied data after it expires.
+
 /// State for notification preferences and clipboard auto-clear.
 #[derive(Default)]
 pub struct NotificationState {

--- a/src/domain/pin_duration_overlay.rs
+++ b/src/domain/pin_duration_overlay.rs
@@ -1,3 +1,9 @@
+//! Pin duration picker overlay state.
+//!
+//! Tracks the cursor `index` over the duration choices and the
+//! `pending` `PinPending` context (target conversation + message)
+//! captured when the picker was opened.
+
 use crate::app::PinPending;
 
 /// State for the pin duration picker overlay.

--- a/src/domain/poll_vote_overlay.rs
+++ b/src/domain/poll_vote_overlay.rs
@@ -1,3 +1,11 @@
+//! Poll vote overlay and pending poll-data buffer.
+//!
+//! `index` and `selections` drive the multi-select cursor for the open
+//! vote dialog; `pending` carries the in-flight `PollVotePending`
+//! context. `pending_polls` buffers `PollData` keyed by
+//! `(conv_id, timestamp)` so a poll that arrives before its parent
+//! message is preserved until the message is rendered.
+
 use std::collections::HashMap;
 
 use crate::app::PollVotePending;

--- a/src/domain/profile_overlay.rs
+++ b/src/domain/profile_overlay.rs
@@ -1,3 +1,11 @@
+//! Profile editor overlay state.
+//!
+//! Holds the four editable profile fields (`given_name`,
+//! `family_name`, `about`, `about_emoji`) as a fixed-size array, along
+//! with the cursor `index`, the `editing` flag, and a temporary
+//! `edit_buffer` used to stage changes before they are committed back
+//! to the field array.
+
 /// State for the profile editor overlay.
 #[derive(Default)]
 pub struct ProfileOverlayState {

--- a/src/domain/reaction.rs
+++ b/src/domain/reaction.rs
@@ -1,3 +1,11 @@
+//! Reaction display preferences and reaction picker state.
+//!
+//! `picker_index` tracks the cursor in the reaction picker overlay.
+//! The remaining flags shape rendering: `show_reactions` toggles the
+//! reaction badge entirely, `verbose` swaps counts for usernames, and
+//! `emoji_to_text` rewrites emoji as text shortcodes for terminals
+//! that render emoji poorly.
+
 /// State for reaction display preferences and the reaction picker overlay.
 #[derive(Default)]
 pub struct ReactionState {

--- a/src/domain/search.rs
+++ b/src/domain/search.rs
@@ -1,3 +1,13 @@
+//! Message search overlay: query state, results, and navigation.
+//!
+//! `query` is the live filter text, `results` is the rolling 50-row
+//! match list pulled from SQLite (per-conversation when an active
+//! conversation is set, otherwise across all conversations), and
+//! `index` is the cursor over results. `handle_key` returns a
+//! `SearchAction` for the App to dispatch (jump, status, cancel).
+//! `jump_to_result` powers `n`/`N` traversal within the active
+//! conversation with wrap-around.
+
 use crossterm::event::KeyCode;
 
 use crate::db::Database;

--- a/src/domain/settings_profile_overlay.rs
+++ b/src/domain/settings_profile_overlay.rs
@@ -1,3 +1,10 @@
+//! Settings profile manager overlay state.
+//!
+//! Tracks the currently active profile `name`, the cursor `index`
+//! over the `available` profiles, and the "save as" sub-flow
+//! (`save_as` flag + `save_as_input` text buffer) used to capture a
+//! new profile name without touching the main composer.
+
 use crate::settings_profile::SettingsProfile;
 
 /// State for the settings profile manager overlay.

--- a/src/domain/theme_picker.rs
+++ b/src/domain/theme_picker.rs
@@ -1,3 +1,9 @@
+//! Theme picker overlay state.
+//!
+//! Holds the cursor `index` and the populated `available_themes` list
+//! (built-in plus any user-defined themes loaded from disk) shown in
+//! the `/theme` overlay.
+
 use crate::theme::Theme;
 
 /// State for the theme picker overlay.

--- a/src/domain/typing.rs
+++ b/src/domain/typing.rs
@@ -1,3 +1,11 @@
+//! Typing indicator state: inbound display and outbound throttling.
+//!
+//! `indicators` maps `conv_id` to a `sender_phone` -> last-seen
+//! `Instant` map; entries older than 5s are pruned each tick by
+//! `cleanup`. `sent` and `last_keypress` track our outgoing typing
+//! signal so we throttle start events and emit a stop after 5s of
+//! inactivity (`check_timeout`) or on conversation switch (`reset`).
+
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 

--- a/src/domain/verify_overlay.rs
+++ b/src/domain/verify_overlay.rs
@@ -1,3 +1,10 @@
+//! Identity verification overlay state.
+//!
+//! `identities` is the filtered `IdentityInfo` list shown in the
+//! overlay (one entry for a 1:1 chat, or one per group member);
+//! `index` is the cursor; `confirming` gates the destructive
+//! "verify identity" action behind a confirmation prompt.
+
 use crate::signal::types::IdentityInfo;
 
 /// State for the identity verification overlay.


### PR DESCRIPTION
## Summary

Closes #361. Adds module-level (\`//!\`) docstrings to the 18 domain modules that didn't have them, matching the existing house style on \`input.rs\` / \`mouse.rs\` / \`pending.rs\` / \`scroll.rs\`:

- One-line summary on the first line
- Blank \`//!\` separator
- Short paragraph naming the fields and explaining what the module owns

The headers are written to be useful when navigating with \`cargo doc\` or rust-analyzer hover, and to give a future contributor enough context to know what each domain module is for without having to read the struct.

Also gitignores \`.context/\` so review-tool artifacts (e.g. ce-code-review JSON snapshots) don't accidentally get committed.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (509 tests)
- [x] No code logic touched - docstrings only