### PR TITLE
refactor: extract delete-confirm overlay (#357)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,7 @@ mod status_bar;
 
 use composer::draw_input;
 use overlays::about::draw_about;
+use overlays::delete_confirm::draw_delete_confirm;
 use sidebar::draw_sidebar;
 use status_bar::draw_status_bar;
 
@@ -2090,30 +2091,6 @@ fn draw_emoji_picker(frame: &mut Frame, app: &App, area: Rect) {
 
     let popup = Paragraph::new(lines);
     frame.render_widget(popup, inner);
-}
-
-fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
-    let theme = &app.theme;
-    let msg = app.selected_message();
-    let is_outgoing = msg.is_some_and(|m| m.sender == "you");
-
-    let (popup_area, block) = centered_popup(frame, area, 44, 5, " Delete Message ", theme);
-
-    let prompt = if is_outgoing {
-        "Delete for everyone? (y)es / (l)ocal / (n)o"
-    } else {
-        "Delete locally? (y)es / (n)o"
-    };
-
-    let lines = vec![
-        Line::from(""),
-        Line::from(Span::styled(
-            format!("  {prompt}"),
-            Style::default().fg(theme.fg),
-        )),
-    ];
-    let popup = Paragraph::new(lines).block(block);
-    frame.render_widget(popup, popup_area);
 }
 
 /// Render the welcome/empty-state screen when no conversation is active.

--- a/src/ui/overlays/delete_confirm.rs
+++ b/src/ui/overlays/delete_confirm.rs
@@ -1,0 +1,40 @@
+//! Delete-message confirmation overlay.
+//!
+//! Prompts to delete the focused message. For outgoing messages the
+//! prompt offers "delete for everyone" (`y`), "local only" (`l`), or
+//! cancel (`n`); for incoming messages only "local only" is valid.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use super::super::centered_popup;
+use crate::app::App;
+
+pub(in crate::ui) fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let msg = app.selected_message();
+    let is_outgoing = msg.is_some_and(|m| m.sender == "you");
+
+    let (popup_area, block) = centered_popup(frame, area, 44, 5, " Delete Message ", theme);
+
+    let prompt = if is_outgoing {
+        "Delete for everyone? (y)es / (l)ocal / (n)o"
+    } else {
+        "Delete locally? (y)es / (n)o"
+    };
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  {prompt}"),
+            Style::default().fg(theme.fg),
+        )),
+    ];
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -6,3 +6,4 @@
 //! frame, plus per-overlay popup-width constants for sizing.
 
 pub(super) mod about;
+pub(super) mod delete_confirm;


### PR DESCRIPTION
## Summary

Fifth slice of #357. Smallest overlay so far (~22 lines): the y/l/n delete confirmation popup that adapts its prompt for outgoing vs incoming messages.

\`ui/mod.rs\`: 4,800 -> 4,778 lines.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (509 tests)