### PR TITLE
refactor: extract settings cluster overlays (#357)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -13,11 +13,14 @@ mod status_bar;
 use composer::draw_input;
 use overlays::about::draw_about;
 use overlays::action_menu::draw_action_menu;
+use overlays::customize::draw_customize;
 use overlays::delete_confirm::draw_delete_confirm;
 use overlays::message_request::draw_message_request;
 use overlays::pin_duration::draw_pin_duration_picker;
 use overlays::poll_vote::draw_poll_vote_overlay;
 use overlays::reaction_picker::draw_reaction_picker;
+use overlays::settings::draw_settings;
+use overlays::settings_profile::draw_settings_profile_manager;
 use overlays::theme_picker::draw_theme_picker;
 use sidebar::draw_sidebar;
 use status_bar::draw_status_bar;
@@ -34,10 +37,7 @@ use ratatui::{
     },
 };
 
-use crate::app::{
-    App, AutocompleteMode, GroupMenuState, InputMode, OverlayKind, SETTINGS, SettingDef,
-    VisibleImage,
-};
+use crate::app::{App, AutocompleteMode, GroupMenuState, InputMode, OverlayKind, VisibleImage};
 use crate::domain::CATEGORIES;
 use crate::image_render::{self, ImageProtocol};
 use crate::input::{COMMANDS, format_compact_duration};
@@ -52,8 +52,8 @@ const MIN_CHAT_WIDTH: u16 = 30;
 const MSG_WINDOW_MULTIPLIER: usize = 10;
 
 // Popup dimensions
-const SETTINGS_POPUP_WIDTH: u16 = 50;
-const SETTINGS_POPUP_HEIGHT: u16 = 25;
+pub(super) const SETTINGS_POPUP_WIDTH: u16 = 50;
+pub(super) const SETTINGS_POPUP_HEIGHT: u16 = 25;
 const CONTACTS_POPUP_WIDTH: u16 = 50;
 const CONTACTS_MAX_VISIBLE: usize = 20;
 const FILE_BROWSER_POPUP_WIDTH: u16 = 60;
@@ -2180,175 +2180,6 @@ fn draw_autocomplete(frame: &mut Frame, app: &App, input_area: Rect) {
     frame.render_widget(popup, area);
 }
 
-fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
-    let theme = &app.theme;
-    let height = SETTINGS_POPUP_HEIGHT;
-    let (popup_area, block) = centered_popup(
-        frame,
-        area,
-        SETTINGS_POPUP_WIDTH,
-        height,
-        " Settings ",
-        theme,
-    );
-
-    let header_style = Style::default()
-        .fg(theme.fg_muted)
-        .add_modifier(Modifier::BOLD);
-
-    // Render a toggle row
-    let render_toggle = |lines: &mut Vec<Line>, i: usize, def: &SettingDef| {
-        let enabled = app.setting_value(i);
-        let checkbox = if enabled { "[x]" } else { "[ ]" };
-        let is_selected = i == app.settings_index;
-        let style = if is_selected {
-            Style::default()
-                .bg(theme.bg_selected)
-                .fg(theme.fg)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.fg_secondary)
-        };
-        let check_style = if is_selected {
-            Style::default()
-                .bg(theme.bg_selected)
-                .fg(theme.accent)
-                .add_modifier(Modifier::BOLD)
-        } else if enabled {
-            Style::default().fg(theme.success)
-        } else {
-            Style::default().fg(theme.fg_muted)
-        };
-        lines.push(Line::from(vec![
-            Span::styled(format!("    {} ", checkbox), check_style),
-            Span::styled(def.label.to_string(), style),
-        ]));
-    };
-
-    // Render a special (non-toggle) row
-    let render_special = |lines: &mut Vec<Line>, label: &str, value: &str, index: usize| {
-        let is_selected = app.settings_index == index;
-        let label_style = if is_selected {
-            Style::default()
-                .bg(theme.bg_selected)
-                .fg(theme.fg)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.fg_secondary)
-        };
-        let value_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(theme.accent)
-        } else {
-            Style::default().fg(theme.accent)
-        };
-        lines.push(Line::from(vec![
-            Span::styled(format!("    {label}"), label_style),
-            Span::styled(value.to_string(), value_style),
-        ]));
-    };
-
-    use crate::app::{
-        SETTINGS_SECTION_DISPLAY, SETTINGS_SECTION_INTERFACE, SETTINGS_SECTION_MESSAGES,
-    };
-
-    let preview_index = SETTINGS.len();
-    let image_mode_index = SETTINGS.len() + 1;
-    let customize_index = SETTINGS.len() + 2;
-
-    let mut lines: Vec<Line> = Vec::new();
-
-    // — Notifications —
-    lines.push(Line::from(Span::styled("  Notifications", header_style)));
-    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_DISPLAY) {
-        render_toggle(&mut lines, i, def);
-    }
-    render_special(
-        &mut lines,
-        "Notification preview: ",
-        &app.notifications.notification_preview,
-        preview_index,
-    );
-
-    // — Display —
-    lines.push(Line::from(Span::styled("  Display", header_style)));
-    for (i, def) in SETTINGS
-        .iter()
-        .enumerate()
-        .take(SETTINGS_SECTION_MESSAGES)
-        .skip(SETTINGS_SECTION_DISPLAY)
-    {
-        render_toggle(&mut lines, i, def);
-    }
-    render_special(
-        &mut lines,
-        "Image mode: ",
-        &app.image.image_mode,
-        image_mode_index,
-    );
-
-    // — Messages —
-    lines.push(Line::from(Span::styled("  Messages", header_style)));
-    for (i, def) in SETTINGS
-        .iter()
-        .enumerate()
-        .take(SETTINGS_SECTION_INTERFACE)
-        .skip(SETTINGS_SECTION_MESSAGES)
-    {
-        render_toggle(&mut lines, i, def);
-    }
-
-    // — Interface —
-    lines.push(Line::from(Span::styled("  Interface", header_style)));
-    for (i, def) in SETTINGS.iter().enumerate().skip(SETTINGS_SECTION_INTERFACE) {
-        render_toggle(&mut lines, i, def);
-    }
-    render_special(&mut lines, "Customize...", "", customize_index);
-
-    // Hint line for the currently selected item
-    let hint = if app.settings_index < SETTINGS.len() {
-        SETTINGS[app.settings_index].hint
-    } else {
-        match app.settings_index - SETTINGS.len() {
-            0 => "Control message content in notifications",
-            1 => "native (terminal protocol), halfblock, or none",
-            2 => "Theme, keybindings, and settings profiles",
-            _ => "",
-        }
-    };
-    lines.push(Line::from(Span::styled(
-        format!("  {hint}"),
-        Style::default()
-            .fg(theme.fg_muted)
-            .add_modifier(Modifier::ITALIC),
-    )));
-
-    let popup = Paragraph::new(lines).block(block);
-    frame.render_widget(popup, popup_area);
-}
-
-fn draw_customize(frame: &mut Frame, app: &App, area: Rect) {
-    let theme = &app.theme;
-    let items = ["Theme", "Keybindings", "Settings profile"];
-    let (popup_area, block) = centered_popup(frame, area, 30, 5, " Customize ", theme);
-
-    let mut lines: Vec<Line> = Vec::new();
-    for (i, label) in items.iter().enumerate() {
-        let is_selected = i == app.customize_index;
-        let style = if is_selected {
-            Style::default()
-                .bg(theme.bg_selected)
-                .fg(theme.fg)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.fg_secondary)
-        };
-        lines.push(Line::from(Span::styled(format!("  {label}"), style)));
-    }
-
-    let popup = Paragraph::new(lines).block(block);
-    frame.render_widget(popup, popup_area);
-}
-
 fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let kb = &app.keybindings;
@@ -3418,139 +3249,6 @@ fn draw_keybindings_profile_picker(frame: &mut Frame, app: &App, area: Rect) {
         "  j/k navigate  |  Enter apply  |  Esc cancel",
         Style::default().fg(theme.fg_muted),
     )));
-
-    let popup = Paragraph::new(lines).block(block);
-    frame.render_widget(popup, popup_area);
-}
-
-fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
-    let theme = &app.theme;
-
-    // If save-as input is active, draw that sub-overlay instead
-    if app.settings_profiles.save_as {
-        draw_settings_profile_save_as(frame, app, area);
-        return;
-    }
-
-    let max_visible = 10usize.min(app.settings_profiles.available.len());
-    let pref_height = max_visible as u16 + 5; // borders + footer
-
-    let (popup_area, block) =
-        centered_popup(frame, area, 42, pref_height, " Settings Profiles ", theme);
-
-    let inner_height = popup_area.height.saturating_sub(2) as usize;
-    let footer_lines = 2;
-    let visible_rows = inner_height.saturating_sub(footer_lines);
-
-    let scroll_offset = if app.settings_profiles.index >= visible_rows {
-        app.settings_profiles.index - visible_rows + 1
-    } else {
-        0
-    };
-
-    // Determine if current settings differ from loaded profile
-    let has_changes = !app
-        .settings_profiles
-        .available
-        .iter()
-        .any(|p| p.name == app.settings_profiles.name && p.matches_app(app));
-
-    let mut lines: Vec<Line> = Vec::new();
-    let end = (scroll_offset + visible_rows).min(app.settings_profiles.available.len());
-    for i in scroll_offset..end {
-        let profile = &app.settings_profiles.available[i];
-        let is_selected = i == app.settings_profiles.index;
-        let is_active = profile.name == app.settings_profiles.name;
-
-        let marker = if is_active { ">" } else { " " };
-        let row_style = if is_selected {
-            Style::default()
-                .bg(theme.bg_selected)
-                .fg(theme.fg)
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(theme.fg)
-        };
-        let marker_style = if is_selected {
-            Style::default().bg(theme.bg_selected).fg(if is_active {
-                theme.accent
-            } else {
-                theme.fg_muted
-            })
-        } else {
-            Style::default().fg(if is_active {
-                theme.accent
-            } else {
-                theme.fg_muted
-            })
-        };
-
-        lines.push(Line::from(vec![
-            Span::styled(format!("  {marker} "), marker_style),
-            Span::styled(profile.name.clone(), row_style),
-        ]));
-    }
-
-    while lines.len() < visible_rows {
-        lines.push(Line::from(""));
-    }
-
-    // Build contextual footer hints
-    let selected_profile = app
-        .settings_profiles
-        .available
-        .get(app.settings_profiles.index);
-    let is_builtin = selected_profile
-        .map(|p| crate::settings_profile::is_builtin(&p.name))
-        .unwrap_or(true);
-
-    let mut hints = vec!["j/k nav", "Enter load", "Esc close"];
-    if has_changes {
-        if !is_builtin {
-            hints.push("s save");
-        }
-        hints.push("S save as");
-    }
-    if !is_builtin {
-        hints.push("d delete");
-    }
-
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        format!("  {}", hints.join("  ")),
-        Style::default().fg(theme.fg_muted),
-    )));
-
-    let popup = Paragraph::new(lines).block(block);
-    frame.render_widget(popup, popup_area);
-}
-
-fn draw_settings_profile_save_as(frame: &mut Frame, app: &App, area: Rect) {
-    let theme = &app.theme;
-    let (popup_area, block) = centered_popup(frame, area, 40, 7, " Save Profile As ", theme);
-
-    let cursor_char = if app.settings_profiles.save_as_input.is_empty() {
-        "_"
-    } else {
-        ""
-    };
-    let lines = vec![
-        Line::from(""),
-        Line::from(vec![
-            Span::styled("  Name: ", Style::default().fg(theme.fg_secondary)),
-            Span::styled(
-                format!("{}{cursor_char}", app.settings_profiles.save_as_input),
-                Style::default()
-                    .fg(theme.fg)
-                    .add_modifier(Modifier::UNDERLINED),
-            ),
-        ]),
-        Line::from(""),
-        Line::from(Span::styled(
-            "  Enter save  |  Esc cancel",
-            Style::default().fg(theme.fg_muted),
-        )),
-    ];
 
     let popup = Paragraph::new(lines).block(block);
     frame.render_widget(popup, popup_area);

--- a/src/ui/overlays/customize.rs
+++ b/src/ui/overlays/customize.rs
@@ -1,0 +1,38 @@
+//! Customize sub-overlay: Theme / Keybindings / Settings profile.
+//!
+//! Three-row launcher that picks which secondary overlay to open.
+//! Reachable from the Settings overlay's "Customize..." row.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use super::super::centered_popup;
+use crate::app::App;
+
+pub(in crate::ui) fn draw_customize(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let items = ["Theme", "Keybindings", "Settings profile"];
+    let (popup_area, block) = centered_popup(frame, area, 30, 5, " Customize ", theme);
+
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, label) in items.iter().enumerate() {
+        let is_selected = i == app.customize_index;
+        let style = if is_selected {
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        lines.push(Line::from(Span::styled(format!("  {label}"), style)));
+    }
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -7,9 +7,12 @@
 
 pub(super) mod about;
 pub(super) mod action_menu;
+pub(super) mod customize;
 pub(super) mod delete_confirm;
 pub(super) mod message_request;
 pub(super) mod pin_duration;
 pub(super) mod poll_vote;
 pub(super) mod reaction_picker;
+pub(super) mod settings;
+pub(super) mod settings_profile;
 pub(super) mod theme_picker;

--- a/src/ui/overlays/settings.rs
+++ b/src/ui/overlays/settings.rs
@@ -1,0 +1,163 @@
+//! Main settings overlay.
+//!
+//! Section-grouped (Notifications / Display / Messages / Interface)
+//! list of toggles plus three "special" rows: notification preview
+//! mode, image protocol mode, and the entry into the Customize
+//! sub-overlay. Each row reads its current value from `App` and
+//! shows a one-line hint for the focused setting at the bottom.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use super::super::{SETTINGS_POPUP_HEIGHT, SETTINGS_POPUP_WIDTH, centered_popup};
+use crate::app::{
+    App, SETTINGS, SETTINGS_SECTION_DISPLAY, SETTINGS_SECTION_INTERFACE, SETTINGS_SECTION_MESSAGES,
+    SettingDef,
+};
+
+pub(in crate::ui) fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let height = SETTINGS_POPUP_HEIGHT;
+    let (popup_area, block) = centered_popup(
+        frame,
+        area,
+        SETTINGS_POPUP_WIDTH,
+        height,
+        " Settings ",
+        theme,
+    );
+
+    let header_style = Style::default()
+        .fg(theme.fg_muted)
+        .add_modifier(Modifier::BOLD);
+
+    // Render a toggle row
+    let render_toggle = |lines: &mut Vec<Line>, i: usize, def: &SettingDef| {
+        let enabled = app.setting_value(i);
+        let checkbox = if enabled { "[x]" } else { "[ ]" };
+        let is_selected = i == app.settings_index;
+        let style = if is_selected {
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        let check_style = if is_selected {
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD)
+        } else if enabled {
+            Style::default().fg(theme.success)
+        } else {
+            Style::default().fg(theme.fg_muted)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("    {} ", checkbox), check_style),
+            Span::styled(def.label.to_string(), style),
+        ]));
+    };
+
+    // Render a special (non-toggle) row
+    let render_special = |lines: &mut Vec<Line>, label: &str, value: &str, index: usize| {
+        let is_selected = app.settings_index == index;
+        let label_style = if is_selected {
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg_secondary)
+        };
+        let value_style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(theme.accent)
+        } else {
+            Style::default().fg(theme.accent)
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("    {label}"), label_style),
+            Span::styled(value.to_string(), value_style),
+        ]));
+    };
+
+    let preview_index = SETTINGS.len();
+    let image_mode_index = SETTINGS.len() + 1;
+    let customize_index = SETTINGS.len() + 2;
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // — Notifications —
+    lines.push(Line::from(Span::styled("  Notifications", header_style)));
+    for (i, def) in SETTINGS.iter().enumerate().take(SETTINGS_SECTION_DISPLAY) {
+        render_toggle(&mut lines, i, def);
+    }
+    render_special(
+        &mut lines,
+        "Notification preview: ",
+        &app.notifications.notification_preview,
+        preview_index,
+    );
+
+    // — Display —
+    lines.push(Line::from(Span::styled("  Display", header_style)));
+    for (i, def) in SETTINGS
+        .iter()
+        .enumerate()
+        .take(SETTINGS_SECTION_MESSAGES)
+        .skip(SETTINGS_SECTION_DISPLAY)
+    {
+        render_toggle(&mut lines, i, def);
+    }
+    render_special(
+        &mut lines,
+        "Image mode: ",
+        &app.image.image_mode,
+        image_mode_index,
+    );
+
+    // — Messages —
+    lines.push(Line::from(Span::styled("  Messages", header_style)));
+    for (i, def) in SETTINGS
+        .iter()
+        .enumerate()
+        .take(SETTINGS_SECTION_INTERFACE)
+        .skip(SETTINGS_SECTION_MESSAGES)
+    {
+        render_toggle(&mut lines, i, def);
+    }
+
+    // — Interface —
+    lines.push(Line::from(Span::styled("  Interface", header_style)));
+    for (i, def) in SETTINGS.iter().enumerate().skip(SETTINGS_SECTION_INTERFACE) {
+        render_toggle(&mut lines, i, def);
+    }
+    render_special(&mut lines, "Customize...", "", customize_index);
+
+    // Hint line for the currently selected item
+    let hint = if app.settings_index < SETTINGS.len() {
+        SETTINGS[app.settings_index].hint
+    } else {
+        match app.settings_index - SETTINGS.len() {
+            0 => "Control message content in notifications",
+            1 => "native (terminal protocol), halfblock, or none",
+            2 => "Theme, keybindings, and settings profiles",
+            _ => "",
+        }
+    };
+    lines.push(Line::from(Span::styled(
+        format!("  {hint}"),
+        Style::default()
+            .fg(theme.fg_muted)
+            .add_modifier(Modifier::ITALIC),
+    )));
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}

--- a/src/ui/overlays/settings_profile.rs
+++ b/src/ui/overlays/settings_profile.rs
@@ -1,0 +1,151 @@
+//! Settings profile manager + Save-As sub-overlay.
+//!
+//! Lists named profiles with a marker on the active one. Footer hints
+//! adapt to context: builtin profiles only allow Load; user profiles
+//! also allow `s` save in place, `S` save-as, and `d` delete. The
+//! save-as flow opens a separate text-input overlay
+//! (`draw_settings_profile_save_as`).
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use super::super::centered_popup;
+use crate::app::App;
+
+pub(in crate::ui) fn draw_settings_profile_manager(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+
+    // If save-as input is active, draw that sub-overlay instead
+    if app.settings_profiles.save_as {
+        draw_settings_profile_save_as(frame, app, area);
+        return;
+    }
+
+    let max_visible = 10usize.min(app.settings_profiles.available.len());
+    let pref_height = max_visible as u16 + 5; // borders + footer
+
+    let (popup_area, block) =
+        centered_popup(frame, area, 42, pref_height, " Settings Profiles ", theme);
+
+    let inner_height = popup_area.height.saturating_sub(2) as usize;
+    let footer_lines = 2;
+    let visible_rows = inner_height.saturating_sub(footer_lines);
+
+    let scroll_offset = if app.settings_profiles.index >= visible_rows {
+        app.settings_profiles.index - visible_rows + 1
+    } else {
+        0
+    };
+
+    // Determine if current settings differ from loaded profile
+    let has_changes = !app
+        .settings_profiles
+        .available
+        .iter()
+        .any(|p| p.name == app.settings_profiles.name && p.matches_app(app));
+
+    let mut lines: Vec<Line> = Vec::new();
+    let end = (scroll_offset + visible_rows).min(app.settings_profiles.available.len());
+    for i in scroll_offset..end {
+        let profile = &app.settings_profiles.available[i];
+        let is_selected = i == app.settings_profiles.index;
+        let is_active = profile.name == app.settings_profiles.name;
+
+        let marker = if is_active { ">" } else { " " };
+        let row_style = if is_selected {
+            Style::default()
+                .bg(theme.bg_selected)
+                .fg(theme.fg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme.fg)
+        };
+        let marker_style = if is_selected {
+            Style::default().bg(theme.bg_selected).fg(if is_active {
+                theme.accent
+            } else {
+                theme.fg_muted
+            })
+        } else {
+            Style::default().fg(if is_active {
+                theme.accent
+            } else {
+                theme.fg_muted
+            })
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {marker} "), marker_style),
+            Span::styled(profile.name.clone(), row_style),
+        ]));
+    }
+
+    while lines.len() < visible_rows {
+        lines.push(Line::from(""));
+    }
+
+    // Build contextual footer hints
+    let selected_profile = app
+        .settings_profiles
+        .available
+        .get(app.settings_profiles.index);
+    let is_builtin = selected_profile
+        .map(|p| crate::settings_profile::is_builtin(&p.name))
+        .unwrap_or(true);
+
+    let mut hints = vec!["j/k nav", "Enter load", "Esc close"];
+    if has_changes {
+        if !is_builtin {
+            hints.push("s save");
+        }
+        hints.push("S save as");
+    }
+    if !is_builtin {
+        hints.push("d delete");
+    }
+
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        format!("  {}", hints.join("  ")),
+        Style::default().fg(theme.fg_muted),
+    )));
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}
+
+fn draw_settings_profile_save_as(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let (popup_area, block) = centered_popup(frame, area, 40, 7, " Save Profile As ", theme);
+
+    let cursor_char = if app.settings_profiles.save_as_input.is_empty() {
+        "_"
+    } else {
+        ""
+    };
+    let lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Name: ", Style::default().fg(theme.fg_secondary)),
+            Span::styled(
+                format!("{}{cursor_char}", app.settings_profiles.save_as_input),
+                Style::default()
+                    .fg(theme.fg)
+                    .add_modifier(Modifier::UNDERLINED),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Enter save  |  Esc cancel",
+            Style::default().fg(theme.fg_muted),
+        )),
+    ];
+
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}


### PR DESCRIPTION
## Summary

Eighth slice of #357. Bundles four settings-related overlays:

- \`draw_settings\` (~145 lines) - main settings overlay with grouped toggles
- \`draw_customize\` (~22 lines) - Theme/Keybindings/Profile launcher
- \`draw_settings_profile_manager\` (~100 lines) - profile manager with builtin/user contextual hints
- \`draw_settings_profile_save_as\` (~30 lines) - kept private in \`settings_profile.rs\` since it's only called by the manager

\`SETTINGS\`, \`SettingDef\`, and the \`SETTINGS_SECTION_*\` constants are now only imported by the settings overlay submodule, so the import block in \`ui/mod.rs\` shed three more entries.

\`ui/mod.rs\`: 4,434 -> 4,132 lines.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (509 tests, all snapshots green)