### PR TITLE
fix: reset composer state on conversation switch (closes #362)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7046,6 +7046,7 @@ impl App {
         self.save_scroll_position();
         self.pending_attachment = None;
         self.reset_typing_with_stop();
+        self.input.reset_for_conv_switch();
         self.clear_kitty_placements();
 
         // Try exact match first
@@ -7106,6 +7107,7 @@ impl App {
         self.save_scroll_position();
         self.pending_attachment = None;
         self.reset_typing_with_stop();
+        self.input.reset_for_conv_switch();
         self.clear_kitty_placements();
         let idx = self
             .active_conversation
@@ -7139,6 +7141,7 @@ impl App {
         self.save_scroll_position();
         self.pending_attachment = None;
         self.reset_typing_with_stop();
+        self.input.reset_for_conv_switch();
         self.clear_kitty_placements();
         let len = self.store.conversation_order.len();
         let idx = self
@@ -10146,6 +10149,40 @@ mod tests {
             .get_or_create_conversation("+2", "Bob", false, &app.db);
         app.next_conversation();
         assert!(app.pending_attachment.is_none());
+    }
+
+    #[rstest]
+    fn history_browse_state_does_not_bleed_across_conv_switch(mut app: App) {
+        // Reproduces #362: pressing Up in conversation A starts history browsing
+        // (sets history_index and history_draft). Switching to conversation B
+        // must clear that browse state so pressing Down in B does nothing.
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+2", "Bob", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+
+        app.input.history = vec!["earlier".to_string()];
+        app.input.buffer = "in-progress draft".to_string();
+        app.input.cursor = "in-progress draft".len();
+
+        app.history_up();
+        assert_eq!(app.input.buffer, "earlier");
+        assert_eq!(app.input.history_index, Some(0));
+        assert_eq!(app.input.history_draft, "in-progress draft");
+
+        app.next_conversation();
+
+        assert_eq!(app.active_conversation.as_deref(), Some("+2"));
+        assert!(app.input.buffer.is_empty(), "buffer should be cleared");
+        assert_eq!(app.input.cursor, 0);
+        assert_eq!(app.input.history_index, None);
+        assert_eq!(app.input.history_draft, "");
+        assert_eq!(
+            app.input.history,
+            vec!["earlier".to_string()],
+            "session history must be preserved across switches"
+        );
     }
 
     #[rstest]

--- a/src/domain/input.rs
+++ b/src/domain/input.rs
@@ -18,3 +18,16 @@ pub struct InputState {
     /// Saves in-progress input when browsing history.
     pub history_draft: String,
 }
+
+impl InputState {
+    /// Reset the composer's transient state on conversation switch:
+    /// clears the buffer, cursor, and history-browse position. The
+    /// `history` vec is preserved because it's per-session, not
+    /// per-conversation.
+    pub fn reset_for_conv_switch(&mut self) {
+        self.buffer.clear();
+        self.cursor = 0;
+        self.history_index = None;
+        self.history_draft.clear();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #362. \`next_conversation\`, \`prev_conversation\`, and \`join_conversation\` cleared typing indicators and pending attachments but not the composer state. That meant \`history_index\` and \`history_draft\` from one conversation could bleed into the next: starting an Up-history browse in A and switching to B left \`history_index=Some(n)\` on B's composer, so pressing Down in B restored A's saved draft.

## Fix

Added \`InputState::reset_for_conv_switch()\` which clears \`buffer\`, \`cursor\`, \`history_index\`, and \`history_draft\`. The session-wide \`history\` Vec is **preserved** — it's per-user, not per-conversation; clearing it on every switch would lose useful Up-recall context.

Hooked it into all three conversation-switch entry points: \`next_conversation\`, \`prev_conversation\`, and \`join_conversation\` (which is also what sidebar mouse-clicks and \`/join\` go through).

## Test

New test \`history_browse_state_does_not_bleed_across_conv_switch\` exercises the original repro: \`history_up()\` in A, switch to B via \`next_conversation()\`, assert buffer is cleared and \`history_draft\` is reset while \`input.history\` itself persists.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (510 tests, +1 for the new repro)