### PR TITLE
ci: expand test matrix to ubuntu/macos/windows (closes #358)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [master]
 
 jobs:
-  check:
-    name: Lint & Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,8 +23,22 @@ jobs:
       - name: Clippy
         run: cargo clippy --tests -- -D warnings
 
-      - name: Test
-        run: cargo test
-
       - name: App field-count ratchet
         run: bash scripts/check-app-field-count.sh
+
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test
+        run: cargo test


### PR DESCRIPTION
## Summary

Closes #358. Splits CI into two jobs:

- **\`lint\`** (ubuntu-only): \`cargo fmt --check\`, \`cargo clippy --tests -- -D warnings\`, and the App field-count ratchet. Style is platform-agnostic; no need to 3x the lint cost.
- **\`test\`** (matrix): \`cargo test\` on \`ubuntu-latest\`, \`macos-latest\`, \`windows-latest\` — the three OSes siggy ships binaries for.

\`fail-fast: false\` so a failure on one OS doesn't cancel the others — when something breaks we want to see whether it's all-platform or platform-specific in one CI run.

## Why now

siggy releases 4 platform binaries but CI only ran on Linux. Platform divergences (signal-cli.bat vs shell script, MSYS2 JAVA_HOME quirks, filesystem rename semantics differing on Windows vs Linux) had to be caught manually at release time or by users. Pre-existing \`#[cfg(unix)]\` / \`#[cfg(windows)]\` gates suggest the code is already aware of these splits; CI should now actually verify both branches compile and pass tests.

## Test plan

- [x] CI will run against this PR on all three OSes
- [x] If macOS or Windows surface latent test failures, they get triaged here before merge