### PR TITLE
ci: run cargo-fuzz targets on every PR (closes #359)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,25 @@ jobs:
 
       - name: Test
         run: cargo test
+
+  fuzz:
+    name: Fuzz (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [fuzz_command_parse, fuzz_input_edit, fuzz_json_rpc, fuzz_key_combo]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@nightly
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz --locked
+
+      - name: Run ${{ matrix.target }}
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
       fail-fast: false
       matrix:
         target: [fuzz_command_parse, fuzz_input_edit, fuzz_json_rpc, fuzz_key_combo]
+    env:
+      # cargo-fuzz needs nightly. RUSTUP_TOOLCHAIN overrides
+      # rust-toolchain.toml's stable pin for this job only.
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary

Closes #359. Adds a \`fuzz\` job to CI that runs each of the four existing fuzz targets for 60 seconds on every PR:

- \`fuzz_command_parse\`
- \`fuzz_input_edit\`
- \`fuzz_json_rpc\`
- \`fuzz_key_combo\`

Each target runs as a separate matrix entry so they execute concurrently and fail independently — one panic in \`fuzz_json_rpc\` shouldn't mask results from the other three. Total wall-clock time per PR stays close to a single 60s budget.

Uses nightly toolchain (cargo-fuzz requires it) and \`rust-cache\` scoped to the fuzz workspace so corpus and target compilation are reused across runs.

## Not yet a gating check

This PR is **not** wired into the master branch ruleset as a required check. The plan is to prove the job runs reliably first, then gate it as a follow-up once we have a few green runs on master. That avoids surprise merge blocks if cargo-fuzz install is flaky or nightly breaks.

## Test plan

- [x] \`cargo fmt --check\` / \`cargo clippy --tests -- -D warnings\` / \`cargo test\` (unchanged from previous PRs)
- [x] CI fuzz matrix runs and reports status per-target on this PR
- [x] If any target finds a real crash, that gets triaged here before merge