### PR TITLE
test: cover filesystem migrations + fix Windows rename bug (closes #350)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2449,6 +2449,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ icy_sixel = "0.5"
 [dev-dependencies]
 insta = "1"
 rstest = "0.26"
+tempfile = "3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
@@ -208,19 +208,8 @@ impl Config {
             Some(p) => PathBuf::from(p),
             None => {
                 let new_path = Self::default_config_path();
-                // Auto-migrate from old "signal-tui" config directory
-                if !new_path.exists() {
-                    let old_path = dirs::config_dir()
-                        .unwrap_or_else(|| PathBuf::from(".config"))
-                        .join("signal-tui")
-                        .join("config.toml");
-                    if old_path.exists() {
-                        if let Some(parent) = new_path.parent() {
-                            let _ = std::fs::create_dir_all(parent);
-                        }
-                        let _ =
-                            std::fs::rename(old_path.parent().unwrap(), new_path.parent().unwrap());
-                    }
+                if let (Some(new_dir), Some(old_dir)) = (new_path.parent(), legacy_config_dir()) {
+                    migrate_config_dir(&old_dir, new_dir);
                 }
                 new_path
             }
@@ -304,6 +293,31 @@ impl Config {
     }
 }
 
+/// Path to the legacy `signal-tui` config directory, if `dirs::config_dir()`
+/// is resolvable on this platform.
+fn legacy_config_dir() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("signal-tui"))
+}
+
+/// Move the legacy config directory into place at `new_dir` if and only if
+/// `new_dir` does not already exist and `old_dir` does. Silently no-ops on
+/// rename errors -- the user can always fall back to running the setup wizard.
+///
+/// The previous implementation pre-created `new_dir` before calling rename,
+/// which works on POSIX (rename onto an empty dir is allowed) but fails on
+/// Windows (`std::fs::rename` returns an error if the target exists). The
+/// fix is to only ensure `new_dir`'s parent exists, leaving `new_dir` itself
+/// absent so rename can create it atomically.
+pub(crate) fn migrate_config_dir(old_dir: &Path, new_dir: &Path) {
+    if new_dir.exists() || !old_dir.exists() {
+        return;
+    }
+    if let Some(parent) = new_dir.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::rename(old_dir, new_dir);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,5 +364,74 @@ mod tests {
         };
         c.migrate_legacy_image_mode();
         assert_eq!(c.image_mode, "native");
+    }
+
+    // --- migrate_config_dir (filesystem) ---
+
+    #[test]
+    fn migrate_config_dir_renames_when_only_old_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("siggy");
+        std::fs::create_dir(&old).unwrap();
+        std::fs::write(old.join("config.toml"), b"account = \"+1\"").unwrap();
+
+        migrate_config_dir(&old, &new);
+
+        assert!(!old.exists());
+        assert!(new.exists());
+        assert_eq!(
+            std::fs::read_to_string(new.join("config.toml")).unwrap(),
+            "account = \"+1\""
+        );
+    }
+
+    #[test]
+    fn migrate_config_dir_noops_when_new_already_exists() {
+        // Pre-fix: the previous implementation pre-created `new_dir` then
+        // tried to rename onto it, which fails on Windows. The fix removed
+        // the pre-creation and the no-op guard ensures nothing happens
+        // when the user already has a fresh siggy config dir.
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("siggy");
+        std::fs::create_dir(&old).unwrap();
+        std::fs::write(old.join("config.toml"), b"old").unwrap();
+        std::fs::create_dir(&new).unwrap();
+        std::fs::write(new.join("config.toml"), b"new").unwrap();
+
+        migrate_config_dir(&old, &new);
+
+        assert_eq!(std::fs::read(old.join("config.toml")).unwrap(), b"old");
+        assert_eq!(std::fs::read(new.join("config.toml")).unwrap(), b"new");
+    }
+
+    #[test]
+    fn migrate_config_dir_noops_when_old_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("siggy");
+
+        migrate_config_dir(&old, &new);
+
+        assert!(!old.exists());
+        assert!(!new.exists());
+    }
+
+    #[test]
+    fn migrate_config_dir_creates_missing_parent() {
+        // dirs::config_dir() should always exist on a real machine, but
+        // verify we don't choke when it doesn't (e.g., a fresh tempdir
+        // pretending to be `~/.config/`). The new path's parent gets
+        // created so rename can succeed.
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("nested").join("subdir").join("siggy");
+        std::fs::create_dir(&old).unwrap();
+
+        migrate_config_dir(&old, &new);
+
+        assert!(!old.exists());
+        assert!(new.exists());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -1036,6 +1036,30 @@ impl Database {
     }
 }
 
+/// Move the legacy `signal-tui` data directory into place at `new_dir` if
+/// `new_dir` doesn't already exist and `old_dir` does. Silently no-ops on
+/// rename errors -- on first launch we'll fall back to creating an empty
+/// data dir.
+pub fn migrate_data_dir(old_dir: &Path, new_dir: &Path) {
+    if new_dir.exists() || !old_dir.exists() {
+        return;
+    }
+    if let Some(parent) = new_dir.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::rename(old_dir, new_dir);
+}
+
+/// Move the legacy `signal-tui.db` file to the new `siggy.db` filename if
+/// the new file doesn't already exist and the old one does. Silently no-ops
+/// on rename errors -- a fresh DB will be initialized at the new path.
+pub fn migrate_db_file(old_path: &Path, new_path: &Path) {
+    if new_path.exists() || !old_path.exists() {
+        return;
+    }
+    let _ = std::fs::rename(old_path, new_path);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1619,5 +1643,86 @@ mod tests {
         // Most recent first
         assert_eq!(results[0].3, "+2"); // Bob's conversation
         assert_eq!(results[1].3, "+1"); // Alice's conversation
+    }
+
+    // --- migrate_data_dir / migrate_db_file ---
+
+    #[test]
+    fn migrate_data_dir_renames_when_only_old_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("siggy");
+
+        std::fs::create_dir(&old).unwrap();
+        std::fs::write(old.join("siggy.db"), b"payload").unwrap();
+
+        migrate_data_dir(&old, &new);
+
+        assert!(!old.exists(), "old dir should be gone after rename");
+        assert!(new.exists(), "new dir should exist after rename");
+        assert_eq!(
+            std::fs::read(new.join("siggy.db")).unwrap(),
+            b"payload",
+            "DB content should survive the rename"
+        );
+    }
+
+    #[test]
+    fn migrate_data_dir_noops_when_new_already_exists() {
+        // Reproduces the Windows-rename-over-existing-dir failure mode:
+        // we should not even attempt the rename when the new dir is present.
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("siggy");
+        std::fs::create_dir(&old).unwrap();
+        std::fs::write(old.join("marker"), b"old").unwrap();
+        std::fs::create_dir(&new).unwrap();
+        std::fs::write(new.join("marker"), b"new").unwrap();
+
+        migrate_data_dir(&old, &new);
+
+        assert!(old.exists(), "old dir should be left alone");
+        assert!(new.exists(), "new dir should be left alone");
+        assert_eq!(std::fs::read(new.join("marker")).unwrap(), b"new");
+    }
+
+    #[test]
+    fn migrate_data_dir_noops_when_old_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui");
+        let new = tmp.path().join("siggy");
+
+        migrate_data_dir(&old, &new);
+
+        assert!(!old.exists());
+        assert!(!new.exists());
+    }
+
+    #[test]
+    fn migrate_db_file_renames_when_only_old_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui.db");
+        let new = tmp.path().join("siggy.db");
+        std::fs::write(&old, b"sqlite-bytes").unwrap();
+
+        migrate_db_file(&old, &new);
+
+        assert!(!old.exists());
+        assert!(new.exists());
+        assert_eq!(std::fs::read(&new).unwrap(), b"sqlite-bytes");
+    }
+
+    #[test]
+    fn migrate_db_file_noops_when_new_already_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old = tmp.path().join("signal-tui.db");
+        let new = tmp.path().join("siggy.db");
+        std::fs::write(&old, b"old").unwrap();
+        std::fs::write(&new, b"new").unwrap();
+
+        migrate_db_file(&old, &new);
+
+        assert_eq!(std::fs::read(&old).unwrap(), b"old");
+        assert_eq!(std::fs::read(&new).unwrap(), b"new");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,31 +273,15 @@ async fn run_main_flow(
     let database = if incognito {
         db::Database::open_in_memory()?
     } else {
-        let db_dir = dirs::data_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("."))
-            .join("siggy");
-
-        // Auto-migrate from old "signal-tui" data directory
-        if !db_dir.exists() {
-            let old_db_dir = dirs::data_dir()
-                .unwrap_or_else(|| std::path::PathBuf::from("."))
-                .join("signal-tui");
-            if old_db_dir.exists() {
-                let _ = std::fs::rename(&old_db_dir, &db_dir);
-            }
-        }
+        let data_root = dirs::data_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
+        let db_dir = data_root.join("siggy");
+        let old_db_dir = data_root.join("signal-tui");
+        db::migrate_data_dir(&old_db_dir, &db_dir);
 
         std::fs::create_dir_all(&db_dir)?;
         set_dir_permissions(&db_dir);
         let db_path = db_dir.join("siggy.db");
-
-        // Auto-migrate old database filename
-        if !db_path.exists() {
-            let old_db_path = db_dir.join("signal-tui.db");
-            if old_db_path.exists() {
-                let _ = std::fs::rename(&old_db_path, &db_path);
-            }
-        }
+        db::migrate_db_file(&db_dir.join("signal-tui.db"), &db_path);
         set_file_permissions(&db_path);
         db::Database::open(&db_path)?
     };


### PR DESCRIPTION
## Summary

Closes #350. The two silent rename migrations from v0.9.0 (\`signal-tui\` → \`siggy\`) had zero test coverage. Both touched \`dirs::config_dir\` / \`dirs::data_dir\` and inline \`std::fs::rename\` calls, so they could only be exercised end-to-end against a real filesystem. Now extracted into pure helpers that take \`(old, new)\` paths and tested with \`tempfile\`.

## New helpers

- \`config::migrate_config_dir\` (was inline in \`Config::load\`)
- \`db::migrate_data_dir\` (was inline in \`main\`)
- \`db::migrate_db_file\` (was inline in \`main\`)

Each helper:
- No-ops when new already exists (avoids the Windows rename-over-existing-dir failure mode)
- No-ops when old is missing
- Creates the destination's parent so a fresh-machine first launch doesn't trip on a missing intermediate directory

## Windows bug fixed

The previous \`Config::load\` implementation called \`create_dir_all\` on the **new** config dir, then tried to rename the old dir onto it. Linux allows rename onto an empty dir; Windows does not, so the migration silently failed for upgraders on Windows. The new \`migrate_config_dir\` only ensures the *parent* of \`new_dir\` exists and skips when \`new_dir\` is already present, which works on both.

## Tests

9 new tests cover: rename-on-only-old-exists, no-op on already-migrated, no-op on missing legacy data, and parent-creation when the destination is nested. Tests run on all three OSes via the CI matrix added in #391, so the Windows fix is now actually verified by CI rather than only by manual upgrade testing.

Added \`tempfile\` to dev-dependencies.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (519 tests, +9 for the migrations)
- [x] CI matrix on \`ubuntu-latest\`, \`macos-latest\`, \`windows-latest\` will exercise the Windows-specific path