### PR TITLE
fix: pause spinner during sync to honor redraw throttle (refs #326)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7098,6 +7098,18 @@ impl App {
         }
     }
 
+    /// Whether the startup spinner should advance this event-loop tick.
+    ///
+    /// Pauses during the initial sync burst (`sync.active`). The event loop
+    /// polls every 50ms, and ticking the spinner unconditionally on every
+    /// iteration sets `needs_redraw = true`, which bypasses the 500ms sync
+    /// redraw throttle in `drain_events`. The status bar already shows
+    /// "Syncing... (N messages received)" during sync, so the spinner adds
+    /// no information; pausing it lets the throttle actually take effect.
+    pub fn should_tick_spinner(&self) -> bool {
+        self.loading && !self.sync.active
+    }
+
     pub fn next_conversation(&mut self) {
         if self.store.conversation_order.is_empty() {
             return;
@@ -10183,6 +10195,38 @@ mod tests {
             vec!["earlier".to_string()],
             "session history must be preserved across switches"
         );
+    }
+
+    #[rstest]
+    fn spinner_pauses_during_sync(app: App) {
+        // Default state on a fresh App: loading=true AND sync.active=true
+        // (SyncState::new initializes active=true). The fix for #326 requires
+        // the spinner to pause in this overlap window so its 50ms tick rate
+        // doesn't bypass the 500ms sync redraw throttle in main's event loop.
+        assert!(app.loading);
+        assert!(app.sync.active);
+        assert!(
+            !app.should_tick_spinner(),
+            "spinner must not tick while sync is active"
+        );
+    }
+
+    #[rstest]
+    fn spinner_ticks_after_sync_ends_but_loading_continues(mut app: App) {
+        // Sync ended (no more incoming burst) but contact list hasn't arrived
+        // yet, so loading is still true. Spinner should resume so the user
+        // sees the "Loading contacts..." status animate.
+        app.sync.active = false;
+        assert!(app.loading);
+        assert!(app.should_tick_spinner());
+    }
+
+    #[rstest]
+    fn spinner_does_not_tick_when_loading_is_false(mut app: App) {
+        // Steady-state app: nothing to spin for.
+        app.loading = false;
+        app.sync.active = false;
+        assert!(!app.should_tick_spinner());
     }
 
     #[rstest]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1331,8 +1331,10 @@ async fn run_app(
             needs_redraw = true;
         }
 
-        // Animate the loading spinner
-        if app.loading {
+        // Animate the loading spinner. Skipped during sync.active so the
+        // 50ms event-loop tick rate doesn't bypass the 500ms sync redraw
+        // throttle below; see App::should_tick_spinner for context.
+        if app.should_tick_spinner() {
             app.spinner_tick = app.spinner_tick.wrapping_add(1);
             needs_redraw = true;
         }


### PR DESCRIPTION
## Summary

Refs #326. Fixes the input-sluggishness side of the issue. The viewport-drift side is filed as #394 and will land separately.

## Root cause

Investigated with \`/ce-debug\`. Full causal chain:

1. App startup: \`app.loading = true\` (default at app.rs:2910) AND \`app.sync.active = true\` (\`SyncState::new\` initializes \`active=true\` at app.rs:366)
2. Both states overlap until \`handle_contact_list\` clears \`loading\` at app.rs:5514 — typically 1-3 seconds after reconnect, exactly during the densest part of the message flood
3. \`main.rs:1335-1338\` runs every loop iteration:
   \`\`\`rust
   if app.loading {
       app.spinner_tick = app.spinner_tick.wrapping_add(1);
       needs_redraw = true;
   }
   \`\`\`
4. \`POLL_TIMEOUT = 50ms\` → spinner sets \`needs_redraw = true\` ~20 times/second
5. The 500ms throttle at main.rs:1399-1409 only filters \`drain_events\`-triggered redraws — it has **no effect** on the spinner-set \`needs_redraw\`
6. Result: ~20 expensive redraws/sec while loading + sync overlap, ignoring the throttle entirely. Each redraw recomputes \`line_heights\` for the rendered window (\`available_height * 10\` messages), which is what makes the input feel sluggish

## Fix

Skip the spinner tick when \`sync.active\`. The status bar already shows \`Syncing... (N messages received)\` during sync (status_bar.rs:39-58), so the spinner adds no information.

Extracted as \`App::should_tick_spinner\` so the predicate is testable without spinning up the event loop:

\`\`\`rust
pub fn should_tick_spinner(&self) -> bool {
    self.loading && !self.sync.active
}
\`\`\`

## What this does NOT fix

The viewport pinning during sync (scroll.offset += 1 per message) is broken in a different way — it under-compensates relative to actual message line counts (most messages render on 2-3 lines, but the pin only adds 1 line of compensation). That causes the "visible replay" feel described in #326. Filed as #394 with a render-time timestamp-anchoring proposal.

## Tests

- \`spinner_pauses_during_sync\` — fresh App default state (loading + sync.active both true) → \`should_tick_spinner()\` is false
- \`spinner_ticks_after_sync_ends_but_loading_continues\` — sync.active=false, loading=true → ticks
- \`spinner_does_not_tick_when_loading_is_false\` — steady state → no tick

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (522 tests, +3 for the spinner predicate)