### PR TITLE
fix: anchor sync viewport on captured timestamp (closes #394, closes #326)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -358,6 +358,13 @@ pub struct SyncState {
     pub suppressed_notifications: HashMap<String, usize>,
     /// True if the user manually scrolled the viewport during sync.
     pub user_scrolled: bool,
+    /// Viewport pin anchor for the active conversation: (timestamp of the
+    /// message that was at viewport bottom when sync started, scroll.offset
+    /// at that moment). Captured once per active-conversation sync session;
+    /// used by the chat-pane renderer to keep that message at its original
+    /// screen position regardless of how many lines incoming messages add.
+    /// Cleared on conversation switch and on sync end.
+    pub pin: Option<(DateTime<Utc>, usize)>,
 }
 
 impl SyncState {
@@ -369,6 +376,7 @@ impl SyncState {
             started_at: Instant::now(),
             suppressed_notifications: HashMap::new(),
             user_scrolled: false,
+            pin: None,
         }
     }
 
@@ -3236,6 +3244,7 @@ impl App {
     /// marks the active conversation read, and resets sync state.
     pub fn end_sync(&mut self) {
         self.sync.active = false;
+        self.sync.pin = None;
 
         // Snap viewport to newest messages (unless user manually scrolled)
         if !self.sync.user_scrolled {
@@ -4366,6 +4375,11 @@ impl App {
             self.sync.last_message_time = Some(Instant::now());
             self.status_message =
                 format!("Syncing... ({} messages received)", self.sync.message_count);
+            // Pin the viewport against the message at the bottom of the
+            // active conversation BEFORE we append the new sync message,
+            // so subsequent renders can hold that message at its original
+            // screen position. See #394.
+            self.maybe_capture_sync_pin(&conv_id);
         }
 
         // Store source_name in contact lookup for future resolution (typing indicators, etc.)
@@ -4727,14 +4741,8 @@ impl App {
             }
         }
 
-        // Viewport stabilization: keep scroll offset pinned during sync so newly
-        // arriving messages don't jump the viewport.
-        if self.sync.active
-            && !self.sync.user_scrolled
-            && self.active_conversation.as_ref() == Some(&conv_id)
-        {
-            self.scroll.offset = self.scroll.offset.saturating_add(1);
-        }
+        // Viewport stabilization happens render-side via SyncState::pin --
+        // see App::maybe_capture_sync_pin and the chat_pane renderer.
 
         // Active conversation: send read receipt and advance read marker
         let conv_accepted = self
@@ -7047,6 +7055,7 @@ impl App {
         self.pending_attachment = None;
         self.reset_typing_with_stop();
         self.input.reset_for_conv_switch();
+        self.sync.pin = None;
         self.clear_kitty_placements();
 
         // Try exact match first
@@ -7098,6 +7107,34 @@ impl App {
         }
     }
 
+    /// Capture the viewport pin anchor on the first sync message arrival
+    /// for the active conversation. The pin records (a) the timestamp of
+    /// the message currently at the bottom of the conversation -- the one
+    /// the user was looking at when sync began -- and (b) the user's
+    /// `scroll.offset` at that moment. The renderer uses both to keep
+    /// the pinned message at its original screen position regardless of
+    /// how many lines the incoming sync messages add.
+    ///
+    /// Skipped when:
+    /// - sync is not active (no need to pin)
+    /// - the user has manually scrolled (their explicit choice wins)
+    /// - the pin is already set (only first arrival captures)
+    /// - the message is for a non-active conversation (pin is per-active)
+    /// - the conversation has no prior messages (nothing to anchor to)
+    pub(crate) fn maybe_capture_sync_pin(&mut self, conv_id: &str) {
+        if !self.sync.active || self.sync.user_scrolled || self.sync.pin.is_some() {
+            return;
+        }
+        if self.active_conversation.as_deref() != Some(conv_id) {
+            return;
+        }
+        if let Some(conv) = self.store.conversations.get(conv_id)
+            && let Some(last) = conv.messages.last()
+        {
+            self.sync.pin = Some((last.timestamp, self.scroll.offset));
+        }
+    }
+
     /// Whether the startup spinner should advance this event-loop tick.
     ///
     /// Pauses during the initial sync burst (`sync.active`). The event loop
@@ -7120,6 +7157,7 @@ impl App {
         self.pending_attachment = None;
         self.reset_typing_with_stop();
         self.input.reset_for_conv_switch();
+        self.sync.pin = None;
         self.clear_kitty_placements();
         let idx = self
             .active_conversation
@@ -7154,6 +7192,7 @@ impl App {
         self.pending_attachment = None;
         self.reset_typing_with_stop();
         self.input.reset_for_conv_switch();
+        self.sync.pin = None;
         self.clear_kitty_placements();
         let len = self.store.conversation_order.len();
         let idx = self
@@ -11410,6 +11449,21 @@ mod tests {
         }
     }
 
+    /// Like `make_msg` but with an explicit millisecond timestamp offset, so
+    /// tests that send multiple messages in quick succession get distinct
+    /// timestamps (avoiding the dedup path).
+    fn make_msg_with_ts(
+        source: &str,
+        body: Option<&str>,
+        group_id: Option<&str>,
+        is_outgoing: bool,
+        ts_ms: i64,
+    ) -> SignalMessage {
+        let mut m = make_msg(source, body, group_id, is_outgoing);
+        m.timestamp = chrono::DateTime::from_timestamp_millis(ts_ms).unwrap();
+        m
+    }
+
     // --- Typing indicator tests ---
 
     #[rstest]
@@ -12085,31 +12139,124 @@ mod tests {
     }
 
     #[rstest]
-    fn sync_stabilizes_scroll(mut app: App) {
+    fn sync_captures_pin_on_first_message(mut app: App) {
+        // Conversation has a prior message (so there's something to anchor to).
+        // First sync arrival captures the pin to that message's timestamp + the
+        // current scroll.offset.
         assert!(app.sync.active);
         app.store
             .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
-        app.scroll.offset = 0;
-        let msg = make_msg("+1", Some("hello from sync"), None, false);
+        let prior = make_msg_with_ts("+1", Some("prior message"), None, false, 1000);
+        app.handle_signal_event(SignalEvent::MessageReceived(prior));
+        let pinned_ts = app.store.conversations["+1"]
+            .messages
+            .last()
+            .unwrap()
+            .timestamp;
+        // Set a non-zero offset to verify it's captured rather than coerced to 0.
+        app.scroll.offset = 4;
+
+        let msg = make_msg_with_ts("+1", Some("first sync msg"), None, false, 2000);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
-        assert!(
-            app.scroll.offset > 0,
-            "scroll.offset should increase during sync"
+
+        let (pin_ts, pin_offset) = app
+            .sync
+            .pin
+            .expect("pin should be captured on first sync msg");
+        assert_eq!(pin_ts, pinned_ts);
+        assert_eq!(pin_offset, 4);
+    }
+
+    #[rstest]
+    fn sync_pin_only_captured_once(mut app: App) {
+        // Subsequent sync messages must NOT overwrite the pin -- it anchors
+        // to the user's view at sync start, not the most recent arrival.
+        assert!(app.sync.active);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        let prior = make_msg_with_ts("+1", Some("prior"), None, false, 1000);
+        app.handle_signal_event(SignalEvent::MessageReceived(prior));
+        let pinned_ts = app.store.conversations["+1"]
+            .messages
+            .last()
+            .unwrap()
+            .timestamp;
+
+        let msg1 = make_msg_with_ts("+1", Some("first"), None, false, 2000);
+        app.handle_signal_event(SignalEvent::MessageReceived(msg1));
+        let msg2 = make_msg_with_ts("+1", Some("second"), None, false, 3000);
+        app.handle_signal_event(SignalEvent::MessageReceived(msg2));
+
+        let (pin_ts, _) = app.sync.pin.expect("pin should still be set");
+        assert_eq!(
+            pin_ts, pinned_ts,
+            "pin must still anchor to the original message"
         );
     }
 
     #[rstest]
-    fn sync_does_not_stabilize_after_user_scroll(mut app: App) {
+    fn sync_does_not_capture_pin_after_user_scroll(mut app: App) {
         assert!(app.sync.active);
         app.store
             .get_or_create_conversation("+1", "Alice", false, &app.db);
         app.active_conversation = Some("+1".to_string());
-        app.scroll.offset = 0;
+        let prior = make_msg_with_ts("+1", Some("prior"), None, false, 1000);
+        app.handle_signal_event(SignalEvent::MessageReceived(prior));
         app.sync.user_scrolled = true;
-        let msg = make_msg("+1", Some("hello"), None, false);
+
+        let msg = make_msg_with_ts("+1", Some("sync"), None, false, 2000);
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
+
+        assert!(app.sync.pin.is_none());
+        // Old behavior: scroll.offset += 1 was suppressed by user_scrolled.
+        // New behavior preserves that property — scroll.offset stays put.
         assert_eq!(app.scroll.offset, 0);
+    }
+
+    #[rstest]
+    fn sync_pin_skips_non_active_conversation(mut app: App) {
+        // Pin is per-active-conversation. Sync messages for a non-active conv
+        // must not capture or overwrite the active conv's pin.
+        assert!(app.sync.active);
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+2", "Bob", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        let prior_other = make_msg_with_ts("+2", Some("prior"), None, false, 1000);
+        app.handle_signal_event(SignalEvent::MessageReceived(prior_other));
+
+        let msg = make_msg_with_ts("+2", Some("from non-active"), None, false, 2000);
+        app.handle_signal_event(SignalEvent::MessageReceived(msg));
+
+        assert!(
+            app.sync.pin.is_none(),
+            "sync messages for the non-active conversation must not capture pin"
+        );
+    }
+
+    #[rstest]
+    fn sync_pin_cleared_on_end_sync(mut app: App) {
+        app.sync.pin = Some((Utc::now(), 3));
+        app.end_sync();
+        assert!(app.sync.pin.is_none());
+    }
+
+    #[rstest]
+    fn sync_pin_cleared_on_conv_switch(mut app: App) {
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+2", "Bob", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.sync.pin = Some((Utc::now(), 2));
+        app.next_conversation();
+        assert!(
+            app.sync.pin.is_none(),
+            "switching conversations must clear the pin so it doesn't apply to the new conv"
+        );
     }
 
     #[rstest]

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -636,6 +636,27 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
         .collect();
     let content_height: usize = line_heights.iter().sum();
 
+    // Sync viewport pin (#394): when a pin anchor was captured at sync start,
+    // derive scroll.offset from the pin message's current line position so it
+    // stays at its original screen offset regardless of how many lines the
+    // incoming sync messages add. Without this, scroll.offset += 1 per arriving
+    // message under-compensates against multi-line messages and the viewport
+    // drifts downward.
+    if app.sync.active
+        && !app.sync.user_scrolled
+        && let Some((pin_ts, pin_offset)) = app.sync.pin
+        && let Some(pin_idx) = visible.iter().position(|m| m.timestamp == pin_ts)
+        && let Some(new_offset) = compute_sync_pin_offset(
+            &line_heights,
+            &line_msg_idx,
+            content_height,
+            pin_idx,
+            pin_offset,
+        )
+    {
+        app.scroll.offset = new_offset;
+    }
+
     // Bottom-align by default; app.scroll.offset shifts the view upward
     let base_scroll = content_height.saturating_sub(available_height);
     app.scroll.offset = app.scroll.offset.min(base_scroll);
@@ -970,11 +991,132 @@ fn build_poll_display(
     lines
 }
 
+/// Compute the `scroll.offset` that keeps the pinned message at its original
+/// screen position, given the current rendered content. See #394.
+///
+/// Math: `pin_last_line` is the index of the pin message's last rendered line
+/// in the current content. `lines_below_pin` is how many rendered lines now
+/// sit after that line. The new offset = original offset at pin time + lines
+/// added below pin since then. Adding the number of lines that grew below pin
+/// preserves pin's distance from the bottom of the rendered content, and thus
+/// its distance from the bottom of the viewport.
+///
+/// Returns `None` when `pin_idx` does not appear in `line_msg_idx` (e.g., the
+/// pin message has been evicted from the renderer's sliding window).
+fn compute_sync_pin_offset(
+    line_heights: &[usize],
+    line_msg_idx: &[Option<usize>],
+    content_height: usize,
+    pin_idx: usize,
+    pin_offset_at_capture: usize,
+) -> Option<usize> {
+    let mut last_line: Option<usize> = None;
+    let mut cumul = 0usize;
+    for (idx, &h) in line_heights.iter().enumerate() {
+        if line_msg_idx.get(idx) == Some(&Some(pin_idx)) {
+            last_line = Some(cumul + h - 1);
+        }
+        cumul += h;
+    }
+    let pin_last_line = last_line?;
+    let lines_below_pin = content_height
+        .saturating_sub(1)
+        .saturating_sub(pin_last_line);
+    Some(pin_offset_at_capture.saturating_add(lines_below_pin))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::signal::types::{PollData, PollOption, PollVote, Reaction};
     use crate::theme::default_theme;
+
+    // --- compute_sync_pin_offset ---
+
+    #[test]
+    fn pin_offset_single_row_message_addition() {
+        // Pre-sync: 5 messages, each rendered as one Line of height 1.
+        // Pin = msg 4 (the last pre-sync message). One sync message arrives
+        // also as 1 Line, height 1. Old `+= 1` per message would set offset=1;
+        // the render-time math agrees here -- this is the boundary case where
+        // the old code happened to be correct.
+        let line_heights = vec![1, 1, 1, 1, 1, 1];
+        let line_msg_idx: Vec<Option<usize>> = (0..6).map(Some).collect();
+        let content_height = 6;
+        let new_offset =
+            compute_sync_pin_offset(&line_heights, &line_msg_idx, content_height, 4, 0).unwrap();
+        assert_eq!(new_offset, 1);
+    }
+
+    #[test]
+    fn pin_offset_multi_line_message_addition() {
+        // Pre-sync: 5 messages, each as 2 Lines (sender/timestamp + body),
+        // each Line of height 1 -> 10 rows total. Pin = msg 4.
+        // One sync message arrives as 2 Lines, with body wrapping to 2 rows
+        // (height = 2) -> 3 new rows. The old `+= 1` would put scroll.offset
+        // at 1, leaving pin 2 rows above the original viewport bottom -- the
+        // exact bug from #394. The new math sets offset = 3 so pin lands
+        // exactly at the bottom.
+        let mut line_heights = vec![1; 10]; // 5 messages * 2 lines * 1 row
+        line_heights.extend([1, 2]); // sync: timestamp Line (1 row) + body Line (wrapped 2 rows)
+        let mut line_msg_idx: Vec<Option<usize>> = Vec::new();
+        for i in 0..5 {
+            line_msg_idx.push(Some(i));
+            line_msg_idx.push(Some(i));
+        }
+        line_msg_idx.push(Some(5));
+        line_msg_idx.push(Some(5));
+        let content_height = 13;
+        let new_offset =
+            compute_sync_pin_offset(&line_heights, &line_msg_idx, content_height, 4, 0).unwrap();
+        assert_eq!(
+            new_offset, 3,
+            "offset must grow by the row count of new content (3), not by 1 per message"
+        );
+    }
+
+    #[test]
+    fn pin_offset_preserves_user_scroll_distance() {
+        // User was scrolled up by 2 rows when sync started (pin_offset=2).
+        // After sync adds 2 rows of new content, new offset should be 4 --
+        // preserving the user's 2-row distance from pin while compensating
+        // for the 2 new rows below pin.
+        let mut line_heights = vec![1, 1, 1]; // 3 pre-sync single-line messages
+        line_heights.extend([1, 1]); // sync adds 2 rows (one 2-line message)
+        let mut line_msg_idx: Vec<Option<usize>> = (0..3).map(Some).collect();
+        line_msg_idx.push(Some(3));
+        line_msg_idx.push(Some(3));
+        let content_height = 5;
+        let new_offset =
+            compute_sync_pin_offset(&line_heights, &line_msg_idx, content_height, 2, 2).unwrap();
+        assert_eq!(new_offset, 4);
+    }
+
+    #[test]
+    fn pin_offset_returns_none_when_pin_message_evicted() {
+        // Pin message isn't present in line_msg_idx (e.g., evicted from the
+        // renderer's sliding window). Caller should fall back to default
+        // behavior, which is what `None` signals.
+        let line_heights = vec![1, 1, 1];
+        let line_msg_idx = vec![Some(10), Some(11), Some(12)];
+        let pin_idx = 5; // not present
+        let result = compute_sync_pin_offset(&line_heights, &line_msg_idx, 3, pin_idx, 0);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn pin_offset_skips_separator_lines() {
+        // Some lines are date separators / unread markers (None in line_msg_idx).
+        // The walk must ignore those when locating pin's last line.
+        let line_heights = vec![1, 1, 1, 1, 1];
+        let line_msg_idx = vec![Some(0), None, Some(1), Some(1), Some(2)];
+        // Pin = msg 1, which spans lines 2..=3. Last line of pin is index 3.
+        // content_height=5, lines_below_pin = 5 - 1 - 3 = 1 (the line for msg 2).
+        let new_offset = compute_sync_pin_offset(&line_heights, &line_msg_idx, 5, 1, 0).unwrap();
+        assert_eq!(new_offset, 1);
+    }
+
+    // --- end compute_sync_pin_offset ---
 
     #[test]
     fn reaction_summary_counts() {


### PR DESCRIPTION
## Summary

Closes #394 (the deferred follow-up from #326's investigation) and finishes off #326.

PR #313's \`scroll.offset += 1\` per arriving sync message under-compensates against multi-line messages: each message renders as 2–3 rows (sender/timestamp + body + optional reactions/wrapping), so \`base_scroll\` grew by ~2–3 rows per message but \`scroll.offset\` only grew by 1. Net effect: viewport drifted ~1–2 rows downward per arriving message. After 50 typical messages, that's 50–100 rows of drift — past the user's read position — producing the "visible replay" feel.

## Fix

Capture a \`(timestamp, scroll.offset)\` anchor on the first sync message arrival in the active conversation. Derive \`scroll.offset\` render-side from where that anchor's last rendered line lives now. Adding the actual row count of new content below the anchor preserves its screen position regardless of how the new messages render.

### Architecture

- \`SyncState\` gets \`pin: Option<(DateTime<Utc>, usize)>\`
- \`App::maybe_capture_sync_pin\` is called from \`handle_message\` **before** the new message is appended, so \`messages.last()\` is the correct pre-sync anchor
- The render math is a pure helper \`compute_sync_pin_offset\` that takes \`line_heights + line_msg_idx\` and returns the new offset
- \`chat_pane::draw_messages\` calls the helper before the existing \`base_scroll\` clamp; the clamp still applies as a safety bound
- Pin clears on \`end_sync\` and on every conversation-switch path (\`next_conversation\` / \`prev_conversation\` / \`join_conversation\`)
- The previous \`+= 1\` hook in \`handle_message\` is removed — \`scroll.offset\` mutation is now exclusively render-side during sync

## Tests

11 new tests:

**Capture-side (app.rs)**:
- First-message capture stores the right \`(timestamp, scroll.offset)\`
- Subsequent messages do **not** overwrite the pin
- \`user_scrolled = true\` suppresses capture
- Sync messages for non-active conversations don't capture
- \`end_sync\` clears the pin
- Conversation switch clears the pin (so it doesn't apply to the new conv)

**Math-side (chat_pane.rs)**:
- Single-row addition: matches the old \`+= 1\` boundary case
- Multi-row addition: offset grows by row count, not message count — the actual #394 bug
- User scrolled up: preserves the user's distance from pin while compensating for new content
- Pin evicted from the renderer's window: returns \`None\` (caller falls back to default)
- Separator/marker lines (None entries in \`line_msg_idx\`) are skipped in the walk

The capture-side and math-side are decoupled, which is why the math is a pure function in chat_pane.rs — testable without spinning up a renderer.

## #326 closes with this

#395 fixed the spinner-throttle side (input sluggishness during the loading window). This PR fixes the viewport-drift side (visible replay during sync). Together they cover both causes identified in the original investigation. The third suspected cause (small-buffer clamp) was determined not to be a real bug.

## Test plan

- [x] \`cargo fmt --check\` passes
- [x] \`cargo clippy --tests -- -D warnings\` passes
- [x] \`cargo test\` passes (531 tests, +9 from previous)