### PR TITLE
feat: add /delete command for conversations (closes #312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 - **Reply / quote** -- Press `q` on a focused message to reply with quoted context
 - **Edit messages** -- Press `e` to edit your own sent messages
 - **Delete messages** -- Press `d` to delete locally or remotely (for your own messages)
+- **Delete conversations** -- Use `/delete` to remove the current conversation locally (declines pending message requests)
 - **Message search** -- `/search <query>` with `n`/`N` to jump between results
 - **@mentions** -- Type `@` in group chats to mention members with autocomplete
 - **Message selection** -- Focused message highlight when scrolling; `J`/`K` to jump between messages
@@ -150,6 +151,7 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 |---|---|---|
 | `/join <name>` | `/j` | Switch to a conversation by contact name, number, or group |
 | `/part` | `/p` | Leave current conversation |
+| `/delete` | | Delete current conversation (declines pending message requests) |
 | `/attach` | `/a` | Open file browser to attach a file |
 | `/search <query>` | `/s` | Search messages in current (or all) conversations |
 | `/sidebar` | `/sb` | Toggle sidebar visibility |

--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -8,6 +8,7 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 |---|---|---|---|
 | `/join` | `/j` | `<name>` | Switch to a conversation by contact name, number, or group |
 | `/part` | `/p` | | Leave current conversation |
+| `/delete` | | | Delete current conversation (declines pending message requests) |
 | `/search` | `/s` | `<query>` | Search messages across all conversations |
 | `/attach` | `/a` | | Open file browser to attach a file |
 | `/paste` | `/pa` | | Paste from clipboard (text or image) |
@@ -73,6 +74,15 @@ complete the selection.
 ```
 /mute
 ```
+
+**Delete the current conversation:**
+```
+/delete
+```
+
+Removes the conversation, its messages, and any cached state from siggy.
+Accepted conversations are deleted only locally; for pending message requests
+this also sends Signal's request-delete response so the sender stops appearing.
 
 **Search for a message:**
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -257,6 +257,7 @@ pub enum OverlayKind {
     PinDuration,
     ActionMenu,
     DeleteConfirm,
+    DeleteConversationConfirm,
     FilePicker,
     EmojiPicker,
     ReactionPicker,
@@ -2050,23 +2051,8 @@ impl App {
                 })
             }
             KeyCode::Char('d') => {
-                let is_group = self
-                    .store
-                    .conversations
-                    .get(&conv_id)
-                    .map(|c| c.is_group)
-                    .unwrap_or(false);
-                self.store.conversations.remove(&conv_id);
-                self.store.conversation_order.retain(|id| id != &conv_id);
-                self.scroll.positions.remove(&conv_id);
-                self.db_warn_visible(self.db.delete_conversation(&conv_id), "delete_conversation");
                 self.close_overlay();
-                self.active_conversation = None;
-                Some(SendRequest::MessageRequestResponse {
-                    recipient: conv_id,
-                    is_group,
-                    response_type: "delete".to_string(),
-                })
+                self.delete_active_conversation()
             }
             KeyCode::Esc => {
                 self.close_overlay();
@@ -3526,6 +3512,10 @@ impl App {
             }
             OverlayKind::DeleteConfirm => {
                 let send = self.handle_delete_confirm_key(code);
+                (true, send)
+            }
+            OverlayKind::DeleteConversationConfirm => {
+                let send = self.handle_delete_conversation_confirm_key(code);
                 (true, send)
             }
             OverlayKind::FilePicker => {
@@ -5060,6 +5050,81 @@ impl App {
                 None
             }
             _ => None,
+        }
+    }
+
+    /// Handle a key press in the delete-conversation confirmation overlay.
+    pub fn handle_delete_conversation_confirm_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+        match code {
+            KeyCode::Char('y') => {
+                self.close_overlay();
+                self.delete_active_conversation()
+            }
+            KeyCode::Char('n') | KeyCode::Esc => {
+                self.close_overlay();
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// Remove the active conversation from local state, the database, and any
+    /// cached side tables, then clear the composer.
+    ///
+    /// For unaccepted message requests this also returns a
+    /// `MessageRequestResponse { response_type: "delete" }` so signal-cli can
+    /// notify the server. For accepted conversations the deletion is purely
+    /// local.
+    pub(crate) fn delete_active_conversation(&mut self) -> Option<SendRequest> {
+        let conv_id = match self.active_conversation.clone() {
+            Some(id) => id,
+            None => {
+                self.status_message = "No active conversation to delete".to_string();
+                return None;
+            }
+        };
+
+        let (name, is_group, accepted) = match self.store.conversations.get(&conv_id) {
+            Some(conv) => (conv.name.clone(), conv.is_group, conv.accepted),
+            None => {
+                self.status_message = "Active conversation no longer exists".to_string();
+                self.active_conversation = None;
+                return None;
+            }
+        };
+
+        self.store.conversations.remove(&conv_id);
+        self.store.conversation_order.retain(|id| id != &conv_id);
+        self.store.last_read_index.remove(&conv_id);
+        self.store.has_more_messages.remove(&conv_id);
+        self.store.groups.remove(&conv_id);
+        self.scroll.positions.remove(&conv_id);
+        self.muted_conversations.remove(&conv_id);
+        self.blocked_conversations.remove(&conv_id);
+        self.db_warn_visible(self.db.delete_conversation(&conv_id), "delete_conversation");
+
+        self.active_conversation = None;
+        self.scroll.offset = 0;
+        self.scroll.focused_index = None;
+        self.pending_attachment = None;
+        self.reply_target = None;
+        self.editing_message = None;
+        self.reset_typing_with_stop();
+        self.clear_kitty_placements();
+        if self.is_overlay(OverlayKind::SidebarFilter) {
+            self.refresh_sidebar_filter();
+        }
+
+        self.status_message = format!("Deleted conversation \"{name}\"");
+
+        if !accepted {
+            Some(SendRequest::MessageRequestResponse {
+                recipient: conv_id,
+                is_group,
+                response_type: "delete".to_string(),
+            })
+        } else {
+            None
         }
     }
 
@@ -10301,11 +10366,25 @@ mod tests {
     fn delete_key_removes_conversation(mut app: App) {
         app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+1")));
         app.active_conversation = Some("+1".to_string());
+        // Pre-populate auxiliary state that the dedup with delete_active_conversation
+        // is supposed to clean up (regression guard for the partial cleanup the
+        // 'd' arm did before PR #312).
+        app.scroll.positions.insert("+1".to_string(), (3, Some(0)));
+        app.store.last_read_index.insert("+1".to_string(), 1);
+        app.store.has_more_messages.insert("+1".to_string());
+        app.muted_conversations
+            .insert("+1".to_string(), MuteState::Permanent);
+        app.blocked_conversations.insert("+1".to_string());
         app.open_overlay(OverlayKind::MessageRequest);
 
         let req = app.handle_message_request_key(KeyCode::Char('d'));
         assert!(!app.store.conversations.contains_key("+1"));
         assert!(!app.store.conversation_order.contains(&"+1".to_string()));
+        assert!(!app.scroll.positions.contains_key("+1"));
+        assert!(!app.store.last_read_index.contains_key("+1"));
+        assert!(!app.store.has_more_messages.contains("+1"));
+        assert!(!app.muted_conversations.contains_key("+1"));
+        assert!(!app.blocked_conversations.contains("+1"));
         assert!(app.active_conversation.is_none());
         assert!(!app.is_overlay(OverlayKind::MessageRequest));
         assert!(matches!(
@@ -10325,6 +10404,112 @@ mod tests {
         assert!(req.is_none());
         assert!(!app.is_overlay(OverlayKind::MessageRequest));
         assert!(app.active_conversation.is_none());
+    }
+
+    // --- /delete slash command + confirmation overlay (PR #312) ---
+
+    #[rstest]
+    fn slash_delete_opens_confirmation_overlay(mut app: App) {
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.input.buffer = "/delete".to_string();
+        app.input.cursor = 7;
+
+        let req = app.handle_input();
+
+        assert!(req.is_none());
+        assert!(app.is_overlay(OverlayKind::DeleteConversationConfirm));
+        // Confirmation overlay is just a prompt — must not delete yet.
+        assert!(app.store.conversations.contains_key("+1"));
+        assert_eq!(app.active_conversation.as_deref(), Some("+1"));
+    }
+
+    #[rstest]
+    fn slash_delete_without_active_conversation_sets_error(mut app: App) {
+        app.input.buffer = "/delete".to_string();
+        app.input.cursor = 7;
+
+        let req = app.handle_input();
+
+        assert!(req.is_none());
+        assert!(!app.is_overlay(OverlayKind::DeleteConversationConfirm));
+        assert!(app.status_message.contains("No active conversation"));
+    }
+
+    #[rstest]
+    fn delete_confirm_yes_removes_accepted_conversation(mut app: App) {
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.scroll.positions.insert("+1".to_string(), (3, Some(0)));
+        app.store.last_read_index.insert("+1".to_string(), 1);
+        app.open_overlay(OverlayKind::DeleteConversationConfirm);
+
+        let (handled, req) = app.handle_overlay_key(KeyCode::Char('y'));
+
+        assert!(handled);
+        // Accepted conversation: purely local, no remote response.
+        assert!(req.is_none());
+        assert!(!app.is_overlay(OverlayKind::DeleteConversationConfirm));
+        assert!(!app.store.conversations.contains_key("+1"));
+        assert!(!app.scroll.positions.contains_key("+1"));
+        assert!(!app.store.last_read_index.contains_key("+1"));
+        assert!(app.active_conversation.is_none());
+    }
+
+    #[rstest]
+    fn delete_confirm_yes_on_unaccepted_returns_remote_delete(mut app: App) {
+        app.handle_signal_event(SignalEvent::MessageReceived(msg_from("+15550007777")));
+        assert!(!app.store.conversations["+15550007777"].accepted);
+        app.active_conversation = Some("+15550007777".to_string());
+        app.open_overlay(OverlayKind::DeleteConversationConfirm);
+
+        let (_, req) = app.handle_overlay_key(KeyCode::Char('y'));
+
+        let Some(SendRequest::MessageRequestResponse {
+            recipient,
+            is_group,
+            response_type,
+        }) = req
+        else {
+            panic!("expected MessageRequestResponse(delete) for unaccepted conversation");
+        };
+        assert_eq!(recipient, "+15550007777");
+        assert!(!is_group);
+        assert_eq!(response_type, "delete");
+        assert!(!app.store.conversations.contains_key("+15550007777"));
+        assert!(app.active_conversation.is_none());
+    }
+
+    #[rstest]
+    fn delete_confirm_no_keeps_conversation(mut app: App) {
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.open_overlay(OverlayKind::DeleteConversationConfirm);
+
+        let (handled, req) = app.handle_overlay_key(KeyCode::Char('n'));
+
+        assert!(handled);
+        assert!(req.is_none());
+        assert!(!app.is_overlay(OverlayKind::DeleteConversationConfirm));
+        assert!(app.store.conversations.contains_key("+1"));
+        assert_eq!(app.active_conversation.as_deref(), Some("+1"));
+    }
+
+    #[rstest]
+    fn delete_confirm_esc_keeps_conversation(mut app: App) {
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.open_overlay(OverlayKind::DeleteConversationConfirm);
+
+        let (_, req) = app.handle_overlay_key(KeyCode::Esc);
+
+        assert!(req.is_none());
+        assert!(!app.is_overlay(OverlayKind::DeleteConversationConfirm));
+        assert!(app.store.conversations.contains_key("+1"));
     }
 
     #[rstest]

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -46,6 +46,14 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
             app.update_status();
             None
         }
+        InputAction::DeleteConversation => {
+            if app.active_conversation.is_some() {
+                app.open_overlay(OverlayKind::DeleteConversationConfirm);
+            } else {
+                app.status_message = "No active conversation to delete".to_string();
+            }
+            None
+        }
         InputAction::Quit => {
             if app.input.buffer.is_empty() || app.quit_confirm {
                 app.should_quit = true;

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,6 +27,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description: "Leave current conversation",
     },
     CommandInfo {
+        name: "/delete",
+        alias: "",
+        args: "",
+        description: "Delete current conversation",
+    },
+    CommandInfo {
         name: "/sidebar",
         alias: "/sb",
         args: "",
@@ -169,6 +175,8 @@ pub enum InputAction {
     Join(String),
     /// Leave current conversation (go back to no selection)
     Part,
+    /// Delete the current conversation (with confirmation)
+    DeleteConversation,
     /// Quit the application
     Quit,
     /// Toggle sidebar visibility
@@ -249,6 +257,7 @@ pub fn parse_input(input: &str) -> InputAction {
             }
         }
         "/part" | "/p" => InputAction::Part,
+        "/delete" => InputAction::DeleteConversation,
         "/quit" | "/q" => InputAction::Quit,
         "/sidebar" | "/sb" => InputAction::ToggleSidebar,
         "/bell" | "/notify" => {
@@ -480,6 +489,7 @@ mod tests {
     #[rstest]
     #[case("/part", InputAction::Part)]
     #[case("/p", InputAction::Part)]
+    #[case("/delete", InputAction::DeleteConversation)]
     #[case("/quit", InputAction::Quit)]
     #[case("/q", InputAction::Quit)]
     #[case("/sidebar", InputAction::ToggleSidebar)]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -21,6 +21,7 @@ use links::collect_link_regions;
 use overlays::about::draw_about;
 use overlays::action_menu::{draw_action_menu, draw_delete_confirm};
 use overlays::contacts::draw_contacts;
+use overlays::delete_conversation_confirm::draw_delete_conversation_confirm;
 use overlays::emoji_picker::draw_emoji_picker;
 use overlays::file_browser::draw_file_browser;
 use overlays::forward::draw_forward;
@@ -285,6 +286,11 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     // Delete confirmation overlay
     if app.is_overlay(OverlayKind::DeleteConfirm) {
         draw_delete_confirm(frame, app, size);
+    }
+
+    // Delete conversation confirmation overlay (/delete and message-request 'd')
+    if app.is_overlay(OverlayKind::DeleteConversationConfirm) {
+        draw_delete_conversation_confirm(frame, app, size);
     }
 
     // Theme picker overlay

--- a/src/ui/overlays/delete_conversation_confirm.rs
+++ b/src/ui/overlays/delete_conversation_confirm.rs
@@ -1,0 +1,46 @@
+//! Confirmation prompt for `/delete` (remove the active conversation).
+//!
+//! Accepted conversations show "Delete conversation locally?" because no
+//! network response is sent. Unaccepted message requests show "Delete and
+//! decline request?" because the underlying handler emits a
+//! `MessageRequestResponse { response_type: "delete" }` to signal-cli.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::Style,
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+
+use super::super::centered_popup;
+use crate::app::App;
+
+pub(in crate::ui) fn draw_delete_conversation_confirm(frame: &mut Frame, app: &App, area: Rect) {
+    let theme = &app.theme;
+    let accepted = app
+        .active_conversation
+        .as_deref()
+        .and_then(|id| app.store.conversations.get(id))
+        .map(|c| c.accepted)
+        .unwrap_or(true);
+
+    let prompt = if accepted {
+        "Delete conversation locally? (y)es / (n)o"
+    } else {
+        "Delete conversation and decline request? (y)es / (n)o"
+    };
+
+    let width = (prompt.len() as u16).saturating_add(6);
+    let (popup_area, block) = centered_popup(frame, area, width, 5, " Delete Conversation ", theme);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("  {prompt}"),
+            Style::default().fg(theme.fg),
+        )),
+    ];
+    let popup = Paragraph::new(lines).block(block);
+    frame.render_widget(popup, popup_area);
+}

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -25,6 +25,7 @@ pub(in crate::ui) fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
     let commands: &[(&str, &str)] = &[
         ("/join <name>", "Switch to a conversation"),
         ("/part", "Leave current conversation"),
+        ("/delete", "Delete current conversation"),
         ("/attach", "Attach a file"),
         ("/search <query>", "Search messages"),
         ("/sidebar", "Toggle sidebar visibility"),

--- a/src/ui/overlays/mod.rs
+++ b/src/ui/overlays/mod.rs
@@ -11,6 +11,7 @@
 pub(super) mod about;
 pub(super) mod action_menu;
 pub(super) mod contacts;
+pub(super) mod delete_conversation_confirm;
 pub(super) mod emoji_picker;
 pub(super) mod file_browser;
 pub(super) mod forward;

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
@@ -1,6 +1,5 @@
 ---
-source: src/ui.rs
-assertion_line: 5062
+source: src/ui/mod.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
@@ -8,28 +7,28 @@ expression: output
   • ##Family (2)     │││  Commands                                          │                      │
   • Carol (1)        │││  /join <name>        Switch to a conversation      │                      │
     ##Rust Devs      │││  /part               Leave current conversation    │                      │
-    Bob              │││  /attach             Attach a file                 │ run                  │
-▸   Alice            │││  /search <query>     Search messages               │d before 7            │
-    Dave             │││  /sidebar            Toggle sidebar visibility     │habit                 │
-                     │││  /bell [type]        Toggle notifications          │                      │
-                     │││  /mute               Mute/unmute conversation      │matic                 │
-                     │││  /contacts           Browse contacts               │                      │
-                     │││  /settings           Open settings                 │too                   │
+    Bob              │││  /delete             Delete current conversation   │ run                  │
+▸   Alice            │││  /attach             Attach a file                 │d before 7            │
+    Dave             │││  /search <query>     Search messages               │habit                 │
+                     │││  /sidebar            Toggle sidebar visibility     │                      │
+                     │││  /bell [type]        Toggle notifications          │matic                 │
+                     │││  /mute               Mute/unmute conversation      │                      │
+                     │││  /contacts           Browse contacts               │too                   │
+                     │││  /settings           Open settings                 │                      │
                      │││  /keybindings        Configure keybindings         │                      │
-                     │││  /quit               Exit siggy                    │                      │
-                     │││                                                    │ocalmarket.example.com│
-                     │││  Shortcuts                                         │                      │
-                     │││  Tab / Shift+Tab     Next / prev conversation      │ Saturday…            │
+                     │││  /quit               Exit siggy                    │ocalmarket.example.com│
+                     │││                                                    │                      │
+                     │││  Shortcuts                                         │ Saturday…            │
+                     │││  Tab / Shift+Tab     Next / prev conversation      │                      │
                      │││  Up / Down           Recall input history          │                      │
-                     │││  @                   Mention autocomplete          │                      │
-                     │││  PgUp / PgDn         Scroll messages               │ded.                  │
+                     │││  @                   Mention autocomplete          │ded.                  │
+                     │││  PgUp / PgDn         Scroll messages               │                      │
                      │││  Ctrl+Left / Ctrl+RightResize sidebar              │                      │
-                     │││  Ctrl+c              Quit                          │                      │
-                     │││                                                    │ to browse early      │
+                     │││  Ctrl+c              Quit                          │ to browse early      │
+                     │││                                                    │                      │
                      │││  Keybindings [Default]                             │                      │
-                     │││  Esc                 Normal mode                   │                      │
-                     │╰│  i / a / I / A / o   Insert mode                   │──────────────────────╯
-                     │╭│  Shift+Enter         Insert newline in input       │──────────────────────╮
-                     │││  Ctrl+e / Ctrl+y     Scroll up / down              │                      │
+                     │╰│  Esc                 Normal mode                   │──────────────────────╯
+                     │╭│  i / a / I / A / o   Insert mode                   │──────────────────────╮
+                     │││  Shift+Enter         Insert newline in input       │                      │
                      │╰╰────────────────────────────────────────────────────╯──────────────────────╯
  [INSERT] │  ● connected │ Alice │ 7 chats


### PR DESCRIPTION
## Summary

- Adds `/delete` slash command to remove the active conversation from local state, the SQLite store, and cached side tables (mute, block, scroll, last-read, groups, has-more).
- y/n confirmation overlay before deletion. Prompt text differentiates between accepted ("Delete conversation locally?") and unaccepted message requests ("Delete conversation and decline request?"), since unaccepted deletes also send Signal's request-delete response.
- Refactors `handle_message_request_key`'s `'d'` (decline) arm to call the same `delete_active_conversation` helper, so both deletion paths get the full cleanup (was previously clearing only 3 of the affected fields).

## Background

This rebuilds @jackplus-xyz's PR #312 on top of current master. The original branch was opened before significant refactoring (`src/ui.rs` was split into `src/ui/` with per-overlay submodules, `App::handle_input` was extracted into `src/handlers/input.rs`, snapshot path moved) and no longer rebases cleanly. Jack's design is preserved (slash command, confirmation overlay, `delete_active_conversation` helper); the implementation here adapts it to the new module structure. Jack is co-author on the commit. Closes #312.

## Differences from #312

- Uses the `OverlayKind` enum dispatcher instead of a `show_*: bool` flag, so the App field count baseline stays at 66.
- New file `src/ui/overlays/delete_conversation_confirm.rs` for the overlay drawer (rather than co-locating in action_menu.rs, since this overlay is unrelated to the action menu).
- Confirmation prompt text differentiates accepted vs unaccepted (one of the review items on #312).
- `handle_message_request_key`'s `'d'` arm now delegates to `delete_active_conversation()` so the message-request decline path also gets the thorough cleanup (the other review item on #312). The existing test for that path now asserts mute/block/scroll/last-read state is also cleared, as a regression guard.

## Test plan

- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `cargo test` passes (535 tests, +6 new)
- [x] `cargo fmt --check` passes
- [x] App field count baseline preserved (66/66)
- [ ] Manual TUI: `/delete` on accepted conversation removes it locally
- [ ] Manual TUI: `/delete` on unaccepted message request removes locally + sends decline response
- [ ] Manual TUI: pressing `'d'` on the message-request overlay still works the same as before