### PR TITLE
fix(ci): drop --locked from cargo-fuzz install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,11 @@ jobs:
           workspaces: fuzz
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        # Intentionally not --locked: cargo-fuzz's bundled lockfile pins
+        # rustix v0.36.5, which uses unstable `rustc_attrs` no longer
+        # accepted by current nightly. Resolving fresh transitive deps
+        # picks a rustix that compiles.
+        run: cargo install cargo-fuzz
 
       - name: Run ${{ matrix.target }}
         run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60


### PR DESCRIPTION
## Summary

All four fuzz CI jobs have been failing on master since the dependabot bumps merged (#406, #407). The failures are unrelated to those PRs and are pre-existing infrastructure breakage:

- `cargo install cargo-fuzz --locked` builds cargo-fuzz from source against its bundled `Cargo.lock`, which pins `rustix v0.36.5`.
- `rustix v0.36.5` uses unstable `rustc_attrs` attributes that current nightly Rust no longer accepts.
- The install step exits 101 before any fuzzing runs.

Dropping `--locked` lets cargo resolve fresh transitive deps and pick a newer `rustix` that compiles. The fuzz harnesses under `fuzz/` are unaffected since they have their own lockfile.

## Test plan

- [x] CI runs the fuzz jobs on this PR (will be visible once checks finish)

If we want a more robust fix later, we could switch to a precompiled cargo-fuzz binary (e.g. via `taiki-e/install-action`), but this single-line change unblocks current CI without churn.