### PR TITLE
fix: cap image-render input dims to unstick decode (#408)

### DIFF
--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -7,8 +7,9 @@
 
 use std::io::Cursor;
 use std::path::Path;
+use std::time::Instant;
 
-use image::GenericImageView;
+use image::{GenericImageView, ImageReader, Limits};
 use ratatui::{
     style::{Color, Style},
     text::{Line, Span},
@@ -387,9 +388,38 @@ pub fn kitty_id_color(image_id: u32) -> Color {
 /// Each terminal cell represents two vertical pixels using the upper-half-block
 /// character (▀) with the top pixel as foreground and bottom pixel as background.
 ///
-/// Returns `None` if the image cannot be loaded or decoded.
+/// Returns `None` if the image cannot be loaded or decoded, or if the source
+/// image exceeds `MAX_INPUT_DIM` on either axis. The size cap is defensive:
+/// a pathological link-preview og:image (e.g. a 30000×30000 promotional poster)
+/// can pin a `spawn_blocking` thread for minutes inside the resize step, and
+/// the output is at most a 30-cell column anyway. See issue #408.
 pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
-    let img = image::open(path).ok()?;
+    /// Largest input dimension we'll attempt to decode. Anything over this
+    /// is treated as a broken / hostile image and silently skipped.
+    const MAX_INPUT_DIM: u32 = 8192;
+
+    let start = Instant::now();
+    crate::debug_log::logf(format_args!(
+        "render_image start: path={} max_width={max_width}",
+        path.display()
+    ));
+
+    let mut reader = ImageReader::open(path).ok()?.with_guessed_format().ok()?;
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(MAX_INPUT_DIM);
+    limits.max_image_height = Some(MAX_INPUT_DIM);
+    reader.limits(limits);
+    let img = match reader.decode() {
+        Ok(img) => img,
+        Err(e) => {
+            crate::debug_log::logf(format_args!(
+                "render_image decode failed: path={} err={e} elapsed_ms={}",
+                path.display(),
+                start.elapsed().as_millis()
+            ));
+            return None;
+        }
+    };
 
     let cap_width = max_width;
     let cap_height: u32 = 60; // 30 cell-rows × 2 pixels per row
@@ -451,6 +481,15 @@ pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
         lines.push(Line::from(spans));
     }
 
+    crate::debug_log::logf(format_args!(
+        "render_image done: path={} elapsed_ms={} src={}x{} out={}x{}",
+        path.display(),
+        start.elapsed().as_millis(),
+        orig_w,
+        orig_h,
+        new_w,
+        new_h
+    ));
     Some(lines)
 }
 


### PR DESCRIPTION
## Summary

pcrockett's --debug log from #408 pinpoints the complex-conversation CPU pinning. With idle iter rate ~19 Hz and zero terminal/signal events, the smoking gun is \`bg_in_flight=1\` stuck for 70+ seconds:

\`\`\`
[06:02:38] loop 5s: iter=89 render=7 term_ev=6 sig_ev=0 bg_in_flight=1 active_conv=yes
[06:02:43] loop 5s: iter=91 render=4 term_ev=0 sig_ev=0 bg_in_flight=1 active_conv=yes
... bg_in_flight=1 sustained until quit
\`\`\`

That's one spawn_blocking image-decode task running forever -- almost certainly the resize step on a pathological link-preview og:image.

## Fix

\`image::Limits\` cap: reject any source > 8192px on either axis before decode. The render output is at most a 30-cell column so larger inputs are wasteful in the happy case and a hang risk in the unhappy case. Limits is checked at decode time -- a 50000x50000 PNG exits immediately instead of allocating ~10GB then iterating pixels.

Plus start/done debug log lines so the next \`--debug\` capture identifies the offending file by path and elapsed_ms. Turns "bg_in_flight=1 stuck" into a specific path the reporter can share, so we can root-cause if anything still hangs under the cap.

## Why 8192

- iPhone photo: 4032x3024 (well below)
- 4K image: 3840x2160 (well below)
- 8K image: 7680x4320 (just under cap)
- Anything bigger isn't a real-world photo or thumbnail; it's an attack on the decoder or an overzealous CMS

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --tests -- -D warnings
- [x] cargo test (536 passing, same as baseline)

Refs #408