### PR TITLE
refactor: extract pin/poll overlay key handlers into handlers/keys.rs (closes #417)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2430,7 +2430,7 @@ impl App {
             }
             "p" => {
                 // Pin/Unpin
-                self.execute_pin_toggle()
+                crate::handlers::keys::execute_pin_toggle(self)
             }
             "v" => {
                 // Vote on poll
@@ -3918,7 +3918,7 @@ impl App {
                 }
                 None
             }
-            Some(KeyAction::PinMessage) => self.execute_pin_toggle(),
+            Some(KeyAction::PinMessage) => crate::handlers::keys::execute_pin_toggle(self),
             Some(KeyAction::JumpToQuote) => {
                 self.jump_to_quote();
                 None
@@ -4124,7 +4124,7 @@ impl App {
                 }
                 None
             }
-            Some(KeyAction::PinMessage) => self.execute_pin_toggle(),
+            Some(KeyAction::PinMessage) => crate::handlers::keys::execute_pin_toggle(self),
             Some(KeyAction::JumpToQuote) => {
                 self.jump_to_quote();
                 None
@@ -4410,123 +4410,9 @@ impl App {
         }
     }
 
-    fn execute_pin_toggle(&mut self) -> Option<SendRequest> {
-        let msg = self.selected_message()?;
-        if msg.is_system || msg.is_deleted {
-            return None;
-        }
-        let was_pinned = msg.is_pinned;
-        let target_timestamp = msg.timestamp_ms;
-        let author_phone = msg.sender_id.clone();
-        let conv_id = self.active_conversation.clone()?;
-        let is_group = self
-            .store
-            .conversations
-            .get(&conv_id)
-            .map(|c| c.is_group)
-            .unwrap_or(false);
-
-        let target_author = if author_phone.is_empty() || author_phone == "you" {
-            self.account.clone()
-        } else {
-            author_phone
-        };
-
-        if was_pinned {
-            // Unpin immediately — no duration needed
-            if let Some(conv) = self.store.conversations.get_mut(&conv_id)
-                && let Some(idx) = conv.find_msg_idx(target_timestamp)
-            {
-                conv.messages[idx].is_pinned = false;
-            }
-            self.db_warn_visible(
-                self.db
-                    .set_message_pinned(&conv_id, target_timestamp, false),
-                "set_message_pinned",
-            );
-            self.scroll.offset = 0;
-            self.scroll.focused_index = None;
-            let body = "you unpinned a message";
-            let now = Utc::now();
-            let now_ms = now.timestamp_millis();
-            crate::handlers::signal::handle_system_message(self, &conv_id, body, now, now_ms);
-            Some(SendRequest::Unpin {
-                recipient: conv_id,
-                is_group,
-                target_author,
-                target_timestamp,
-            })
-        } else {
-            // Open pin duration picker
-            self.pin_duration.pending = Some(PinPending {
-                conv_id,
-                is_group,
-                target_author,
-                target_timestamp,
-            });
-            self.open_overlay(OverlayKind::PinDuration);
-            self.pin_duration.index = 0;
-            None
-        }
-    }
-
     /// Handle a key press while the pin duration picker overlay is open.
     pub fn handle_pin_duration_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        match classify_list_key(code, false) {
-            ListKeyAction::Down => {
-                if self.pin_duration.index < PIN_DURATIONS.len() - 1 {
-                    self.pin_duration.index += 1;
-                }
-                None
-            }
-            ListKeyAction::Up => {
-                self.pin_duration.index = self.pin_duration.index.saturating_sub(1);
-                None
-            }
-            ListKeyAction::Select => {
-                let duration = PIN_DURATIONS[self.pin_duration.index].0;
-                self.close_overlay();
-                let pending = self.pin_duration.pending.take()?;
-
-                // Optimistically pin
-                if let Some(conv) = self.store.conversations.get_mut(&pending.conv_id)
-                    && let Some(idx) = conv.find_msg_idx(pending.target_timestamp)
-                {
-                    conv.messages[idx].is_pinned = true;
-                }
-                self.db_warn_visible(
-                    self.db
-                        .set_message_pinned(&pending.conv_id, pending.target_timestamp, true),
-                    "set_message_pinned",
-                );
-                self.scroll.offset = 0;
-                self.scroll.focused_index = None;
-                let body = "you pinned a message";
-                let now = Utc::now();
-                let now_ms = now.timestamp_millis();
-                crate::handlers::signal::handle_system_message(
-                    self,
-                    &pending.conv_id,
-                    body,
-                    now,
-                    now_ms,
-                );
-
-                Some(SendRequest::Pin {
-                    recipient: pending.conv_id,
-                    is_group: pending.is_group,
-                    target_author: pending.target_author,
-                    target_timestamp: pending.target_timestamp,
-                    pin_duration: duration,
-                })
-            }
-            ListKeyAction::Close => {
-                self.close_overlay();
-                self.pin_duration.pending = None;
-                None
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_pin_duration_key(self, code)
     }
 
     /// Handle keys in the profile editor overlay.
@@ -4594,80 +4480,9 @@ impl App {
         None
     }
 
+    /// Handle a key press while the poll vote overlay is open.
     pub fn handle_poll_vote_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        let pending = self.poll_vote.pending.as_ref()?;
-        let option_count = pending.options.len();
-        match code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.poll_vote.index < option_count.saturating_sub(1) {
-                    self.poll_vote.index += 1;
-                }
-                None
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.poll_vote.index = self.poll_vote.index.saturating_sub(1);
-                None
-            }
-            KeyCode::Char(' ') => {
-                let allow_multiple = pending.allow_multiple;
-                if allow_multiple {
-                    if let Some(sel) = self.poll_vote.selections.get_mut(self.poll_vote.index) {
-                        *sel = !*sel;
-                    }
-                } else {
-                    // Single select: clear all, select current
-                    for sel in &mut self.poll_vote.selections {
-                        *sel = false;
-                    }
-                    if let Some(sel) = self.poll_vote.selections.get_mut(self.poll_vote.index) {
-                        *sel = true;
-                    }
-                }
-                None
-            }
-            KeyCode::Enter => {
-                let selected: Vec<i64> = self
-                    .poll_vote
-                    .selections
-                    .iter()
-                    .enumerate()
-                    .filter(|&(_, &sel)| sel)
-                    .map(|(i, _)| i as i64)
-                    .collect();
-                if selected.is_empty() {
-                    return None;
-                }
-                let pending = self.poll_vote.pending.take()?;
-                self.close_overlay();
-
-                // Optimistic local vote
-                let voter = self.account.clone();
-                crate::handlers::signal::handle_poll_vote(
-                    self,
-                    &pending.conv_id,
-                    pending.poll_timestamp,
-                    &voter,
-                    None,
-                    &selected,
-                    1,
-                );
-
-                Some(SendRequest::PollVote {
-                    recipient: pending.conv_id,
-                    is_group: pending.is_group,
-                    poll_author: pending.poll_author,
-                    poll_timestamp: pending.poll_timestamp,
-                    option_indexes: selected,
-                    vote_count: 1,
-                })
-            }
-            KeyCode::Esc => {
-                self.close_overlay();
-                self.poll_vote.pending = None;
-                None
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_poll_vote_key(self, code)
     }
 
     /// Prepare outgoing mentions: replace @Name with U+FFFC and compute UTF-16 offsets.

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -1,0 +1,207 @@
+//! Overlay key and action handlers extracted from `App`.
+//!
+//! These are user-initiated actions on existing messages -- pinning, unpinning,
+//! and voting in polls. They sit alongside `handlers/input.rs` (composer text
+//! dispatch) and `handlers/signal.rs` (signal-cli event dispatch). Splitting
+//! them out lets `handlers::signal::handle_system_message` and
+//! `handlers::signal::handle_poll_vote` return to private visibility -- those
+//! calls are now internal to `handlers::keys` rather than crossing the
+//! `app.rs` boundary.
+
+use chrono::Utc;
+use crossterm::event::KeyCode;
+
+use crate::app::{App, OverlayKind, PIN_DURATIONS, PinPending, SendRequest};
+use crate::list_overlay::{ListKeyAction, classify_list_key};
+
+/// Toggle the pinned state of the currently focused message. For unpinning,
+/// this runs the local update immediately. For pinning, it opens the duration
+/// picker overlay and defers the actual pin until the user selects a duration.
+pub(crate) fn execute_pin_toggle(app: &mut App) -> Option<SendRequest> {
+    let msg = app.selected_message()?;
+    if msg.is_system || msg.is_deleted {
+        return None;
+    }
+    let was_pinned = msg.is_pinned;
+    let target_timestamp = msg.timestamp_ms;
+    let author_phone = msg.sender_id.clone();
+    let conv_id = app.active_conversation.clone()?;
+    let is_group = app
+        .store
+        .conversations
+        .get(&conv_id)
+        .map(|c| c.is_group)
+        .unwrap_or(false);
+
+    let target_author = if author_phone.is_empty() || author_phone == "you" {
+        app.account.clone()
+    } else {
+        author_phone
+    };
+
+    if was_pinned {
+        // Unpin immediately -- no duration needed.
+        if let Some(conv) = app.store.conversations.get_mut(&conv_id)
+            && let Some(idx) = conv.find_msg_idx(target_timestamp)
+        {
+            conv.messages[idx].is_pinned = false;
+        }
+        app.db_warn_visible(
+            app.db.set_message_pinned(&conv_id, target_timestamp, false),
+            "set_message_pinned",
+        );
+        app.scroll.offset = 0;
+        app.scroll.focused_index = None;
+        let body = "you unpinned a message";
+        let now = Utc::now();
+        let now_ms = now.timestamp_millis();
+        super::signal::handle_system_message(app, &conv_id, body, now, now_ms);
+        Some(SendRequest::Unpin {
+            recipient: conv_id,
+            is_group,
+            target_author,
+            target_timestamp,
+        })
+    } else {
+        // Open pin duration picker.
+        app.pin_duration.pending = Some(PinPending {
+            conv_id,
+            is_group,
+            target_author,
+            target_timestamp,
+        });
+        app.open_overlay(OverlayKind::PinDuration);
+        app.pin_duration.index = 0;
+        None
+    }
+}
+
+/// Handle a key press while the pin duration picker overlay is open.
+pub fn handle_pin_duration_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    match classify_list_key(code, false) {
+        ListKeyAction::Down => {
+            if app.pin_duration.index < PIN_DURATIONS.len() - 1 {
+                app.pin_duration.index += 1;
+            }
+            None
+        }
+        ListKeyAction::Up => {
+            app.pin_duration.index = app.pin_duration.index.saturating_sub(1);
+            None
+        }
+        ListKeyAction::Select => {
+            let duration = PIN_DURATIONS[app.pin_duration.index].0;
+            app.close_overlay();
+            let pending = app.pin_duration.pending.take()?;
+
+            // Optimistically pin.
+            if let Some(conv) = app.store.conversations.get_mut(&pending.conv_id)
+                && let Some(idx) = conv.find_msg_idx(pending.target_timestamp)
+            {
+                conv.messages[idx].is_pinned = true;
+            }
+            app.db_warn_visible(
+                app.db
+                    .set_message_pinned(&pending.conv_id, pending.target_timestamp, true),
+                "set_message_pinned",
+            );
+            app.scroll.offset = 0;
+            app.scroll.focused_index = None;
+            let body = "you pinned a message";
+            let now = Utc::now();
+            let now_ms = now.timestamp_millis();
+            super::signal::handle_system_message(app, &pending.conv_id, body, now, now_ms);
+
+            Some(SendRequest::Pin {
+                recipient: pending.conv_id,
+                is_group: pending.is_group,
+                target_author: pending.target_author,
+                target_timestamp: pending.target_timestamp,
+                pin_duration: duration,
+            })
+        }
+        ListKeyAction::Close => {
+            app.close_overlay();
+            app.pin_duration.pending = None;
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Handle a key press while the poll vote overlay is open.
+pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    let pending = app.poll_vote.pending.as_ref()?;
+    let option_count = pending.options.len();
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            if app.poll_vote.index < option_count.saturating_sub(1) {
+                app.poll_vote.index += 1;
+            }
+            None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.poll_vote.index = app.poll_vote.index.saturating_sub(1);
+            None
+        }
+        KeyCode::Char(' ') => {
+            let allow_multiple = pending.allow_multiple;
+            if allow_multiple {
+                if let Some(sel) = app.poll_vote.selections.get_mut(app.poll_vote.index) {
+                    *sel = !*sel;
+                }
+            } else {
+                // Single select: clear all, select current.
+                for sel in &mut app.poll_vote.selections {
+                    *sel = false;
+                }
+                if let Some(sel) = app.poll_vote.selections.get_mut(app.poll_vote.index) {
+                    *sel = true;
+                }
+            }
+            None
+        }
+        KeyCode::Enter => {
+            let selected: Vec<i64> = app
+                .poll_vote
+                .selections
+                .iter()
+                .enumerate()
+                .filter(|&(_, &sel)| sel)
+                .map(|(i, _)| i as i64)
+                .collect();
+            if selected.is_empty() {
+                return None;
+            }
+            let pending = app.poll_vote.pending.take()?;
+            app.close_overlay();
+
+            // Optimistic local vote.
+            let voter = app.account.clone();
+            super::signal::handle_poll_vote(
+                app,
+                &pending.conv_id,
+                pending.poll_timestamp,
+                &voter,
+                None,
+                &selected,
+                1,
+            );
+
+            Some(SendRequest::PollVote {
+                recipient: pending.conv_id,
+                is_group: pending.is_group,
+                poll_author: pending.poll_author,
+                poll_timestamp: pending.poll_timestamp,
+                option_indexes: selected,
+                vote_count: 1,
+            })
+        }
+        KeyCode::Esc => {
+            app.close_overlay();
+            app.poll_vote.pending = None;
+            None
+        }
+        _ => None,
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -6,4 +6,5 @@
 //! same global state.
 
 pub(crate) mod input;
+pub(crate) mod keys;
 pub(crate) mod signal;

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -754,7 +754,7 @@ fn handle_message(app: &mut App, msg: SignalMessage) {
     apply_notification_policy(app, &resolved, is_active, conv_accepted);
 }
 
-pub(crate) fn handle_system_message(
+pub(super) fn handle_system_message(
     app: &mut App,
     conv_id: &str,
     body: &str,
@@ -957,7 +957,7 @@ fn handle_poll_created(app: &mut App, conv_id: &str, timestamp: i64, poll_data: 
     );
 }
 
-pub(crate) fn handle_poll_vote(
+pub(super) fn handle_poll_vote(
     app: &mut App,
     conv_id: &str,
     target_timestamp: i64,


### PR DESCRIPTION
## Summary

Last bidirectional dep between app.rs and handlers::signal goes away. \`execute_pin_toggle\`, \`handle_pin_duration_key\`, and \`handle_poll_vote_key\` move out of impl App into a new \`src/handlers/keys.rs\` module. They were the only callers of \`handle_system_message\` and \`handle_poll_vote\` from outside \`handlers/signal.rs\`, which was forcing those two functions to be pub(crate). With the call sites now in a sibling module under \`handlers/\`, those targets drop to pub(super) -- visible inside the handlers/ tree, private from app.rs and the rest of the crate.

\`handle_signal_event\` is now the only handlers::signal symbol exposed to the rest of the crate.

## Shape

- New \`src/handlers/keys.rs\` (195 lines) holding the three free functions
- \`App::handle_pin_duration_key\` and \`App::handle_poll_vote_key\` are thin shims so the main event loop call sites don't change
- \`execute_pin_toggle\` was private to begin with, so its three intra-app callers get rewritten to \`crate::handlers::keys::execute_pin_toggle(self)\`
- \`handle_system_message\` and \`handle_poll_vote\` in handlers/signal.rs go from pub(crate) to pub(super)

## Stats

- src/app.rs: -193 +6 (net -187)
- src/handlers/keys.rs: +195 new
- src/handlers/signal.rs: +/-2 (visibility narrowing)
- src/handlers/mod.rs: +1 (register submodule)
- 548 tests still passing
- clippy --tests -- -D warnings clean
- App field-count baseline 66/66 unchanged

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --tests -- -D warnings
- [x] cargo test
- [x] scripts/check-app-field-count.sh

Closes #417