### PR TITLE
fix: persist wire-quote on body row only, not attachment rows (closes #423)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10818,4 +10818,54 @@ mod tests {
         let idx = conv.find_msg_idx(ts).expect("group message present");
         assert_eq!(conv.messages[idx].status, Some(MessageStatus::Read));
     }
+
+    #[rstest]
+    fn wire_quote_attached_to_body_row_not_attachment_row(mut app: App) {
+        // Regression for #423: a message with a body + image attachment + quote
+        // should persist the wire-quote on the body row only. The attachment
+        // row's quote_author / quote_body / quote_ts_ms columns must be NULL
+        // so a reload from DB doesn't render a duplicate quote on the
+        // attachment message.
+        let ts = 1_700_000_040_000;
+        let quote_ts = ts - 1000;
+        let mut m = make_msg_with_ts("+1", Some("see this"), None, false, ts);
+        m.source_name = Some("Alice".to_string());
+        m.quote = Some((quote_ts, "+2".to_string(), "original".to_string()));
+        m.attachments = vec![Attachment {
+            id: "att1".to_string(),
+            content_type: "image/png".to_string(),
+            filename: Some("pic.png".to_string()),
+            local_path: None,
+        }];
+        app.handle_signal_event(SignalEvent::MessageReceived(m));
+
+        // Read what was persisted. load_messages_page reconstructs the quote
+        // field from the quote_* DB columns, so it accurately reflects what
+        // we wrote.
+        let rows = app
+            .db
+            .load_messages_page("+1", 100, 0)
+            .expect("DB query succeeds");
+        assert_eq!(rows.len(), 2, "body + one attachment row");
+
+        // Body row carries the wire-quote.
+        let body_row = rows
+            .iter()
+            .find(|r| !r.body.starts_with('['))
+            .expect("body row present");
+        let q = body_row.quote.as_ref().expect("body row has quote");
+        assert_eq!(q.body, "original");
+        assert_eq!(q.timestamp_ms, quote_ts);
+
+        // Attachment row does NOT carry the wire-quote.
+        let attachment_row = rows
+            .iter()
+            .find(|r| r.body.starts_with("[image:"))
+            .expect("attachment row present");
+        assert!(
+            attachment_row.quote.is_none(),
+            "attachment row should not carry wire-quote columns; got {:?}",
+            attachment_row.quote
+        );
+    }
 }

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -573,6 +573,12 @@ fn push_resolved(app: &mut App, r: &ResolvedMessage, is_active: bool) -> bool {
         .pending_polls
         .remove(&(r.conv_id.clone(), r.msg_ts_ms));
 
+    // Likewise, the wire-quote belongs to the message as a whole, not per-entry.
+    // Hand it to on_message_added on the first entry only -- attachment rows that
+    // followed historically had the same quote_author/body/ts columns populated
+    // which produced duplicate quote rendering on reload.
+    let mut entry_wire_quote = Some(r.wire_quote.clone());
+
     // Append each entry as a DisplayMessage in push order.
     for entry in &r.entries {
         let display = DisplayMessage {
@@ -602,7 +608,8 @@ fn push_resolved(app: &mut App, r: &ResolvedMessage, is_active: bool) -> bool {
             preview_image_lines: None,
             preview_image_path: None,
         };
-        app.on_message_added(&r.conv_id, display, r.wire_quote.clone(), true);
+        let wq = entry_wire_quote.take().unwrap_or_default();
+        app.on_message_added(&r.conv_id, display, wq, true);
     }
 
     // Persist raw body + mentions so the display body can be re-resolved


### PR DESCRIPTION
## Summary

What started as the M5 cleanup from PR #421 (skip wire_quote.clone() for attachment iterations) turned out to fix a latent bug: the DB-write side of the loop was persisting quote_author / quote_body / quote_ts_ms onto every row from a multi-entry message, not just the body row. The in-memory display_quote was already correctly None for attachments, but load_messages_page reconstructs DisplayMessage.quote from those DB columns on reload -- so after a restart, the chat pane would render the same quote on the body AND on each attachment of the same message. Pre-existing behavior; this PR fixes it.

## Fix

\`push_resolved\` now hands the wire-quote to the first \`on_message_added\` call only. The first entry is the body when present, otherwise the first attachment, so a body-less-quote-reply (image attachment with no text but with a quote) still attaches the quote to the first attachment row, matching the pre-fix post-restart behavior in that edge case.

## Regression test

Added \`wire_quote_attached_to_body_row_not_attachment_row\`:
- Fires a body + image attachment + quote message
- Calls \`db.load_messages_page\` to inspect persisted state
- Asserts the body row has \`quote = Some(...)\` and the attachment row has \`quote = None\`
- Test fails on master (attachment row would also have the quote populated)

## Stats

- 548 -> 549 tests
- src/handlers/signal.rs: +8 -2
- src/app.rs: +50 (test only)
- App field-count baseline 66/66 unchanged
- cargo fmt --check clean
- cargo clippy --tests -- -D warnings clean

## Test plan

- [x] cargo fmt --check
- [x] cargo clippy --tests -- -D warnings
- [x] cargo test

Closes #423