### PR TITLE
feat: --reset-lock CLI flag for forgotten passphrase recovery (closes #442)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,13 +165,15 @@ All fields are optional. `signal_cli_path` defaults to `"signal-cli"` (found via
 | `/contacts` | `/c` | Browse synced contacts |
 | `/settings` | | Open settings overlay |
 | `/lock` | | Lock the session |
-| `/lock-reset` | | Change the lock passphrase |
+| `/lock-reset` | | Change the lock passphrase (needs current passphrase) |
 | `/help` | `/h` | Show help overlay |
 | `/quit` | `/q` | Exit siggy |
 
 Type `/` to open the autocomplete popup. Use `Tab` to complete, arrow keys to navigate.
 
 To message a new contact: `/join +15551234567` (E.164 format).
+
+**Forgot your lock passphrase?** Quit siggy (or kill the process) and run `siggy --reset-lock`. It deletes the stored passphrase hash and prints the path it removed. The next `/lock` will set a fresh passphrase.
 
 ## Keyboard Shortcuts
 

--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -29,7 +29,7 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 | `/contacts` | `/c` | | Browse synced contacts |
 | `/settings` | | | Open settings overlay |
 | `/lock` | | | Lock the session |
-| `/lock-reset` | | | Change the lock passphrase |
+| `/lock-reset` | | | Change the lock passphrase (needs current passphrase) |
 | `/help` | `/h` | | Show help overlay |
 | `/quit` | `/q` | | Exit siggy |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,7 @@ async fn main() -> Result<()> {
     let mut incognito = false;
     let mut debug = false;
     let mut debug_full = false;
+    let mut reset_lock = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -144,6 +145,10 @@ async fn main() -> Result<()> {
                 debug_full = true;
                 i += 1;
             }
+            "--reset-lock" => {
+                reset_lock = true;
+                i += 1;
+            }
             "--help" => {
                 eprintln!("siggy - Terminal Signal client");
                 eprintln!();
@@ -159,6 +164,7 @@ async fn main() -> Result<()> {
                 eprintln!("      --incognito         No local message storage (in-memory only)");
                 eprintln!("      --debug             Write debug log (PII redacted)");
                 eprintln!("      --debug-full        Write debug log (full, unredacted)");
+                eprintln!("      --reset-lock        Delete the session-lock passphrase and exit");
                 eprintln!("      --help              Show this help");
                 std::process::exit(0);
             }
@@ -182,6 +188,21 @@ async fn main() -> Result<()> {
         Some(p) => std::path::PathBuf::from(p),
         None => Config::default_config_path(),
     };
+
+    if reset_lock {
+        let hash_path = domain::lock_hash_path(&resolved_config_path);
+        if hash_path.exists() {
+            std::fs::remove_file(&hash_path)?;
+            println!("Removed lock hash: {}", hash_path.display());
+        } else {
+            println!(
+                "No lock hash to remove (looked for {})",
+                hash_path.display()
+            );
+        }
+        return Ok(());
+    }
+
     let mut config = Config::load(config_path)?;
     if let Some(acct) = account {
         config.account = acct;


### PR DESCRIPTION
## Summary

- Adds a `siggy --reset-lock` CLI flag that deletes the session-lock passphrase hash and exits before any TUI setup.
- Resolves the hash path via the existing `domain::lock_hash_path()` helper so the CLI and runtime always agree on where the file lives.
- Prints the path it removed (or a no-op message if nothing was there) for transparency.
- Updates README and commands.md to note `/lock-reset` requires the current passphrase, and to point at the new flag as the escape hatch.

## Context

Follow-up from #437 review (shwoop). The lock feature intentionally has no in-app recovery: the passphrase is only ever stored as an argon2 PHC hash, and a backdoor would defeat the point. But the manual recovery path (delete `{config_dir}/lock_hash`) was undocumented and required knowing the platform-specific path. This flag does the lookup and the delete in one go.

## Test plan

- [x] `cargo run -- --reset-lock` with no hash file prints `No lock hash to remove (looked for ...)` and exits 0.
- [x] `cargo run -- --reset-lock` with a hash file deletes it and prints `Removed lock hash: ...`.
- [x] `cargo run -- --help` lists `--reset-lock`.
- [x] `cargo clippy --tests -- -D warnings` clean.
- [x] `cargo test` 559/559 passing.
- [x] `cargo fmt --check` clean.
- [x] App field-count ratchet 67/67.