### PR TITLE
fix(deps): bump rand 0.8.5 to 0.8.6 (GHSA-cq8v-f236-94qc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,7 +1851,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2060,9 +2060,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]


### PR DESCRIPTION
## Summary

Bumps `rand` 0.8.5 -> 0.8.6 to clear [GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc) (low severity, dependabot alert #5).

## Impact assessment

The advisory describes unsoundness when `rand::rng()` is re-entered through a custom logger. Real impact on siggy is essentially nil: the vulnerable `rand 0.8.5` is pulled in only through a build-time-only proc-macro chain.

Dependency path:

```
termwiz -> pest_derive -> pest_generator -> pest_meta
       -> phf 0.11.3 -> phf_codegen -> phf_generator -> rand 0.8.5
```

That runs inside proc-macro and build.rs invocations to generate static hash tables at compile time. None of it ships in the compiled binary, and the unsoundness requires a user-controlled custom logger that re-enters rand, which is impossible at proc-macro expansion. Bumping anyway to clear the advisory and stay current.

## Change

`cargo update -p rand@0.8.5`. Cargo.lock only, no manifest edits required.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test` 559/559 passing
- [x] No `rand 0.8.5` remaining in `Cargo.lock`; `rand 0.9.3` (the runtime one used elsewhere) untouched