### PR TITLE
fix(main): advance spinner counter during sync to remove startup freeze (closes #426)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -5365,14 +5365,16 @@ impl App {
         }
     }
 
-    /// Whether the startup spinner should advance this event-loop tick.
+    /// Whether the startup spinner should force a redraw on this tick.
     ///
-    /// Pauses during the initial sync burst (`sync.active`). The event loop
-    /// polls every 50ms, and ticking the spinner unconditionally on every
-    /// iteration sets `needs_redraw = true`, which bypasses the 500ms sync
-    /// redraw throttle in `drain_events`. The status bar already shows
-    /// "Syncing... (N messages received)" during sync, so the spinner adds
-    /// no information; pausing it lets the throttle actually take effect.
+    /// The spinner's *counter* advances at 80ms cadence whenever `loading`
+    /// is true (see main.rs and #426), but the *redraw* it triggers is gated
+    /// here. During the initial sync burst (`sync.active`), drain_events
+    /// throttles redraws to 500ms so the UI stays responsive; forcing a
+    /// redraw on every spinner tick (12.5fps) would bypass that throttle.
+    /// Returning false during sync defers spinner rendering to the next
+    /// throttled redraw, which still picks up the advanced counter value
+    /// -- so the spinner animates at ~2fps during sync, 12.5fps after.
     pub fn should_tick_spinner(&self) -> bool {
         self.loading && !self.sync.active
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1265,7 +1265,13 @@ async fn run_app(
 
     let mut last_expiry_sweep = Instant::now();
     let mut last_sync_redraw = Instant::now();
-    let mut last_spinner_tick = Instant::now();
+    // Initialise far enough in the past that the spinner ticks on the very
+    // first loop iteration. Without this the spinner sits on frame 0 for the
+    // first 80ms after entering run_app, which on slow hardware looks like a
+    // freeze before any animation starts (#426).
+    let mut last_spinner_tick = Instant::now()
+        .checked_sub(Duration::from_millis(80))
+        .unwrap_or_else(Instant::now);
     let mut needs_redraw = true;
     let mut last_title: Option<String> = None;
     // Loop-rate diagnostics: only counted/logged when --debug is on. Helps
@@ -1358,10 +1364,19 @@ async fn run_app(
         // collapses bursts of input into a single outer iteration, which
         // would otherwise tie the spinner to "events arrived" rather than
         // "time passed". 80ms = 12.5fps, brisk but not frantic.
-        if app.should_tick_spinner() && last_spinner_tick.elapsed() >= Duration::from_millis(80) {
+        //
+        // The counter advances whenever loading=true regardless of sync state
+        // (see #426 -- otherwise the spinner appears frozen during the initial
+        // sync burst). The redraw, however, only fires outside sync so the
+        // 500ms sync redraw throttle in drain_events still applies (see #326).
+        // During sync the spinner therefore animates at ~2fps (one frame per
+        // throttled redraw), and at 12.5fps after sync ends.
+        if app.loading && last_spinner_tick.elapsed() >= Duration::from_millis(80) {
             app.spinner_tick = app.spinner_tick.wrapping_add(1);
             last_spinner_tick = Instant::now();
-            needs_redraw = true;
+            if app.should_tick_spinner() {
+                needs_redraw = true;
+            }
         }
 
         // Load older messages when scrolled to the top


### PR DESCRIPTION
## Summary

Fixes pcrockett's startup-freeze observation reported on a 2008 ThinkPad after #414 (steady-state cadence) and #425 (image-decode cap) landed:

> Spinner still an issue -- On first start it froze at first, then started spinning, then showed the welcome page. On second start it just froze and then showed the welcome page (no spinning).

## Root cause

`should_tick_spinner` returned `false` while `sync.active=true`, which was both:
- **Intentional** -- to prevent the 80ms spinner tick from bypassing the 500ms sync redraw throttle from #326.
- **A bug** -- it also prevented the spinner *counter* from advancing, so during the entire sync burst the spinner sat on frame 0.

`SyncState::new()` initialises `active=true`, so on startup the spinner sat on frame 0 until sync ended. That is exactly what pcrockett saw on slow hardware where the sync burst is long enough to notice.

## Fix

Decouple "advance counter" from "force redraw":

- `main.rs`: `spinner_tick` now advances whenever `app.loading`, every 80ms, regardless of sync state.
- `main.rs`: `needs_redraw` is set on tick **only** when `should_tick_spinner` returns true (`loading && !sync.active`), preserving the #326 throttle guarantee.

Result: during sync the spinner animates at ~2fps (one frame per throttled redraw); after sync at 12.5fps. No more perceived freeze.

Also fixed a smaller first-frame issue: initialise `last_spinner_tick` to 80ms in the past so the very first loop iteration ticks immediately, instead of holding frame 0 for the first 80ms after entering `run_app`.

## Compatibility

`should_tick_spinner` keeps its existing return semantics so all three existing tests pass unchanged. Only its docstring is updated to describe its new role (redraw gating, not counter gating).

## Test plan

- [x] `cargo test` 559/559 passing.
- [x] `cargo clippy --tests -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] Real-world: pcrockett to retest on the ThinkPad. The signal will be the spinner animating throughout sync rather than appearing frozen.