### PR TITLE
refactor: notification_preview + image_mode stringly-typed -> enums

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -211,33 +211,23 @@ pub(crate) fn show_desktop_notification(
     body: &str,
     is_group: bool,
     group_name: Option<&str>,
-    preview_level: &str,
+    preview_level: crate::domain::NotificationPreview,
 ) {
+    use crate::domain::NotificationPreview;
+    let sender_title = || -> String {
+        if is_group {
+            match group_name {
+                Some(gn) => format!("{} - {}", gn, sender),
+                None => sender.to_string(),
+            }
+        } else {
+            sender.to_string()
+        }
+    };
     let (title, preview) = match preview_level {
-        "minimal" => ("New message".to_string(), String::new()),
-        "sender" => {
-            let t = if is_group {
-                match group_name {
-                    Some(gn) => format!("{} — {}", gn, sender),
-                    None => sender.to_string(),
-                }
-            } else {
-                sender.to_string()
-            };
-            (t, "New message".to_string())
-        }
-        _ => {
-            // "full" or any unknown value — current behavior
-            let t = if is_group {
-                match group_name {
-                    Some(gn) => format!("{} — {}", gn, sender),
-                    None => sender.to_string(),
-                }
-            } else {
-                sender.to_string()
-            };
-            (t, body.chars().take(100).collect())
-        }
+        NotificationPreview::Minimal => ("New message".to_string(), String::new()),
+        NotificationPreview::Sender => (sender_title(), "New message".to_string()),
+        NotificationPreview::Full => (sender_title(), body.chars().take(100).collect()),
     };
 
     tokio::task::spawn_blocking(move || {
@@ -929,8 +919,8 @@ impl App {
         config.theme = self.theme.name.clone();
         config.keybinding_profile = self.keybindings.profile_name.clone();
         config.settings_profile = self.settings_profiles.name.clone();
-        config.notification_preview = self.notifications.notification_preview.clone();
-        config.image_mode = self.image.image_mode.clone();
+        config.notification_preview = self.notifications.notification_preview;
+        config.image_mode = Some(self.image.image_mode);
         config.sidebar_width = self.sidebar_width;
         for def in SETTINGS {
             if let Some(save_fn) = def.save {
@@ -985,7 +975,7 @@ impl App {
             }
         }
 
-        if self.image.image_mode == "none" {
+        if self.image.image_mode == crate::domain::ImageMode::None {
             return drained;
         }
         let Some(ref id) = self.active_conversation else {
@@ -1032,7 +1022,7 @@ impl App {
         }
 
         // Spawn background render tasks
-        let is_native = self.image.image_mode == "native";
+        let is_native = self.image.image_mode == crate::domain::ImageMode::Native;
         let is_sixel = self.image.image_protocol == image_render::ImageProtocol::Sixel;
         let cell_px = self.image.cell_px;
         for (ts, path, max_width, is_preview) in work {
@@ -1117,17 +1107,9 @@ impl App {
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
                 if self.settings_overlay.index == preview_index {
                     self.notifications.notification_preview =
-                        match self.notifications.notification_preview.as_str() {
-                            "full" => "sender".to_string(),
-                            "sender" => "minimal".to_string(),
-                            _ => "full".to_string(),
-                        };
+                        self.notifications.notification_preview.cycle();
                 } else if self.settings_overlay.index == image_mode_index {
-                    self.image.image_mode = match self.image.image_mode.as_str() {
-                        "native" => "halfblock".to_string(),
-                        "halfblock" => "none".to_string(),
-                        _ => "native".to_string(),
-                    };
+                    self.image.image_mode = self.image.image_mode.cycle();
                 } else if self.settings_overlay.index == customize_index {
                     self.open_overlay(OverlayKind::Customize);
                     self.settings_overlay.customize_index = 0;
@@ -3300,7 +3282,13 @@ impl App {
                     "conversations"
                 };
                 let body = format!("{total} new messages in {conv_count} {conv_word}");
-                show_desktop_notification("siggy", &body, false, None, "full");
+                show_desktop_notification(
+                    "siggy",
+                    &body,
+                    false,
+                    None,
+                    crate::domain::NotificationPreview::Full,
+                );
             }
         }
         self.sync.suppressed_notifications.clear();

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,75 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
+/// Notification preview detail level. Drives whether desktop notification
+/// bodies show the message text, just the sender, or nothing beyond
+/// "new message". Persisted in `notification_preview` config field.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NotificationPreview {
+    /// Show sender + body.
+    #[default]
+    Full,
+    /// Show sender only.
+    Sender,
+    /// Show "new message" only.
+    Minimal,
+}
+
+impl NotificationPreview {
+    /// Cycle to the next preview level (Full -> Sender -> Minimal -> Full).
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Full => Self::Sender,
+            Self::Sender => Self::Minimal,
+            Self::Minimal => Self::Full,
+        }
+    }
+
+    /// User-facing label for the settings overlay.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Sender => "sender",
+            Self::Minimal => "minimal",
+        }
+    }
+}
+
+/// Image rendering mode. Selects the protocol used to draw inline image
+/// previews in the chat pane. Persisted in `image_mode` config field.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImageMode {
+    /// Native terminal image protocols (Kitty, iTerm2, Sixel).
+    Native,
+    /// Unicode halfblock approximation. Universal fallback.
+    #[default]
+    Halfblock,
+    /// Do not render images.
+    None,
+}
+
+impl ImageMode {
+    /// Cycle to the next image mode (Native -> Halfblock -> None -> Native).
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::Native => Self::Halfblock,
+            Self::Halfblock => Self::None,
+            Self::None => Self::Native,
+        }
+    }
+
+    /// User-facing label for the settings overlay.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Halfblock => "halfblock",
+            Self::None => "none",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     /// Phone number in E.164 format (e.g., +15551234567)
@@ -35,17 +104,19 @@ pub struct Config {
     #[serde(default)]
     pub desktop_notifications: bool,
 
-    /// Notification preview level: "full", "sender", or "minimal"
-    #[serde(default = "default_notification_preview")]
-    pub notification_preview: String,
+    /// Notification preview level (full / sender / minimal).
+    #[serde(default)]
+    pub notification_preview: NotificationPreview,
 
     /// Seconds before clipboard is auto-cleared after copying (0 = disabled)
     #[serde(default = "default_clipboard_clear_seconds")]
     pub clipboard_clear_seconds: u64,
 
-    /// Image display mode: "native" (terminal protocol), "halfblock", or "none"
+    /// Image display mode (native / halfblock / none). `None` here means the
+    /// field was absent from the on-disk TOML and migration should fill it in
+    /// from the legacy `inline_images` / `native_images` flags.
     #[serde(default)]
-    pub image_mode: String,
+    pub image_mode: Option<ImageMode>,
 
     /// Override cell pixel width for Sixel sizing (0 = auto-detect)
     #[serde(default)]
@@ -144,10 +215,6 @@ fn default_settings_profile() -> String {
     "Default".to_string()
 }
 
-fn default_notification_preview() -> String {
-    "full".to_string()
-}
-
 fn default_clipboard_clear_seconds() -> u64 {
     30
 }
@@ -175,9 +242,9 @@ impl Default for Config {
             notify_direct: true,
             notify_group: true,
             desktop_notifications: false,
-            notification_preview: default_notification_preview(),
+            notification_preview: NotificationPreview::Full,
             clipboard_clear_seconds: default_clipboard_clear_seconds(),
-            image_mode: "halfblock".to_string(),
+            image_mode: Some(ImageMode::Halfblock),
             cell_pixel_width: 0,
             cell_pixel_height: 0,
             inline_images: true,
@@ -232,16 +299,16 @@ impl Config {
     /// flags when upgrading from a config written by siggy < v1.6.0. No-op
     /// once `image_mode` is set.
     fn migrate_legacy_image_mode(&mut self) {
-        if !self.image_mode.is_empty() {
+        if self.image_mode.is_some() {
             return;
         }
-        self.image_mode = if self.native_images {
-            "native".to_string()
+        self.image_mode = Some(if self.native_images {
+            ImageMode::Native
         } else if self.inline_images {
-            "halfblock".to_string()
+            ImageMode::Halfblock
         } else {
-            "none".to_string()
-        };
+            ImageMode::None
+        });
     }
 
     /// Serialize this config to TOML and write it to the default config path.
@@ -304,10 +371,10 @@ mod tests {
     use super::*;
 
     fn legacy_config(inline: bool, native: bool) -> Config {
-        // image_mode MUST be explicitly empty here — Config::default()
-        // sets it to "halfblock", which would early-return the migration.
+        // image_mode MUST be explicitly None here -- Config::default()
+        // sets it to Some(Halfblock), which would early-return the migration.
         Config {
-            image_mode: String::new(),
+            image_mode: None,
             inline_images: inline,
             native_images: native,
             ..Config::default()
@@ -318,33 +385,33 @@ mod tests {
     fn migrate_legacy_image_mode_native_wins() {
         let mut c = legacy_config(true, true);
         c.migrate_legacy_image_mode();
-        assert_eq!(c.image_mode, "native");
+        assert_eq!(c.image_mode, Some(ImageMode::Native));
     }
 
     #[test]
     fn migrate_legacy_image_mode_halfblock_when_only_inline() {
         let mut c = legacy_config(true, false);
         c.migrate_legacy_image_mode();
-        assert_eq!(c.image_mode, "halfblock");
+        assert_eq!(c.image_mode, Some(ImageMode::Halfblock));
     }
 
     #[test]
     fn migrate_legacy_image_mode_none_when_both_disabled() {
         let mut c = legacy_config(false, false);
         c.migrate_legacy_image_mode();
-        assert_eq!(c.image_mode, "none");
+        assert_eq!(c.image_mode, Some(ImageMode::None));
     }
 
     #[test]
     fn migrate_legacy_image_mode_preserves_existing() {
         let mut c = Config {
-            image_mode: "native".to_string(),
+            image_mode: Some(ImageMode::Native),
             inline_images: false,
             native_images: false,
             ..Config::default()
         };
         c.migrate_legacy_image_mode();
-        assert_eq!(c.image_mode, "native");
+        assert_eq!(c.image_mode, Some(ImageMode::Native));
     }
 
     // Filesystem migrations are tested in db::tests::migrate_path_*.

--- a/src/domain/image.rs
+++ b/src/domain/image.rs
@@ -13,14 +13,16 @@ use std::collections::{HashMap, HashSet};
 
 use std::sync::mpsc;
 
+pub use crate::config::ImageMode;
+
 use crate::app::{ImageRenderResult, VisibleImage};
 use crate::image_render::ImageProtocol;
 use crate::ui::LinkRegion;
 
 /// State for image rendering, caching, and link overlay tracking.
 pub struct ImageState {
-    /// Image display mode: "native", "halfblock", or "none"
-    pub image_mode: String,
+    /// Image display mode
+    pub image_mode: ImageMode,
     /// Show link previews (title, description, thumbnail) for URLs
     pub show_link_previews: bool,
     /// Link regions detected in the last rendered frame
@@ -67,7 +69,7 @@ impl ImageState {
     ) -> Self {
         use crate::image_render;
         Self {
-            image_mode: "halfblock".to_string(),
+            image_mode: ImageMode::Halfblock,
             show_link_previews: true,
             link_regions: Vec::new(),
             link_url_map: HashMap::new(),

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -22,12 +22,12 @@ mod typing;
 
 pub use emoji_picker::{CATEGORIES, EmojiPickerAction, EmojiPickerSource, EmojiPickerState};
 pub use file_picker::{FilePickerOutcome, FilePickerState};
-pub use image::ImageState;
+pub use image::{ImageMode, ImageState};
 pub use input::InputState;
 pub use lock::{LockPhase, LockState};
 pub use lock::{hash_passphrase, load_hash, lock_hash_path, save_hash, verify_passphrase};
 pub use mouse::MouseState;
-pub use notification::NotificationState;
+pub use notification::{NotificationPreview, NotificationState};
 pub use overlays::{
     ActionMenuState, ContactsOverlayState, ForwardOverlayState, GroupMenuOverlayState,
     KeybindingsOverlayState, PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState,

--- a/src/domain/notification.rs
+++ b/src/domain/notification.rs
@@ -6,6 +6,8 @@
 //! window (`clipboard_clear_seconds`) and the `clipboard_set_at`
 //! timestamp used to scrub copied data after it expires.
 
+pub use crate::config::NotificationPreview;
+
 /// State for notification preferences and clipboard auto-clear.
 #[derive(Default)]
 pub struct NotificationState {
@@ -17,8 +19,8 @@ pub struct NotificationState {
     pub notify_group: bool,
     /// OS-level desktop notifications for incoming messages
     pub desktop_notifications: bool,
-    /// Notification preview level: "full", "sender", or "minimal"
-    pub notification_preview: String,
+    /// Notification preview level
+    pub notification_preview: NotificationPreview,
     /// Seconds before clipboard is auto-cleared after copying (0 = disabled)
     pub clipboard_clear_seconds: u64,
     /// Timestamp when clipboard was last set
@@ -30,7 +32,7 @@ impl NotificationState {
         Self {
             notify_direct: true,
             notify_group: true,
-            notification_preview: "full".to_string(),
+            notification_preview: NotificationPreview::Full,
             clipboard_clear_seconds: 30,
             ..Default::default()
         }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -371,14 +371,15 @@ fn build_outgoing_attachment_body(
     } else {
         format!("[{prefix}: {fname}] {text}")
     };
-    let (img_lines, img_path) = if is_image && app.image.image_mode != "none" {
-        (
-            image_render::render_image(path, 40),
-            Some(path.to_string_lossy().into_owned()),
-        )
-    } else {
-        (None, None)
-    };
+    let (img_lines, img_path) =
+        if is_image && app.image.image_mode != crate::domain::ImageMode::None {
+            (
+                image_render::render_image(path, 40),
+                Some(path.to_string_lossy().into_owned()),
+            )
+        } else {
+            (None, None)
+        };
     (body, img_lines, img_path)
 }
 

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -682,7 +682,7 @@ fn persist_message_extras(app: &mut App, r: &ResolvedMessage) {
             .find(|m| m.timestamp_ms == r.msg_ts_ms && !m.body.starts_with('['))
     {
         let (img_lines, img_path) = if app.image.show_link_previews
-            && app.image.image_mode != "none"
+            && app.image.image_mode != crate::domain::ImageMode::None
             && let Some(ref p) = preview.image_path
         {
             (
@@ -780,7 +780,7 @@ fn apply_notification_policy(
             notif_body,
             r.is_group,
             notif_group.as_deref(),
-            &app.notifications.notification_preview,
+            app.notifications.notification_preview,
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1225,9 +1225,9 @@ async fn run_app(
     app.notifications.notify_direct = config.notify_direct;
     app.notifications.notify_group = config.notify_group;
     app.notifications.desktop_notifications = config.desktop_notifications;
-    app.notifications.notification_preview = config.notification_preview.clone();
+    app.notifications.notification_preview = config.notification_preview;
     app.notifications.clipboard_clear_seconds = config.clipboard_clear_seconds;
-    app.image.image_mode = config.image_mode.clone();
+    app.image.image_mode = config.image_mode.unwrap_or_default();
     app.image.show_link_previews = config.show_link_previews;
     app.incognito = incognito;
     app.date_separators = config.date_separators;
@@ -1320,7 +1320,7 @@ async fn run_app(
         // Only redraw when state has changed (avoids resetting cursor blink timer every 50ms)
         if needs_redraw {
             diag_render = diag_render.wrapping_add(1);
-            let native = app.image.image_mode == "native";
+            let native = app.image.image_mode == crate::domain::ImageMode::Native;
             let sixel_mode =
                 native && app.image.image_protocol == image_render::ImageProtocol::Sixel;
 

--- a/src/settings_profile.rs
+++ b/src/settings_profile.rs
@@ -8,6 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::app::App;
+use crate::domain::ImageMode;
 
 /// A settings profile: a named collection of persisted display settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,8 +17,8 @@ pub struct SettingsProfile {
     pub notify_direct: bool,
     pub notify_group: bool,
     pub desktop_notifications: bool,
-    #[serde(default = "default_halfblock")]
-    pub image_mode: String,
+    #[serde(default)]
+    pub image_mode: ImageMode,
     pub show_link_previews: bool,
     pub date_separators: bool,
     pub show_receipts: bool,
@@ -29,17 +30,13 @@ pub struct SettingsProfile {
     pub sidebar_on_right: bool,
 }
 
-fn default_halfblock() -> String {
-    "halfblock".to_string()
-}
-
 pub fn default_profile() -> SettingsProfile {
     SettingsProfile {
         name: "Default".to_string(),
         notify_direct: true,
         notify_group: true,
         desktop_notifications: false,
-        image_mode: "halfblock".to_string(),
+        image_mode: ImageMode::Halfblock,
         show_link_previews: true,
         date_separators: true,
         show_receipts: true,
@@ -58,7 +55,7 @@ pub fn minimal_profile() -> SettingsProfile {
         notify_direct: false,
         notify_group: false,
         desktop_notifications: false,
-        image_mode: "none".to_string(),
+        image_mode: ImageMode::None,
         show_link_previews: false,
         date_separators: false,
         show_receipts: false,
@@ -77,7 +74,7 @@ pub fn full_profile() -> SettingsProfile {
         notify_direct: true,
         notify_group: true,
         desktop_notifications: true,
-        image_mode: "native".to_string(),
+        image_mode: ImageMode::Native,
         show_link_previews: true,
         date_separators: true,
         show_receipts: true,
@@ -221,7 +218,7 @@ impl SettingsProfile {
             notify_direct: app.notifications.notify_direct,
             notify_group: app.notifications.notify_group,
             desktop_notifications: app.notifications.desktop_notifications,
-            image_mode: app.image.image_mode.clone(),
+            image_mode: app.image.image_mode,
             show_link_previews: app.image.show_link_previews,
             date_separators: app.date_separators,
             show_receipts: app.show_receipts,
@@ -239,7 +236,7 @@ impl SettingsProfile {
         app.notifications.notify_direct = self.notify_direct;
         app.notifications.notify_group = self.notify_group;
         app.notifications.desktop_notifications = self.desktop_notifications;
-        app.image.image_mode = self.image_mode.clone();
+        app.image.image_mode = self.image_mode;
         app.image.show_link_previews = self.show_link_previews;
         app.date_separators = self.date_separators;
         app.show_receipts = self.show_receipts;
@@ -308,7 +305,7 @@ mod tests {
         assert!(!p.notify_direct);
         assert!(!p.notify_group);
         assert!(!p.desktop_notifications);
-        assert_eq!(p.image_mode, "none");
+        assert_eq!(p.image_mode, ImageMode::None);
         assert!(!p.show_link_previews);
         assert!(!p.date_separators);
         assert!(!p.show_receipts);
@@ -326,7 +323,7 @@ mod tests {
         assert!(p.notify_direct);
         assert!(p.notify_group);
         assert!(p.desktop_notifications);
-        assert_eq!(p.image_mode, "native");
+        assert_eq!(p.image_mode, ImageMode::Native);
         assert!(p.show_link_previews);
         assert!(p.date_separators);
         assert!(p.show_receipts);

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -307,8 +307,8 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     let mut line_msg_idx: Vec<Option<usize>> = Vec::new();
 
     // Track images for native protocol overlay: (first_line_index, line_count, path)
-    let use_native =
-        app.image.image_mode == "native" && app.image.image_protocol != ImageProtocol::Halfblock;
+    let use_native = app.image.image_mode == crate::domain::ImageMode::Native
+        && app.image.image_protocol != ImageProtocol::Halfblock;
     let mut image_records: Vec<(usize, usize, String)> = Vec::new();
 
     for (i, msg) in visible.iter().enumerate() {
@@ -491,7 +491,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
 
             // Render inline image preview if available (skip for deleted, skip if images disabled)
             if !msg.is_deleted
-                && app.image.image_mode != "none"
+                && app.image.image_mode != crate::domain::ImageMode::None
                 && let Some(ref image_lines) = msg.image_lines
             {
                 let first_idx = lines.len();
@@ -541,7 +541,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 line_msg_idx.push(Some(msg_index));
 
                 // Render link preview thumbnail (only when images enabled)
-                if app.image.image_mode != "none"
+                if app.image.image_mode != crate::domain::ImageMode::None
                     && let Some(ref img_lines) = msg.preview_image_lines
                 {
                     let first_idx = lines.len();

--- a/src/ui/overlays/settings.rs
+++ b/src/ui/overlays/settings.rs
@@ -106,7 +106,7 @@ pub(in crate::ui) fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     render_special(
         &mut lines,
         "Notification preview: ",
-        &app.notifications.notification_preview,
+        app.notifications.notification_preview.label(),
         preview_index,
     );
 
@@ -123,7 +123,7 @@ pub(in crate::ui) fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     render_special(
         &mut lines,
         "Image mode: ",
-        &app.image.image_mode,
+        app.image.image_mode.label(),
         image_mode_index,
     );
 


### PR DESCRIPTION
## Summary

Simplicity review item #4 from the final-sweep stock-take. Both fields were typed \`String\` with three valid values each, dispatched via \`match value.as_str() { ... _ => default }\` patterns with wildcard fallback arms that silently masked typos.

A user editing config.toml and writing \`notification_preview = \"Full\"\` (capital F) would get the silent default - no warning. The cycle logic at \`app.rs:1144-1155\` was 12 lines of literal string matching that the compiler couldn't audit.

## What changed

Two enums in \`config.rs\` (where they're already serialized):

\`\`\`rust
#[derive(Default, Copy, Clone, Serialize, Deserialize)]
#[serde(rename_all = \"lowercase\")]
pub enum NotificationPreview { #[default] Full, Sender, Minimal }
pub enum ImageMode { Native, #[default] Halfblock, None }
\`\`\`

Each gets a \`.cycle()\` method (Full -> Sender -> Minimal -> Full, etc.) and a \`.label()\` for the settings overlay display.

The cycle blocks in app.rs go from 12 lines to 4:

\`\`\`rust
self.notifications.notification_preview = self.notifications.notification_preview.cycle();
self.image.image_mode = self.image.image_mode.cycle();
\`\`\`

\`show_desktop_notification\`'s \`preview_level: &str\` parameter becomes \`NotificationPreview\`, with an exhaustive match. The duplicated title-building logic in the Sender / Full arms collapses into a shared \`sender_title()\` closure.

## Compat

- TOML wire format is unchanged. \`#[serde(rename_all = \"lowercase\")]\` parses the same strings as before.
- \`Config::image_mode\` becomes \`Option<ImageMode>\` so the legacy \`inline_images\`/\`native_images\` migration can still detect \"not set yet\" (was \`String::is_empty\` before).

## Stats

- 11 files changed: +173 / -115.
- Eliminates 2 stringly-typed dispatch sites + their wildcard fallback arms.
- Compiler now exhaustively enforces all cycle / display logic.

## Test plan

- [x] \`cargo test\` 559/559 passing including the 4 \`migrate_legacy_image_mode_*\` tests updated for the new \`Option<ImageMode>\` field.
- [x] \`cargo clippy --tests -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.