### PR TITLE
refactor: extract SettingsOverlayState + drop dead on_toggle hook

### DIFF
--- a/scripts/check-app-field-count.sh
+++ b/scripts/check-app-field-count.sh
@@ -13,10 +13,12 @@
 #
 # Baseline history:
 #   66 -> 67: added lock: LockState for session-lock / boss-key feature (#261)
+#   67 -> 65: extracted SettingsOverlayState (settings_index, customize_index,
+#             settings_mouse_snapshot -> settings_overlay) from final-sweep review.
 #
 set -euo pipefail
 
-BASELINE=67
+BASELINE=65
 
 count=$(awk '
   /^pub struct App \{/ { inside=1; next }

--- a/src/app.rs
+++ b/src/app.rs
@@ -25,8 +25,8 @@ use crate::domain::{
     FilePickerState, ForwardOverlayState, GroupMenuOverlayState, ImageState, InputState,
     KeybindingsOverlayState, LockState, MouseState, NotificationState, PendingState,
     PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState, ReactionState, ScrollState,
-    SearchAction, SearchState, SettingsProfileOverlayState, ThemePickerState, TypingState,
-    VerifyOverlayState,
+    SearchAction, SearchState, SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState,
+    TypingState, VerifyOverlayState,
 };
 use crate::image_render;
 use crate::image_render::ImageProtocol;
@@ -526,10 +526,8 @@ pub struct App {
     pub blocked_conversations: HashSet<String>,
     /// Autocomplete popup state: candidates, selection, pending mentions.
     pub autocomplete: AutocompleteState,
-    /// Cursor position in settings list
-    pub settings_index: usize,
-    /// Cursor position in customize sub-menu
-    pub customize_index: usize,
+    /// Settings overlay state (cursor, customize sub-menu cursor, mouse snapshot)
+    pub settings_overlay: SettingsOverlayState,
     /// State for the contacts list overlay
     pub contacts_overlay: ContactsOverlayState,
     /// State for the identity verification overlay
@@ -607,8 +605,6 @@ pub struct App {
     pub profile: ProfileOverlayState,
     /// Settings profile overlay state
     pub settings_profiles: SettingsProfileOverlayState,
-    /// Mouse enabled state when settings overlay opened (for deferred toggle)
-    pub settings_mouse_snapshot: bool,
     /// Sync state: tracks the initial message burst on startup.
     pub sync: SyncState,
     /// Currently active overlay, when one is open.
@@ -777,7 +773,6 @@ pub struct SettingDef {
     get: fn(&App) -> bool,
     set: fn(&mut App, bool),
     save: Option<fn(&mut crate::config::Config, bool)>,
-    on_toggle: Option<fn(&mut App)>,
 }
 
 /// Section boundary indices within the SETTINGS array.
@@ -808,7 +803,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.notifications.notify_direct,
         set: |a, v| a.notifications.notify_direct = v,
         save: Some(|c, v| c.notify_direct = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Group message notifications",
@@ -816,7 +810,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.notifications.notify_group,
         set: |a, v| a.notifications.notify_group = v,
         save: Some(|c, v| c.notify_group = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Desktop notifications",
@@ -824,7 +817,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.notifications.desktop_notifications,
         set: |a, v| a.notifications.desktop_notifications = v,
         save: Some(|c, v| c.desktop_notifications = v),
-        on_toggle: None,
     },
     // — Display (3–8) —
     SettingDef {
@@ -833,7 +825,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.image.show_link_previews,
         set: |a, v| a.image.show_link_previews = v,
         save: Some(|c, v| c.show_link_previews = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Date separators",
@@ -841,7 +832,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.date_separators,
         set: |a, v| a.date_separators = v,
         save: Some(|c, v| c.date_separators = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Read receipts",
@@ -849,7 +839,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.show_receipts,
         set: |a, v| a.show_receipts = v,
         save: Some(|c, v| c.show_receipts = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Receipt colors",
@@ -857,7 +846,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.color_receipts,
         set: |a, v| a.color_receipts = v,
         save: Some(|c, v| c.color_receipts = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Nerd Font icons",
@@ -865,7 +853,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.nerd_fonts,
         set: |a, v| a.nerd_fonts = v,
         save: Some(|c, v| c.nerd_fonts = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Emoji to text",
@@ -873,7 +860,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.reactions.emoji_to_text,
         set: |a, v| a.reactions.emoji_to_text = v,
         save: Some(|c, v| c.emoji_to_text = v),
-        on_toggle: None,
     },
     // — Messages (9–11) —
     SettingDef {
@@ -882,7 +868,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.reactions.show_reactions,
         set: |a, v| a.reactions.show_reactions = v,
         save: Some(|c, v| c.show_reactions = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Verbose reactions",
@@ -890,7 +875,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.reactions.verbose,
         set: |a, v| a.reactions.verbose = v,
         save: Some(|c, v| c.reaction_verbose = v),
-        on_toggle: None,
     },
     SettingDef {
         label: "Send read receipts",
@@ -898,7 +882,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.send_read_receipts,
         set: |a, v| a.send_read_receipts = v,
         save: Some(|c, v| c.send_read_receipts = v),
-        on_toggle: None,
     },
     // — Interface (12–14) —
     SettingDef {
@@ -907,7 +890,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.sidebar_visible,
         set: |a, v| a.sidebar_visible = v,
         save: None, // runtime-only, not persisted
-        on_toggle: None,
     },
     SettingDef {
         label: "Mouse support",
@@ -915,9 +897,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.mouse.enabled,
         set: |a, v| a.mouse.enabled = v,
         save: Some(|c, v| c.mouse_enabled = v),
-        on_toggle: Some(|a| {
-            a.mouse.pending_toggle = Some(a.mouse.enabled);
-        }),
     },
     SettingDef {
         label: "Sidebar on right",
@@ -925,7 +904,6 @@ pub const SETTINGS: &[SettingDef] = &[
         get: |a| a.sidebar_on_right,
         set: |a, v| a.sidebar_on_right = v,
         save: Some(|c, v| c.sidebar_on_right = v),
-        on_toggle: None,
     },
 ];
 
@@ -934,9 +912,6 @@ impl App {
         if let Some(def) = SETTINGS.get(index) {
             let cur = (def.get)(self);
             (def.set)(self, !cur);
-            if let Some(hook) = def.on_toggle {
-                hook(self);
-            }
         }
     }
 
@@ -1129,35 +1104,35 @@ impl App {
         // Find current position in visual order
         let visual_pos = SETTINGS_VISUAL_ORDER
             .iter()
-            .position(|&i| i == self.settings_index)
+            .position(|&i| i == self.settings_overlay.index)
             .unwrap_or(0);
 
         match code {
             KeyCode::Char('j') | KeyCode::Down if visual_pos + 1 < SETTINGS_VISUAL_ORDER.len() => {
-                self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
+                self.settings_overlay.index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
             }
             KeyCode::Char('k') | KeyCode::Up if visual_pos > 0 => {
-                self.settings_index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
+                self.settings_overlay.index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
             }
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
-                if self.settings_index == preview_index {
+                if self.settings_overlay.index == preview_index {
                     self.notifications.notification_preview =
                         match self.notifications.notification_preview.as_str() {
                             "full" => "sender".to_string(),
                             "sender" => "minimal".to_string(),
                             _ => "full".to_string(),
                         };
-                } else if self.settings_index == image_mode_index {
+                } else if self.settings_overlay.index == image_mode_index {
                     self.image.image_mode = match self.image.image_mode.as_str() {
                         "native" => "halfblock".to_string(),
                         "halfblock" => "none".to_string(),
                         _ => "native".to_string(),
                     };
-                } else if self.settings_index == customize_index {
+                } else if self.settings_overlay.index == customize_index {
                     self.open_overlay(OverlayKind::Customize);
-                    self.customize_index = 0;
+                    self.settings_overlay.customize_index = 0;
                 } else {
-                    self.toggle_setting(self.settings_index);
+                    self.toggle_setting(self.settings_overlay.index);
                 }
             }
             KeyCode::Esc | KeyCode::Char('q') => {
@@ -1173,16 +1148,19 @@ impl App {
     pub fn handle_customize_key(&mut self, code: KeyCode) {
         const ITEMS: usize = 3; // Theme, Keybindings, Profile
         match code {
-            KeyCode::Char('j') | KeyCode::Down if self.customize_index + 1 < ITEMS => {
-                self.customize_index += 1;
+            KeyCode::Char('j') | KeyCode::Down
+                if self.settings_overlay.customize_index + 1 < ITEMS =>
+            {
+                self.settings_overlay.customize_index += 1;
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.customize_index = self.customize_index.saturating_sub(1);
+                self.settings_overlay.customize_index =
+                    self.settings_overlay.customize_index.saturating_sub(1);
             }
             KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
                 self.close_overlay();
                 self.save_settings();
-                match self.customize_index {
+                match self.settings_overlay.customize_index {
                     0 => {
                         self.open_overlay(OverlayKind::ThemePicker);
                         self.theme_picker.index = self
@@ -1219,9 +1197,12 @@ impl App {
         self.settings_profiles.name = profile.name.clone();
     }
 
-    /// Fire on_toggle hooks only for settings that changed since the overlay opened.
+    /// Fire deferred side-effects for settings that changed since the overlay opened.
+    /// Currently just the mouse-capture toggle: applying it immediately on each
+    /// keystroke would clobber input mid-edit, so we queue the new state and
+    /// `main.rs` flips the terminal mode on the next tick.
     fn fire_deferred_settings_hooks(&mut self) {
-        if self.mouse.enabled != self.settings_mouse_snapshot {
+        if self.mouse.enabled != self.settings_overlay.mouse_snapshot {
             self.mouse.pending_toggle = Some(self.mouse.enabled);
         }
     }
@@ -2976,8 +2957,10 @@ impl App {
             muted_conversations: HashMap::new(),
             blocked_conversations: HashSet::new(),
             autocomplete: AutocompleteState::new(),
-            settings_index: 0,
-            customize_index: 0,
+            settings_overlay: SettingsOverlayState {
+                mouse_snapshot: true,
+                ..Default::default()
+            },
             contacts_overlay: ContactsOverlayState::default(),
             verify: VerifyOverlayState::default(),
             identity_trust: HashMap::new(),
@@ -3041,7 +3024,6 @@ impl App {
                 available: crate::settings_profile::all_settings_profiles(),
                 ..Default::default()
             },
-            settings_mouse_snapshot: true,
             sync: SyncState::new(),
             current_overlay: None,
             lock: LockState {
@@ -9554,11 +9536,11 @@ mod tests {
     #[rstest]
     fn mouse_overlay_scroll_navigates_list(mut app: App) {
         app.open_overlay(OverlayKind::Settings);
-        app.settings_index = 0;
+        app.settings_overlay.index = 0;
         app.mouse.messages_area = Rect::new(0, 0, 80, 20);
         // Scroll down in overlay should navigate settings list (j), not scroll messages
         app.handle_mouse_event(mouse_scroll_down(10, 10));
-        assert_eq!(app.settings_index, 1);
+        assert_eq!(app.settings_overlay.index, 1);
         assert_eq!(app.scroll.offset, 0); // messages not scrolled
     }
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -31,7 +31,7 @@ pub use notification::NotificationState;
 pub use overlays::{
     ActionMenuState, ContactsOverlayState, ForwardOverlayState, GroupMenuOverlayState,
     KeybindingsOverlayState, PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState,
-    SettingsProfileOverlayState, ThemePickerState, VerifyOverlayState,
+    SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState, VerifyOverlayState,
 };
 pub use pending::PendingState;
 pub use reaction::ReactionState;

--- a/src/domain/overlays.rs
+++ b/src/domain/overlays.rs
@@ -25,6 +25,20 @@ pub struct ActionMenuState {
     pub index: usize,
 }
 
+/// State for the settings overlay and its Customize sub-overlay.
+#[derive(Default)]
+pub struct SettingsOverlayState {
+    /// Cursor position in the settings list
+    pub index: usize,
+    /// Cursor position in the Customize sub-menu (spawned from the
+    /// "Customize..." row in the settings overlay)
+    pub customize_index: usize,
+    /// Snapshot of `mouse.enabled` at overlay-open time, used by
+    /// `fire_deferred_settings_hooks` to decide whether to queue the
+    /// mouse-capture toggle on close.
+    pub mouse_snapshot: bool,
+}
+
 /// State for the contacts list overlay.
 #[derive(Default)]
 pub struct ContactsOverlayState {

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -100,8 +100,8 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
         InputAction::Unblock => unblock(app),
         InputAction::Settings => {
             app.open_overlay(OverlayKind::Settings);
-            app.settings_index = 0;
-            app.settings_mouse_snapshot = app.mouse.enabled;
+            app.settings_overlay.index = 0;
+            app.settings_overlay.mouse_snapshot = app.mouse.enabled;
             None
         }
         InputAction::Attach => {

--- a/src/ui/overlays/settings.rs
+++ b/src/ui/overlays/settings.rs
@@ -45,7 +45,7 @@ pub(in crate::ui) fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     let render_toggle = |lines: &mut Vec<Line>, i: usize, def: &SettingDef| {
         let enabled = app.setting_value(i);
         let checkbox = if enabled { "[x]" } else { "[ ]" };
-        let is_selected = i == app.settings_index;
+        let is_selected = i == app.settings_overlay.index;
         let style = if is_selected {
             Style::default()
                 .bg(theme.bg_selected)
@@ -72,7 +72,7 @@ pub(in crate::ui) fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render a special (non-toggle) row
     let render_special = |lines: &mut Vec<Line>, label: &str, value: &str, index: usize| {
-        let is_selected = app.settings_index == index;
+        let is_selected = app.settings_overlay.index == index;
         let label_style = if is_selected {
             Style::default()
                 .bg(theme.bg_selected)
@@ -146,10 +146,10 @@ pub(in crate::ui) fn draw_settings(frame: &mut Frame, app: &App, area: Rect) {
     render_special(&mut lines, "Customize...", "", customize_index);
 
     // Hint line for the currently selected item
-    let hint = if app.settings_index < SETTINGS.len() {
-        SETTINGS[app.settings_index].hint
+    let hint = if app.settings_overlay.index < SETTINGS.len() {
+        SETTINGS[app.settings_overlay.index].hint
     } else {
-        match app.settings_index - SETTINGS.len() {
+        match app.settings_overlay.index - SETTINGS.len() {
             0 => "Control message content in notifications",
             1 => "native (terminal protocol), halfblock, or none",
             2 => "Theme, keybindings, and settings profiles",
@@ -174,7 +174,7 @@ pub(in crate::ui) fn draw_customize(frame: &mut Frame, app: &App, area: Rect) {
 
     let mut lines: Vec<Line> = Vec::new();
     for (i, label) in items.iter().enumerate() {
-        let is_selected = i == app.customize_index;
+        let is_selected = i == app.settings_overlay.customize_index;
         let style = if is_selected {
             Style::default()
                 .bg(theme.bg_selected)


### PR DESCRIPTION
## Summary

Two unrelated findings from the final-sweep review, bundled as a single housekeeping PR. Both are small structural wins flagged by separate reviewer personas.

## SettingsOverlayState (maintainability review)

Every other modal overlay has been extracted into a per-overlay state struct under \`src/domain/overlays.rs\`. The settings overlay was the lone exception: three loose fields on App (\`settings_index\`, \`customize_index\`, \`settings_mouse_snapshot\`). Now follows the established pattern:

\`\`\`rust
pub struct SettingsOverlayState {
    pub index: usize,
    pub customize_index: usize,
    pub mouse_snapshot: bool,
}
\`\`\`

Net: -2 App fields (3 -> 1 struct), App ratchet lowered 67 -> 65. Strengthens the \"all overlay state lives in domain/\" invariant.

## SettingDef.on_toggle removal (simplicity review)

Of the 16 SETTINGS entries, exactly **1** (mouse-capture toggle) populated \`on_toggle: Some(...)\`. The other 15 spelled \`on_toggle: None\`. And the mouse-toggle side-effect was *also* explicitly implemented in \`fire_deferred_settings_hooks\` for the close-overlay path. So \`on_toggle\` was a plugin point with one plugin whose effect was already duplicated.

Dropped the \`on_toggle\` field, dropped the matching dispatch arm in \`toggle_setting\`, and dropped the now-redundant \`on_toggle: None\` boilerplate from all 15 other entries. The mouse toggle still works -- via \`fire_deferred_settings_hooks\`, which has been the canonical mechanism all along.

## Stats

- App fields 67 -> 65 (ratchet baseline lowered accordingly).
- SETTINGS array entries: -16 lines of \`on_toggle: None,\` plus the one \`Some(|a| ...)\` block.
- \`toggle_setting\` loses a 3-line if-let arm.
- Updated \`fire_deferred_settings_hooks\` docstring to reflect its new sole-mechanism role.

## Test plan

- [x] \`cargo test\` 559/559 passing.
- [x] \`cargo clippy --tests -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.
- [x] App field-count ratchet 65/65.

## Not in this PR

Two reviewer findings I evaluated and skipped:
- \`SyncState::message_count\`/\`last_message_time\` removal -- reviewer was wrong, both fields are load-bearing (status bar display and \`sync.should_end\` heuristic).
- Circular dep break (moving \`GroupMenuState\`/\`PinPending\`/\`PollVotePending\` into domain/) -- speculative, no immediate value.