### PR TITLE
refactor: unify Up/Down nav arms across list overlays (closes #456)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1393,16 +1393,15 @@ impl App {
             KeyCode::Char('q') => KeyCode::Esc,
             other => other,
         };
-        match classify_list_key(code, false) {
-            ListKeyAction::Down
-                if self.theme_picker.index
-                    < self.theme_picker.available_themes.len().saturating_sub(1) =>
-            {
-                self.theme_picker.index += 1;
-            }
-            ListKeyAction::Up => {
-                self.theme_picker.index = self.theme_picker.index.saturating_sub(1);
-            }
+        let action = classify_list_key(code, false);
+        if list_overlay::apply_nav(
+            &action,
+            &mut self.theme_picker.index,
+            self.theme_picker.available_themes.len(),
+        ) {
+            return;
+        }
+        match action {
             ListKeyAction::Select => {
                 if let Some(selected) = self
                     .theme_picker
@@ -2342,17 +2341,11 @@ impl App {
             self.close_overlay();
             return None;
         }
-        match classify_list_key(code, false) {
-            ListKeyAction::Down => {
-                if self.action_menu.index < item_count - 1 {
-                    self.action_menu.index += 1;
-                }
-                None
-            }
-            ListKeyAction::Up => {
-                self.action_menu.index = self.action_menu.index.saturating_sub(1);
-                None
-            }
+        let action = classify_list_key(code, false);
+        if list_overlay::apply_nav(&action, &mut self.action_menu.index, item_count) {
+            return None;
+        }
+        match action {
             ListKeyAction::Select => {
                 let items = self.action_menu_items();
                 if let Some(action) = items.get(self.action_menu.index) {
@@ -2647,17 +2640,15 @@ impl App {
     }
 
     pub fn handle_forward_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        match classify_list_key(code, true) {
-            ListKeyAction::Down => {
-                if !self.forward.filtered.is_empty()
-                    && self.forward.index < self.forward.filtered.len() - 1
-                {
-                    self.forward.index += 1;
-                }
-            }
-            ListKeyAction::Up => {
-                self.forward.index = self.forward.index.saturating_sub(1);
-            }
+        let action = classify_list_key(code, true);
+        if list_overlay::apply_nav(
+            &action,
+            &mut self.forward.index,
+            self.forward.filtered.len(),
+        ) {
+            return None;
+        }
+        match action {
             ListKeyAction::Select => {
                 if let Some((conv_id, name)) =
                     self.forward.filtered.get(self.forward.index).cloned()
@@ -2699,23 +2690,21 @@ impl App {
                 self.forward.filter.pop();
                 self.update_forward_filter();
             }
-            ListKeyAction::None => {}
+            ListKeyAction::None | ListKeyAction::Up | ListKeyAction::Down => {}
         }
         None
     }
 
     pub fn handle_contacts_key(&mut self, code: KeyCode) {
-        match classify_list_key(code, true) {
-            ListKeyAction::Down => {
-                if !self.contacts_overlay.filtered.is_empty()
-                    && self.contacts_overlay.index < self.contacts_overlay.filtered.len() - 1
-                {
-                    self.contacts_overlay.index += 1;
-                }
-            }
-            ListKeyAction::Up => {
-                self.contacts_overlay.index = self.contacts_overlay.index.saturating_sub(1);
-            }
+        let action = classify_list_key(code, true);
+        if list_overlay::apply_nav(
+            &action,
+            &mut self.contacts_overlay.index,
+            self.contacts_overlay.filtered.len(),
+        ) {
+            return;
+        }
+        match action {
             ListKeyAction::Select => {
                 if let Some((number, _)) = self
                     .contacts_overlay
@@ -2740,7 +2729,7 @@ impl App {
                 self.contacts_overlay.filter.pop();
                 self.refresh_contacts_filter();
             }
-            ListKeyAction::None => {}
+            ListKeyAction::None | ListKeyAction::Up | ListKeyAction::Down => {}
         }
     }
 

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -78,17 +78,11 @@ pub(crate) fn execute_pin_toggle(app: &mut App) -> Option<SendRequest> {
 
 /// Handle a key press while the pin duration picker overlay is open.
 pub fn handle_pin_duration_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
-    match classify_list_key(code, false) {
-        ListKeyAction::Down => {
-            if app.pin_duration.index < PIN_DURATIONS.len() - 1 {
-                app.pin_duration.index += 1;
-            }
-            None
-        }
-        ListKeyAction::Up => {
-            app.pin_duration.index = app.pin_duration.index.saturating_sub(1);
-            None
-        }
+    let action = classify_list_key(code, false);
+    if crate::list_overlay::apply_nav(&action, &mut app.pin_duration.index, PIN_DURATIONS.len()) {
+        return None;
+    }
+    match action {
         ListKeyAction::Select => {
             let duration = PIN_DURATIONS[app.pin_duration.index].0;
             app.close_overlay();

--- a/src/list_overlay.rs
+++ b/src/list_overlay.rs
@@ -35,6 +35,28 @@ pub fn classify_list_key(code: KeyCode, filterable: bool) -> ListKeyAction {
     }
 }
 
+/// Apply the Up/Down arms of a `ListKeyAction` to a list overlay's cursor.
+/// Returns `true` if the action was a navigation arm (consumed), `false`
+/// otherwise so callers can fall through to mode-specific arms.
+///
+/// Down on an empty list (`len == 0`) is a consumed no-op rather than an
+/// underflow risk -- previous handlers had inconsistent empty-list guards.
+pub fn apply_nav(action: &ListKeyAction, index: &mut usize, len: usize) -> bool {
+    match action {
+        ListKeyAction::Up => {
+            *index = index.saturating_sub(1);
+            true
+        }
+        ListKeyAction::Down => {
+            if len > 0 {
+                *index = (*index + 1).min(len - 1);
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
 /// Calculate visible rows and scroll offset for a list overlay.
 /// `inner_height` is the popup inner area height (after border subtraction).
 /// `footer_lines` is lines reserved for footer (typically 2: blank + help text).
@@ -187,5 +209,47 @@ mod tests {
         let mut idx = 15;
         clamp_index(&mut idx, 10);
         assert_eq!(idx, 9);
+    }
+
+    #[test]
+    fn apply_nav_up_decrements_with_floor() {
+        let mut idx = 3;
+        assert!(apply_nav(&ListKeyAction::Up, &mut idx, 10));
+        assert_eq!(idx, 2);
+
+        let mut idx = 0;
+        assert!(apply_nav(&ListKeyAction::Up, &mut idx, 10));
+        assert_eq!(idx, 0, "saturating: must not underflow");
+    }
+
+    #[test]
+    fn apply_nav_down_increments_with_ceiling() {
+        let mut idx = 3;
+        assert!(apply_nav(&ListKeyAction::Down, &mut idx, 10));
+        assert_eq!(idx, 4);
+
+        let mut idx = 9;
+        assert!(apply_nav(&ListKeyAction::Down, &mut idx, 10));
+        assert_eq!(idx, 9, "must clamp to len - 1");
+    }
+
+    #[test]
+    fn apply_nav_down_on_empty_list_is_noop() {
+        // Regression for the bug-risk flagged by the unification review:
+        // empty filtered list must not panic on a Down keypress.
+        let mut idx = 0;
+        assert!(apply_nav(&ListKeyAction::Down, &mut idx, 0));
+        assert_eq!(idx, 0);
+    }
+
+    #[test]
+    fn apply_nav_non_nav_actions_return_false() {
+        let mut idx = 5;
+        assert!(!apply_nav(&ListKeyAction::Select, &mut idx, 10));
+        assert!(!apply_nav(&ListKeyAction::Close, &mut idx, 10));
+        assert!(!apply_nav(&ListKeyAction::FilterPush('a'), &mut idx, 10));
+        assert!(!apply_nav(&ListKeyAction::FilterPop, &mut idx, 10));
+        assert!(!apply_nav(&ListKeyAction::None, &mut idx, 10));
+        assert_eq!(idx, 5, "non-nav actions must not move the cursor");
     }
 }


### PR DESCRIPTION
## Summary

Five list-overlay handlers (theme_picker, action_menu, forward, contacts, pin_duration) each open-coded the same Up/Down pattern with only the field path varying. The Down arm specifically had **inconsistent empty-list guards** across the 5 sites -- some checked \`!filtered.is_empty()\` before the subtraction, others did not. The review flagged this as a real underflow-risk bug.

## Fix

New helper in \`list_overlay\`:

\`\`\`rust
pub fn apply_nav(action: &ListKeyAction, index: &mut usize, len: usize) -> bool {
    match action {
        ListKeyAction::Up => { *index = index.saturating_sub(1); true }
        ListKeyAction::Down => {
            if len > 0 {
                *index = (*index + 1).min(len - 1);
            }
            true
        }
        _ => false,
    }
}
\`\`\`

Down on an empty list (\`len == 0\`) is a consumed no-op rather than an underflow risk -- the helper bakes in the safety guard.

Each handler now reads:

\`\`\`rust
let action = classify_list_key(code, ...);
if list_overlay::apply_nav(&action, &mut self.X.index, len) {
    return ...;
}
match action { /* mode-specific arms */ }
\`\`\`

## New tests (+4)

- \`apply_nav_up_decrements_with_floor\` (saturating subtract)
- \`apply_nav_down_increments_with_ceiling\` (clamp to len-1)
- \`apply_nav_down_on_empty_list_is_noop\` (the bug-risk regression test)
- \`apply_nav_non_nav_actions_return_false\` (Select/Close/Filter pass-through)

## Stats

- src/app.rs: -42 LOC
- src/handlers/keys.rs: -7 LOC
- src/list_overlay.rs: +64 LOC (helper + tests)
- 559 -> 563 tests
- Empty-list underflow risk closed in a single place rather than five

## Test plan

- [x] \`cargo test\` 563/563 passing.
- [x] \`cargo clippy --tests -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.