### PR TITLE
refactor: replace stringly 'you' sender with typed helpers (closes #453)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2202,7 +2202,7 @@ impl App {
         let msg = conv.messages.get(index)?;
 
         let target_timestamp = msg.timestamp_ms;
-        let target_author = if msg.sender == "you" {
+        let target_author = if msg.is_outgoing() {
             self.account.clone()
         } else {
             // Reverse lookup: find the phone number for this display name
@@ -2218,7 +2218,7 @@ impl App {
         let is_remove = msg
             .reactions
             .iter()
-            .any(|r| r.sender == "you" && r.emoji == emoji);
+            .any(|r| r.is_from_me() && r.emoji == emoji);
 
         // Optimistic local update
         if let Some(conv) = self.store.conversations.get_mut(&conv_id)
@@ -2226,10 +2226,10 @@ impl App {
         {
             if is_remove {
                 msg.reactions
-                    .retain(|r| !(r.sender == "you" && r.emoji == emoji));
+                    .retain(|r| !(r.is_from_me() && r.emoji == emoji));
             } else {
                 // One reaction per user — replace or push
-                if let Some(existing) = msg.reactions.iter_mut().find(|r| r.sender == "you") {
+                if let Some(existing) = msg.reactions.iter_mut().find(|r| r.is_from_me()) {
                     existing.emoji = emoji.to_string();
                 } else {
                     msg.reactions.push(Reaction {
@@ -2279,7 +2279,7 @@ impl App {
                 nerd_icon: "\u{f045a}",
             });
         }
-        if msg.sender == "you" && !msg.is_system && !msg.is_deleted {
+        if msg.is_outgoing() && !msg.is_system && !msg.is_deleted {
             items.push(ActionMenuItem {
                 label: "Edit",
                 key_hint: ActionMenuHint::Edit,
@@ -2327,7 +2327,7 @@ impl App {
                     nerd_icon: "\u{f0e73}",
                 });
             }
-            if msg.sender == "you" && !poll.closed {
+            if msg.is_outgoing() && !poll.closed {
                 items.push(ActionMenuItem {
                     label: "End Poll",
                     key_hint: ActionMenuHint::EndPoll,
@@ -2416,18 +2416,13 @@ impl App {
                     && !msg.is_system
                     && !msg.is_deleted
                 {
-                    let author_phone = msg.sender_id.clone();
+                    let phone = msg.route_author(&self.account).to_string();
                     let snippet: String = if msg.body.chars().count() > 50 {
                         format!("{}…", msg.body.chars().take(50).collect::<String>())
                     } else {
                         msg.body.clone()
                     };
                     let ts = msg.timestamp_ms;
-                    let phone = if author_phone.is_empty() || author_phone == "you" {
-                        self.account.clone()
-                    } else {
-                        author_phone
-                    };
                     self.reply_target = Some((phone, snippet, ts));
                     self.mode = InputMode::Insert;
                 }
@@ -2436,7 +2431,7 @@ impl App {
             ActionMenuHint::Edit => {
                 // Edit — same as Normal 'e'
                 if let Some(msg) = self.selected_message()
-                    && msg.sender == "you"
+                    && msg.is_outgoing()
                     && !msg.is_deleted
                     && !msg.is_system
                 {
@@ -2503,11 +2498,7 @@ impl App {
                         .get(&conv_id)
                         .map(|c| c.is_group)
                         .unwrap_or(false);
-                    let poll_author = if msg.sender_id.is_empty() || msg.sender_id == "you" {
-                        self.account.clone()
-                    } else {
-                        msg.sender_id.clone()
-                    };
+                    let poll_author = msg.route_author(&self.account).to_string();
                     let options = poll.options.clone();
                     let allow_multiple = poll.allow_multiple;
                     let poll_timestamp = msg.timestamp_ms;
@@ -2529,7 +2520,7 @@ impl App {
             ActionMenuHint::EndPoll => {
                 // End poll
                 if let Some(msg) = self.selected_message()
-                    && msg.sender == "you"
+                    && msg.is_outgoing()
                     && msg.poll_data.as_ref().is_some_and(|p| !p.closed)
                 {
                     let conv_id = self.active_conversation.clone()?;
@@ -4058,18 +4049,13 @@ impl App {
                     && !msg.is_system
                     && !msg.is_deleted
                 {
-                    let author_phone = msg.sender_id.clone();
+                    let phone = msg.route_author(&self.account).to_string();
                     let snippet: String = if msg.body.chars().count() > 50 {
                         format!("{}…", msg.body.chars().take(50).collect::<String>())
                     } else {
                         msg.body.clone()
                     };
                     let ts = msg.timestamp_ms;
-                    let phone = if author_phone.is_empty() || author_phone == "you" {
-                        self.account.clone()
-                    } else {
-                        author_phone
-                    };
                     self.reply_target = Some((phone, snippet, ts));
                     self.mode = InputMode::Insert;
                 }
@@ -4077,7 +4063,7 @@ impl App {
             }
             Some(KeyAction::EditMessage) => {
                 if let Some(msg) = self.selected_message()
-                    && msg.sender == "you"
+                    && msg.is_outgoing()
                     && !msg.is_deleted
                     && !msg.is_system
                 {
@@ -4257,25 +4243,20 @@ impl App {
                     && !msg.is_system
                     && !msg.is_deleted
                 {
-                    let author_phone = msg.sender_id.clone();
+                    let phone = msg.route_author(&self.account).to_string();
                     let snippet: String = if msg.body.chars().count() > 50 {
                         format!("{}…", msg.body.chars().take(50).collect::<String>())
                     } else {
                         msg.body.clone()
                     };
                     let ts = msg.timestamp_ms;
-                    let phone = if author_phone.is_empty() || author_phone == "you" {
-                        self.account.clone()
-                    } else {
-                        author_phone
-                    };
                     self.reply_target = Some((phone, snippet, ts));
                 }
                 None
             }
             Some(KeyAction::EditMessage) => {
                 if let Some(msg) = self.selected_message()
-                    && msg.sender == "you"
+                    && msg.is_outgoing()
                     && !msg.is_deleted
                     && !msg.is_system
                 {
@@ -4484,7 +4465,7 @@ impl App {
                     .focused_index
                     .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
                 let msg = conv.messages.get(index)?;
-                let is_outgoing = msg.sender == "you";
+                let is_outgoing = msg.is_outgoing();
                 let target_timestamp = msg.timestamp_ms;
 
                 // Apply local delete

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -117,6 +117,13 @@ pub(crate) fn short_name(number: &str) -> String {
     }
 }
 
+/// Sentinel string used as `sender` / `sender_id` for outgoing messages and
+/// reactions. Persisted to the DB as the literal string `"you"` for legacy
+/// reasons, but new code should go through `DisplayMessage::is_outgoing` /
+/// `Reaction::is_from_me` / the `OUTGOING_SENDER` const rather than comparing
+/// the string directly. See issue #453 for the history.
+pub const OUTGOING_SENDER: &str = "you";
+
 /// Quoted reply context attached to a message.
 #[derive(Debug, Clone)]
 pub struct Quote {
@@ -185,6 +192,36 @@ impl DisplayMessage {
     pub fn format_time(&self) -> String {
         let local: DateTime<Local> = self.timestamp.with_timezone(&Local);
         local.format("%H:%M").to_string()
+    }
+
+    /// Whether this message was sent from this account (vs. received from a
+    /// contact). Three signals combine because they overlap in different
+    /// data sources: `status.is_some()` is the canonical runtime marker
+    /// (outgoing messages carry a [`MessageStatus`]), while `sender` /
+    /// `sender_id == "you"` cover demo data and legacy DB rows respectively.
+    pub fn is_outgoing(&self) -> bool {
+        self.status.is_some() || self.sender == OUTGOING_SENDER || self.sender_id == OUTGOING_SENDER
+    }
+
+    /// Wire identifier suitable for routing replies / reactions / pin queries
+    /// back to the original author. Resolves to `my_account` for outgoing
+    /// messages or legacy rows with no `sender_id`; otherwise returns the
+    /// sender's phone / UUID. The empty-sender_id fallback is defensive: a
+    /// legacy row with neither signal is rarer than the alternative (an
+    /// invalid empty recipient string sent to signal-cli).
+    pub fn route_author<'a>(&'a self, my_account: &'a str) -> &'a str {
+        if self.is_outgoing() || self.sender_id.is_empty() {
+            my_account
+        } else {
+            &self.sender_id
+        }
+    }
+}
+
+impl crate::signal::types::Reaction {
+    /// Whether this reaction was sent from this account.
+    pub fn is_from_me(&self) -> bool {
+        self.sender == OUTGOING_SENDER
     }
 }
 
@@ -491,11 +528,11 @@ impl ConversationStore {
             for msg in &mut conv.messages {
                 // Resolve reaction senders
                 for reaction in &mut msg.reactions {
-                    if reaction.sender == "you" {
+                    if reaction.is_from_me() {
                         continue;
                     }
                     if reaction.sender == account {
-                        reaction.sender = "you".to_string();
+                        reaction.sender = OUTGOING_SENDER.to_string();
                     } else if let Some(name) = phone_to_name.get(&reaction.sender) {
                         reaction.sender = name.clone();
                     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -438,7 +438,7 @@ impl Database {
                 let idx = ts_to_idx.get(&target_ts).and_then(|idxs| {
                     idxs.iter()
                         .find(|&&i| {
-                            messages[i].sender == target_author || messages[i].sender == "you"
+                            messages[i].sender == target_author || messages[i].is_outgoing()
                         })
                         .or_else(|| idxs.first())
                         .copied()

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -310,14 +310,14 @@ fn try_send_edit(
         .conversations
         .get(&edit_conv_id)
         .and_then(|conv| conv.find_msg_idx(edit_ts).map(|idx| &conv.messages[idx]))
-        .filter(|msg| msg.sender == "you")
+        .filter(|msg| msg.is_outgoing())
         .and_then(|msg| msg.quote.as_ref())
         .map(|q| (q.timestamp_ms, q.author_id.clone(), q.body.clone()));
 
     let conv = app.store.conversations.get_mut(&edit_conv_id)?;
     if let Some(idx) = conv
         .find_msg_idx(edit_ts)
-        .filter(|&idx| conv.messages[idx].sender == "you")
+        .filter(|&idx| conv.messages[idx].is_outgoing())
     {
         conv.messages[idx].body = text.to_string();
         conv.messages[idx].is_edited = true;

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -24,7 +24,7 @@ pub(crate) fn execute_pin_toggle(app: &mut App) -> Option<SendRequest> {
     }
     let was_pinned = msg.is_pinned;
     let target_timestamp = msg.timestamp_ms;
-    let author_phone = msg.sender_id.clone();
+    let target_author = msg.route_author(&app.account).to_string();
     let conv_id = app.active_conversation.clone()?;
     let is_group = app
         .store
@@ -32,12 +32,6 @@ pub(crate) fn execute_pin_toggle(app: &mut App) -> Option<SendRequest> {
         .get(&conv_id)
         .map(|c| c.is_group)
         .unwrap_or(false);
-
-    let target_author = if author_phone.is_empty() || author_phone == "you" {
-        app.account.clone()
-    } else {
-        author_phone
-    };
 
     if was_pinned {
         // Unpin immediately -- no duration needed.

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -876,7 +876,7 @@ fn handle_reaction(
     if let Some(conv) = app.store.conversations.get_mut(conv_id) {
         let found = conv.find_msg_idx(target_timestamp).and_then(|idx| {
             let m = &conv.messages[idx];
-            let matches = if m.sender == "you" {
+            let matches = if m.is_outgoing() {
                 target_author == account.as_str()
             } else {
                 m.sender == target_author || target_display.as_deref() == Some(m.sender.as_str())
@@ -1298,7 +1298,7 @@ fn handle_send_timestamp(app: &mut App, rpc_id: &str, server_ts: i64) {
             // Find the outgoing message with matching local timestamp
             if let Some(idx) = conv
                 .find_msg_idx(local_ts)
-                .filter(|&idx| conv.messages[idx].sender == "you")
+                .filter(|&idx| conv.messages[idx].is_outgoing())
             {
                 conv.messages[idx].timestamp_ms = effective_ts;
                 conv.messages[idx].status = Some(MessageStatus::Sent);
@@ -1344,7 +1344,7 @@ fn handle_send_failed(app: &mut App, rpc_id: &str) {
         if let Some(conv) = app.store.conversations.get_mut(&conv_id)
             && let Some(idx) = conv
                 .find_msg_idx(local_ts)
-                .filter(|&idx| conv.messages[idx].sender == "you")
+                .filter(|&idx| conv.messages[idx].is_outgoing())
         {
             conv.messages[idx].status = Some(MessageStatus::Failed);
             found = true;
@@ -1370,7 +1370,7 @@ fn try_upgrade_receipt(
 ) -> bool {
     if let Some(idx) = conv
         .find_msg_idx(ts)
-        .filter(|&idx| conv.messages[idx].sender == "you")
+        .filter(|&idx| conv.messages[idx].is_outgoing())
     {
         if let Some(current) = conv.messages[idx].status
             && new_status > current

--- a/src/ui/overlays/action_menu.rs
+++ b/src/ui/overlays/action_menu.rs
@@ -87,7 +87,7 @@ pub(in crate::ui) fn draw_action_menu(frame: &mut Frame, app: &App, area: Rect) 
 pub(in crate::ui) fn draw_delete_confirm(frame: &mut Frame, app: &App, area: Rect) {
     let theme = &app.theme;
     let msg = app.selected_message();
-    let is_outgoing = msg.is_some_and(|m| m.sender == "you");
+    let is_outgoing = msg.is_some_and(|m| m.is_outgoing());
 
     let (popup_area, block) = centered_popup(frame, area, 44, 5, " Delete Message ", theme);
 


### PR DESCRIPTION
## Summary

Pattern review item #1 from the final-sweep stock-take. ~50 sites compared \`sender\` / \`sender_id\` against the magic string \"you\" in three subtly-different shapes:

\`\`\`rust
m.sender == \"you\"
sender_id == \"you\"
sender_id.is_empty() || sender_id == \"you\"
\`\`\`

A typo at any site would silently classify an incoming message as outgoing (no compiler help). The three shapes also drifted: some checked the empty-sender_id fallback, some didn't.

## What changed

New typed helpers on \`DisplayMessage\` and \`Reaction\`, plus an \`OUTGOING_SENDER\` const. Comparison sites swept to use them.

\`\`\`rust
pub const OUTGOING_SENDER: &str = \"you\";

impl DisplayMessage {
    pub fn is_outgoing(&self) -> bool {
        self.status.is_some()
            || self.sender == OUTGOING_SENDER
            || self.sender_id == OUTGOING_SENDER
    }
    pub fn route_author<'a>(&'a self, my_account: &'a str) -> &'a str {
        if self.is_outgoing() || self.sender_id.is_empty() {
            my_account
        } else {
            &self.sender_id
        }
    }
}

impl Reaction {
    pub fn is_from_me(&self) -> bool {
        self.sender == OUTGOING_SENDER
    }
}
\`\`\`

\`is_outgoing\` combines three signals because they overlap in different data sources:
- \`status.is_some()\` is the canonical runtime marker (outgoing messages always carry a MessageStatus).
- \`sender == \"you\"\` / \`sender_id == \"you\"\` cover demo data and legacy DB rows respectively.

\`route_author\` adds the empty-sender_id fallback that the old call sites had: legacy rows with neither signal route to \`my_account\` rather than producing an empty recipient string sent to signal-cli.

## On-disk format

Unchanged. The DB still stores \"you\" as TEXT for outgoing messages; the helpers convert in memory only. No migration needed.

## Sweep

- \`app.rs\`: 11 \`m.sender == \"you\"\` / \`r.sender == \"you\"\` sites
- \`app.rs\`: 4 \`(sender_id.is_empty() || sender_id == \"you\")\` sites
- \`handlers/keys.rs\`: 1 \`(author_phone.is_empty() || author_phone == \"you\")\` site

## Not in this PR

Construction sites (test fixtures, demo data) that build outgoing messages with \`sender: \"you\".to_string()\` are left as-is - they're valid uses of the sentinel and a future PR can swap them to \`OUTGOING_SENDER.to_string()\` opportunistically.

## Test plan

- [x] \`cargo test\` 559/559 passing.
- [x] \`cargo clippy --tests -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.