### PR TITLE
feat(debug): warnf + slow image decode warning without --debug (closes #444)

### DIFF
--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -118,3 +118,23 @@ pub fn logf(args: std::fmt::Arguments<'_>) {
     }
     log(&format!("{args}"));
 }
+
+/// Always-on warning log: writes to the debug log file regardless of whether
+/// --debug is enabled. Used for diagnostics the user should see even without
+/// opting into full debug logging (e.g. pathologically slow image decodes
+/// surfaced by issue #444).
+///
+/// Lazy-initialises the log file on first call so the warning lands somewhere
+/// inspectable. Subsequent warnings reuse the open handle.
+pub fn warnf(args: std::fmt::Arguments<'_>) {
+    if FILE.lock().map(|g| g.is_none()).unwrap_or(true) {
+        setup_file();
+    }
+    let msg = format!("WARN: {args}");
+    if let Ok(mut guard) = FILE.lock()
+        && let Some(ref mut f) = *guard
+    {
+        let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
+        let _ = writeln!(f, "[{now}] {msg}");
+    }
+}

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -481,17 +481,36 @@ pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
         lines.push(Line::from(spans));
     }
 
+    let elapsed_ms = start.elapsed().as_millis();
     crate::debug_log::logf(format_args!(
-        "render_image done: path={} elapsed_ms={} src={}x{} out={}x{}",
+        "render_image done: path={} elapsed_ms={elapsed_ms} src={}x{} out={}x{}",
         path.display(),
-        start.elapsed().as_millis(),
         orig_w,
         orig_h,
         new_w,
         new_h
     ));
+    if elapsed_ms > SLOW_DECODE_WARN_MS {
+        // Always-on warning regardless of --debug: a pathologically slow
+        // decode is the symptom of a hostile or broken file, and the user
+        // needs the path + size to triage even without opting into the
+        // full debug log. See issue #444.
+        crate::debug_log::warnf(format_args!(
+            "slow image decode: path={} elapsed_ms={elapsed_ms} src={}x{} out={}x{}",
+            path.display(),
+            orig_w,
+            orig_h,
+            new_w,
+            new_h
+        ));
+    }
     Some(lines)
 }
+
+/// Threshold (ms) above which `render_image` emits an always-on warning,
+/// independent of the --debug flag. 5s is roughly the point at which the
+/// user notices a stall and starts wondering what is hung.
+const SLOW_DECODE_WARN_MS: u128 = 5_000;
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

When an image decode takes longer than 5000 ms, \`render_image\` now emits an always-on warning to the debug log file regardless of whether \`--debug\` was passed.

After #425 the typical decode takes well under 5s on legitimate Signal attachments, so this only fires on the pathological case the original issue (#408) was chasing.

## What changed

Two pieces:

1. \`src/debug_log.rs\`: new \`warnf\` function that lazy-initialises the log file and writes regardless of the \`ENABLED\` flag. Output prefixed with \`WARN:\` and an ISO-8601-ish timestamp.

2. \`src/image_render.rs\`: after the existing \`render_image done\` debug line, check \`elapsed_ms > SLOW_DECODE_WARN_MS\` and call \`warnf\` with the path, elapsed, src dimensions, and out dimensions.

\`\`\`rust
const SLOW_DECODE_WARN_MS: u128 = 5_000;

if elapsed_ms > SLOW_DECODE_WARN_MS {
    crate::debug_log::warnf(format_args!(
        \"slow image decode: path={} elapsed_ms={elapsed_ms} src={}x{} out={}x{}\",
        ...
    ));
}
\`\`\`

## Why this matters

Future #408-style \"my CPU is pinned\" reports will land with the offending file path already in the log, no \`--debug\` rerun required. The log file lives at the platform's cache dir (\`~/.cache/siggy/debug.log\` on Linux) regardless of whether the user opted into debug mode.

## Stats

- 2 files changed: +41 / -2.
- 559/559 tests still pass.

## Test plan

- [x] \`cargo test\` 559/559 passing.
- [x] \`cargo clippy --tests -- -D warnings\` clean.
- [x] \`cargo fmt --check\` clean.

## Not in this PR

Optional per-session skip-list (the issue mentioned as a stretch goal). Defer until we see a recurrence -- the warn log alone is enough triage signal for now.