### PR TITLE
native inline images for kitty in tmux

### DIFF
--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -29,7 +29,21 @@ pub enum ImageProtocol {
 }
 
 /// Detect the best available image protocol by checking environment variables.
+///
+/// Honors an explicit `SIGGY_IMAGE_PROTOCOL` override
+/// (`kitty` | `iterm2` | `sixel` | `halfblock`) which is most useful inside
+/// tmux, where `TERM_PROGRAM` becomes `tmux` and `KITTY_WINDOW_ID` is not
+/// propagated by default.
 pub fn detect_protocol() -> ImageProtocol {
+    if let Ok(p) = std::env::var("SIGGY_IMAGE_PROTOCOL") {
+        match p.trim().to_ascii_lowercase().as_str() {
+            "kitty" => return ImageProtocol::Kitty,
+            "iterm2" | "iterm" => return ImageProtocol::Iterm2,
+            "sixel" => return ImageProtocol::Sixel,
+            "halfblock" | "none" => return ImageProtocol::Halfblock,
+            _ => {}
+        }
+    }
     if std::env::var("KITTY_WINDOW_ID").is_ok() {
         return ImageProtocol::Kitty;
     }
@@ -44,6 +58,30 @@ pub fn detect_protocol() -> ImageProtocol {
         return ImageProtocol::Sixel;
     }
     ImageProtocol::Halfblock
+}
+
+/// Returns true if running inside a tmux session.
+pub fn in_tmux() -> bool {
+    std::env::var("TMUX").is_ok_and(|v| !v.is_empty())
+}
+
+/// Wrap a terminal escape sequence in tmux's DCS passthrough envelope.
+///
+/// tmux 3.3+ with `set -g allow-passthrough on` (or `all`) will unwrap this
+/// and forward the inner bytes to the outer terminal. Every inner ESC
+/// (0x1B) byte is doubled so tmux's parser does not terminate the DCS early.
+pub fn wrap_for_tmux(seq: &str) -> String {
+    let mut out = String::with_capacity(seq.len() + 16);
+    out.push_str("\x1bPtmux;");
+    for c in seq.chars() {
+        if c == '\x1b' {
+            out.push_str("\x1b\x1b");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push_str("\x1b\\");
+    out
 }
 
 /// Pre-resize an image and encode as PNG for native terminal protocol rendering.
@@ -669,5 +707,35 @@ mod tests {
         let pixel_data = &body[preamble_end..];
         let band_count = pixel_data.split('-').count();
         assert_eq!(band_count, 100);
+    }
+
+    #[test]
+    fn wrap_for_tmux_kitty_graphics() {
+        // A representative Kitty graphics escape: \x1b_G<params>;<payload>\x1b\\
+        let inner = "\x1b_Gf=100,a=t,i=1;abcd\x1b\\";
+        let wrapped = wrap_for_tmux(inner);
+        // Every inner ESC is doubled, whole thing wrapped in DCS passthrough.
+        assert_eq!(
+            wrapped,
+            "\x1bPtmux;\x1b\x1b_Gf=100,a=t,i=1;abcd\x1b\x1b\\\x1b\\"
+        );
+    }
+
+    #[test]
+    fn wrap_for_tmux_iterm2_osc_with_bel() {
+        // iTerm2 inline image escape: \x1b]1337;...\x07 (BEL-terminated OSC).
+        // Only the leading ESC needs doubling; BEL passes through unchanged.
+        let inner = "\x1b]1337;File=inline=1:abc\x07";
+        let wrapped = wrap_for_tmux(inner);
+        assert_eq!(
+            wrapped,
+            "\x1bPtmux;\x1b\x1b]1337;File=inline=1:abc\x07\x1b\\"
+        );
+    }
+
+    #[test]
+    fn wrap_for_tmux_passes_non_escape_bytes_through() {
+        let wrapped = wrap_for_tmux("plain ascii");
+        assert_eq!(wrapped, "\x1bPtmux;plain ascii\x1b\\");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -548,6 +548,22 @@ fn get_or_cache_png(
     Some(b64)
 }
 
+/// Write a single native-image escape sequence, wrapping it in tmux's DCS
+/// passthrough envelope when `in_tmux` is true. Outside tmux this is a plain
+/// pass-through (byte-for-byte equivalent to `write!(backend, "{seq}")`).
+fn emit_passthrough_seq(
+    backend: &mut CrosstermBackend<io::Stdout>,
+    seq: &str,
+    in_tmux: bool,
+) -> io::Result<()> {
+    use std::io::Write;
+    if in_tmux {
+        backend.write_all(image_render::wrap_for_tmux(seq).as_bytes())
+    } else {
+        backend.write_all(seq.as_bytes())
+    }
+}
+
 /// Write native terminal image protocol escape sequences.
 ///
 /// For Kitty: process `kitty_pending_transmits` — transmit image data and create
@@ -556,6 +572,11 @@ fn get_or_cache_png(
 ///
 /// For iTerm2: overlay pre-resized images on top of the halfblock placeholders
 /// using cursor-positioned inline image sequences.
+///
+/// When running inside tmux (`$TMUX` set), every Kitty (`\x1b_G…\x1b\\`) and
+/// iTerm2 (`\x1b]1337;…\x07`) escape is wrapped in tmux's DCS passthrough
+/// envelope so the outer terminal can still see it. Requires `tmux 3.3+` with
+/// `set -g allow-passthrough on` (or `all`).
 fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App) -> Result<()> {
     let protocol = app.image.image_protocol;
     if protocol == image_render::ImageProtocol::Halfblock {
@@ -563,6 +584,7 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
     }
 
     use std::io::Write;
+    let tmux = image_render::in_tmux();
 
     if protocol == image_render::ImageProtocol::Kitty {
         // Kitty Unicode Placeholders: transmit pending images and create virtual placements.
@@ -588,18 +610,18 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
             for (i, chunk) in chunks.iter().enumerate() {
                 let m = if i == chunks.len() - 1 { 0 } else { 1 };
                 let chunk_str = std::str::from_utf8(chunk).unwrap_or("");
-                if i == 0 {
-                    write!(
-                        backend,
-                        "\x1b_Gf=100,a=t,i={id},q=2,m={m};{chunk_str}\x1b\\",
-                    )?;
+                let seq = if i == 0 {
+                    format!("\x1b_Gf=100,a=t,i={id},q=2,m={m};{chunk_str}\x1b\\")
                 } else {
-                    write!(backend, "\x1b_Gm={m};{chunk_str}\x1b\\")?;
-                }
+                    format!("\x1b_Gm={m};{chunk_str}\x1b\\")
+                };
+                emit_passthrough_seq(backend, &seq, tmux)?;
             }
 
             // Create virtual placement (U=1 enables Unicode Placeholder mode)
-            write!(backend, "\x1b_Ga=p,U=1,i={id},c={cols},r={rows},q=2\x1b\\",)?;
+            let placement =
+                format!("\x1b_Ga=p,U=1,i={id},c={cols},r={rows},q=2\x1b\\");
+            emit_passthrough_seq(backend, &placement, tmux)?;
 
             app.image.kitty_transmitted.insert(*id);
         }
@@ -703,11 +725,11 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
 
         queue!(backend, MoveTo(img.x, img.y))?;
 
-        write!(
-            backend,
+        let seq = format!(
             "\x1b]1337;File=inline=1;width={};height={};preserveAspectRatio=0:{b64}\x07",
             img.width, img.height
-        )?;
+        );
+        emit_passthrough_seq(backend, &seq, tmux)?;
     }
 
     queue!(backend, RestorePosition)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -619,8 +619,7 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
             }
 
             // Create virtual placement (U=1 enables Unicode Placeholder mode)
-            let placement =
-                format!("\x1b_Ga=p,U=1,i={id},c={cols},r={rows},q=2\x1b\\");
+            let placement = format!("\x1b_Ga=p,U=1,i={id},c={cols},r={rows},q=2\x1b\\");
             emit_passthrough_seq(backend, &placement, tmux)?;
 
             app.image.kitty_transmitted.insert(*id);


### PR DESCRIPTION
This is, admittedly, slop. However, it did take about an hour, and I am currently using it myself. I just figured I'd send a PR because I'm using it for my own workflow, and I assume there are a fair amount of people who use tmux + kitty that are using command line clients like this. It's small too.

## Problem
Inside tmux, siggy's native image protocols (Kitty / iTerm2 / WezTerm / Ghostty) silently fall back to halfblock. Outside tmux they work fine.
Two combined issues:
1. **Auto-detection.** `detect_protocol()` keys off `KITTY_WINDOW_ID` and `TERM_PROGRAM`. Inside tmux, `KITTY_WINDOW_ID` is not propagated unless explicitly added to `update-environment`, and `TERM_PROGRAM` becomes `tmux`, so detection falls through to `Halfblock`.
2. **Escape wrapping.** Even when forced onto the Kitty / iTerm2 path, raw `\x1b_G…\x1b\\` and `\x1b]1337;…\x07` escapes are stripped by tmux. `set -g allow-passthrough on` (or `all`) is necessary but not sufficient — applications must wrap each escape as `\x1bPtmux;<doubled-escapes>\x1b\\`.
## Changes
`src/image_render.rs`
- `in_tmux()` — `$TMUX` is set
- `wrap_for_tmux(seq)` — wraps a single escape in tmux's DCS passthrough envelope, doubling every inner `\x1b`
- `SIGGY_IMAGE_PROTOCOL` env override at the top of `detect_protocol()` (`kitty` / `iterm2` / `sixel` / `halfblock`)
- 3 unit tests for `wrap_for_tmux`
`src/main.rs`
- `emit_passthrough_seq()` helper
- 4 call-site rewrites in `emit_native_images()` (3 Kitty writes, 1 iTerm2 write). Outside tmux, `emit_passthrough_seq` reduces to `backend.write_all(seq.as_bytes())` — byte-for-byte equivalent to the previous `write!` calls, so the non-tmux path is unchanged.
Sixel is intentionally untouched: tmux 3.4+ handles Sixel natively.
## Env var vs. config field — open to your preference
I added `SIGGY_IMAGE_PROTOCOL` as an env var rather than a config field because it felt like the lightest-weight escape hatch for the "can't detect the outer terminal through tmux" case. Happy to switch this to any of:
- A config field (e.g. `force_image_protocol = "kitty"` in the TOML)
- Drop it entirely and just document `set -ag update-environment 'KITTY_WINDOW_ID'` as the recommended tmux setup (the existing detection then works unchanged)
- Both env + config, with config taking precedence
Which do you prefer? Happy to revise.
## Test plan
Requires tmux 3.3+ with `set -g allow-passthrough on` (or `all`). Outer terminal must be one with a native image protocol (kitty, Ghostty, WezTerm, iTerm2).
```sh
SIGGY_IMAGE_PROTOCOL=kitty siggy        # or =iterm2
```
Image attachments now render as actual pixels rather than halfblock.
## Verification
- `cargo build --release` ✔
- `cargo test --release --bin siggy` ✔ (579 pass, +3 new)
- `cargo clippy --tests -- -D warnings` ✔
Tested live on kitty 0.46.2 + tmux 3.6a + macOS.
## Known limitations
tmux does not track graphics cells in its grid model, so images may not redraw cleanly on tmux pane resize / scroll-up. Self-resolves on the next siggy redraw; not worse than other tmux-aware TUI apps like yazi.
## Disclosure
Patch developed with AI assistance; logic, tests, and live verification done by me. Happy to iterate on any feedback.