### PR TITLE
docs(v1.8.0): refresh user-guide and dev-guide pages

### DIFF
--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -67,8 +67,25 @@
 - [x] Multi-line message input (Alt+Enter / Shift+Enter for newlines)
 - [x] Message history pagination (scroll-up to load older messages)
 - [x] Configurable keybindings (profiles, in-app rebinding, TOML overrides)
+- [x] Export chat history (`/export` to a plain text file)
+- [x] Sidebar filter (type-to-filter from Normal mode)
+- [x] Jump to quoted message (`Q` to jump, `Ctrl+O` to jump back)
+- [x] Delete conversations (`/delete` removes locally + declines message requests)
+- [x] Session lock + boss key (`Ctrl-L`, `/lock`, `/lock-reset`, `--reset-lock`)
+- [x] Native inline images inside tmux (DCS passthrough wrapping, `SIGGY_IMAGE_PROTOCOL` override) -- thanks @cultlead3r
 
 ## Future
 
-*No planned features at this time. Have an idea?
-[Open an issue](https://github.com/johnsideserf/siggy/issues).*
+Tracked in GitHub issues:
+
+- [Auto-lock idle timer (#438)](https://github.com/johnsideserf/siggy/issues/438) -- round out the session-lock feature with a configurable idle timeout
+- [Multi-account switching (#260)](https://github.com/johnsideserf/siggy/issues/260)
+- [Voice message playback (#199)](https://github.com/johnsideserf/siggy/issues/199)
+- [Scheduled messages via OS scheduler (#259)](https://github.com/johnsideserf/siggy/issues/259)
+- [Non-interactive CLI mode for scripting (#257)](https://github.com/johnsideserf/siggy/issues/257)
+- [Claude Code skill for siggy CLI (#258)](https://github.com/johnsideserf/siggy/issues/258)
+- [Bridge keybinding system to support command actions (#202)](https://github.com/johnsideserf/siggy/issues/202)
+- [Link Previews enhancement (#267)](https://github.com/johnsideserf/siggy/issues/267)
+- [Translations of README and docs site (#353)](https://github.com/johnsideserf/siggy/issues/353)
+
+Have an idea? [Open an issue](https://github.com/johnsideserf/siggy/issues).

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -28,9 +28,8 @@ notify_group = true
 desktop_notifications = false
 notification_preview = "full"
 clipboard_clear_seconds = 30
-inline_images = true
+image_mode = "halfblock"
 show_link_previews = true
-native_images = false
 date_separators = true
 show_receipts = true
 color_receipts = true
@@ -59,9 +58,8 @@ proxy = ""
 | `desktop_notifications` | bool | `false` | OS-level desktop notifications for incoming messages |
 | `notification_preview` | string | `"full"` | Notification content level: `full`, `sender`, or `minimal` |
 | `clipboard_clear_seconds` | int | `30` | Seconds before clipboard auto-clears after copying (0 = disabled) |
-| `inline_images` | bool | `true` | Render image attachments as halfblock art |
+| `image_mode` | string | `"halfblock"` | Image rendering mode: `native` (Kitty / iTerm2 / Sixel), `halfblock` (universal Unicode fallback), or `none` |
 | `show_link_previews` | bool | `true` | Show link preview cards for URLs in messages |
-| `native_images` | bool | `false` | Use native terminal image protocols (Kitty/iTerm2) |
 | `date_separators` | bool | `true` | Show date separator lines between messages from different days |
 | `show_receipts` | bool | `true` | Show delivery/read receipt status symbols |
 | `color_receipts` | bool | `true` | Colored receipt status symbols (vs monochrome) |
@@ -86,6 +84,17 @@ CLI flags override config file values for the current session:
 | `-a +15551234567` | `account` |
 | `-c /path/to/config.toml` | Config file path |
 | `--incognito` | Uses in-memory database (no persistence) |
+| `--demo` | Launch with dummy data (no signal-cli needed) |
+| `--setup` | Re-run the first-time setup wizard |
+| `--debug` | Write debug log to `~/.cache/siggy/debug.log` (PII redacted) |
+| `--debug-full` | Same as `--debug` but without redaction |
+| `--reset-lock` | Delete the session-lock passphrase hash and exit |
+
+## Environment variables
+
+| Var | Effect |
+|---|---|
+| `SIGGY_IMAGE_PROTOCOL` | Force image protocol selection (`kitty` / `iterm2` / `sixel` / `halfblock`). Useful inside tmux where auto-detection cannot see the outer terminal. |
 
 ## Settings overlay
 
@@ -95,9 +104,9 @@ Press `/settings` inside the app to open the settings overlay. This provides
 toggles for runtime settings:
 
 - Notification toggles (direct / group / desktop)
-- Notification preview level
+- Notification preview level (cycles full / sender / minimal)
 - Sidebar visibility / position
-- Inline image previews / link previews / native images
+- Image mode (cycles native / halfblock / none) and link previews
 - Date separators
 - Show read receipts / receipt colors / nerd font icons
 - Emoji-to-text mode

--- a/docs/src/user-guide/faq.md
+++ b/docs/src/user-guide/faq.md
@@ -46,6 +46,31 @@ siggy -a +15559876543
 
 Each account needs its own device linking via signal-cli.
 
+## I locked the session and forgot my passphrase. Now what?
+
+Quit siggy (or kill the process if the lock screen is in the way) and run:
+
+```sh
+siggy --reset-lock
+```
+
+The flag deletes the stored passphrase hash file and prints the path it
+removed. The next time you `/lock`, you will be prompted to set a fresh
+passphrase. By design there is no in-app recovery -- the lock is a
+casual-snooping deterrent, not protection against file-system access.
+
+## Images aren't rendering as native pixels inside tmux
+
+tmux strips the Kitty / iTerm2 graphics escapes unless you opt into
+passthrough, and `TERM_PROGRAM` becomes `tmux` so siggy cannot auto-detect
+the outer terminal. Two steps:
+
+1. In `~/.tmux.conf`: `set -g allow-passthrough on` (requires tmux 3.3+).
+2. Launch siggy with the outer terminal's protocol named:
+   `SIGGY_IMAGE_PROTOCOL=kitty siggy` (or `iterm2`, `sixel`, `halfblock`).
+
+See the Troubleshooting page for details.
+
 ## How do I update siggy?
 
 Re-run the install script, or download the latest binary from the

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -7,10 +7,16 @@ linked devices) sync into the TUI automatically.
 
 ## Attachments
 
-- **Images** -- rendered inline as halfblock art when `inline_images = true`
-- **Native image protocols** -- for terminals that support Kitty or iTerm2
-  graphics, enable `/settings` > "Native images" for higher-fidelity rendering
-  with proper cropping and flicker-free scrolling
+- **Images** -- rendered inline based on the `image_mode` setting:
+  - `halfblock` (default) -- Unicode halfblock art, universal fallback
+  - `native` -- Kitty / iTerm2 / Sixel graphics protocols for higher-fidelity
+    pixel rendering with proper cropping and flicker-free scrolling
+  - `none` -- skip image rendering entirely
+- **Native images inside tmux** -- Kitty and iTerm2 escapes are wrapped in
+  tmux's DCS passthrough envelope so attachments still render as actual pixels.
+  Requires tmux 3.3+ with `set -g allow-passthrough on` plus the
+  `SIGGY_IMAGE_PROTOCOL` env var to name the outer terminal (auto-detection
+  cannot see through tmux). See the Troubleshooting page.
 - **Other files** -- shown as `[attachment: filename]` with the download path
 - **Send files** -- use `/attach` to open a file browser and attach a file to
   your next message
@@ -102,6 +108,30 @@ siggy --incognito
 Uses an in-memory database instead of on-disk SQLite. No messages, conversations,
 or read markers are written to disk. The status bar shows a bold magenta
 **incognito** indicator. When you exit, everything is gone.
+
+## Session lock + boss key
+
+`Ctrl-L` (or `/lock`) blanks the visible chat behind a passphrase prompt --
+think "boss key" for terminal sessions. The passphrase is stored as an
+argon2 PHC hash, never as plaintext. While locked, terminal bells and
+desktop notifications are suppressed and the window title is clamped to
+bare `siggy` so no unread count leaks. Unlock by typing the passphrase
+followed by Enter.
+
+The first time you `/lock`, you set the passphrase. After that, lock is
+instant. Use `/lock-reset` (from inside the app, requires the current
+passphrase) to change it.
+
+**Forgot the passphrase?** Quit siggy and run:
+
+```sh
+siggy --reset-lock
+```
+
+This deletes the stored hash file (`{config_dir}/lock_hash`) and prints the
+path it removed. The next `/lock` sets a fresh passphrase. By design there
+is no in-app recovery -- the lock is a casual-snooping deterrent, not a
+defence against filesystem access.
 
 ## Message reactions
 

--- a/docs/src/user-guide/security.md
+++ b/docs/src/user-guide/security.md
@@ -100,6 +100,23 @@ Unix systems, the log file and directory are created with restrictive permission
 Copied message content is automatically cleared from the system clipboard after
 30 seconds (configurable via `clipboard_clear_seconds` in config).
 
+### Session lock
+
+`Ctrl-L` (or `/lock`) blanks the chat behind a passphrase prompt for the
+"someone walked up to my terminal" case. The passphrase is stored as an argon2
+PHC hash at `{config_dir}/lock_hash`, never as plaintext. While locked:
+
+- Keyboard input is intercepted; nothing reaches the composer
+- Terminal bell and OS desktop notifications are suppressed
+- Window title is clamped to bare `siggy` so the unread count does not leak
+
+**Threat model.** Session lock is a deterrent against casual on-screen
+snooping, not a defence against an attacker with shell access. Anyone who can
+read your home directory can also delete `lock_hash` and bypass the prompt,
+which is the same escape hatch the maintainer uses to recover from a
+forgotten passphrase (`siggy --reset-lock`). If you need stronger
+at-rest protection for the message DB, rely on full-disk encryption.
+
 ## Recommendations
 
 - **Enable full-disk encryption** on your device (BitLocker, LUKS, FileVault).

--- a/docs/src/user-guide/troubleshooting.md
+++ b/docs/src/user-guide/troubleshooting.md
@@ -58,9 +58,36 @@ the install script uses the native signal-cli build which does not require Java.
 
 **Symptom:** images show as `[attachment: image.jpg]` instead of inline previews.
 
-**Fix:** make sure `inline_images = true` in your config (this is the default).
-Also check that your terminal supports 256 colors or truecolor. Halfblock
-rendering requires a terminal with proper Unicode support.
+**Fix:** make sure `image_mode` in your config is not set to `"none"`. The
+default `"halfblock"` works in any terminal with truecolor / 256-color and
+proper Unicode support. `"native"` uses the Kitty / iTerm2 graphics protocol
+where supported, with automatic fallback otherwise.
+
+## Native images render as halfblock inside tmux
+
+**Symptom:** outside tmux, image attachments render as actual pixels. Inside
+tmux they fall back to halfblock even though the outer terminal supports a
+native protocol.
+
+**Why:** tmux strips Kitty (`ESC _G...`) and iTerm2 (`ESC ]1337;...`) escapes
+unless they are wrapped in tmux's DCS passthrough envelope, and
+`TERM_PROGRAM` becomes `tmux` so auto-detection cannot see the outer terminal.
+
+**Fix:** two steps. First, in your `~/.tmux.conf`:
+
+```
+set -g allow-passthrough on
+```
+
+(Older tmux uses `set -g allow-passthrough all`. Requires tmux 3.3+.) Then
+launch siggy with an explicit protocol override that names the outer
+terminal:
+
+```sh
+SIGGY_IMAGE_PROTOCOL=kitty siggy        # or iterm2 / sixel / halfblock
+```
+
+Sixel passes through tmux 3.4+ natively and does not need the env var.
 
 ## Sidebar disappeared
 


### PR DESCRIPTION
Follow-up to v1.8.0 (#468). The release PR only touched Cargo.toml, the changelog, and the about snapshot. This sweeps the rest of the mdBook so the docsite matches what shipped.

## Pages updated

- **user-guide/features.md** -- new \"Session lock + boss key\" section; Attachments section updated for the \`image_mode\` enum and tmux passthrough requirement.
- **user-guide/troubleshooting.md** -- updated \"Images not rendering\" wording; new \"Native images render as halfblock inside tmux\" entry with the full setup steps.
- **user-guide/security.md** -- new \"Session lock\" subsection under Privacy features, with explicit threat model (deterrent, not anti-shell-access).
- **user-guide/configuration.md** -- field reference updated for \`image_mode\` (was \`inline_images\` + \`native_images\`); CLI flags table extended with \`--demo\`, \`--setup\`, \`--debug\`, \`--debug-full\`, \`--reset-lock\`; new Environment variables subsection covering \`SIGGY_IMAGE_PROTOCOL\`; Settings overlay bullet updated for image-mode cycling.
- **user-guide/faq.md** -- \"I locked the session and forgot my passphrase\" entry and \"Images aren't rendering as native pixels inside tmux\" entry.
- **dev-guide/roadmap.md** -- marked v1.6 - v1.8 completed items; Future section now links the deferred tracked issues (#199, #202, #257, #258, #259, #260, #267, #353, #438) instead of \"no planned features\".

## Out of scope

Backfilling v1.6 / v1.7 changelog entries -- the existing changelog jumped straight from v1.5.0 to v1.8.0 because v1.6 / v1.7 were never written up at release time. Treating that as a separate cleanup if anyone wants it.

No code or runtime behaviour changes.