### PR TITLE
fix: send-status integrity - failed sends no longer display as sent

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3012,11 +3012,15 @@ impl App {
             let msg_count = conv.messages.len();
             let unread = conv.unread;
 
-            // Promote stale Sending messages to Sent — if they're in the DB, the
-            // send completed but the app exited before the RPC response arrived.
+            // Demote stale Sending messages to Failed. A row stuck in Sending
+            // means no SendTimestamp ever confirmed it: the app exited before
+            // the response, the RPC errored without a SendFailed, or the
+            // request never reached signal-cli at all. Promoting to Sent here
+            // displayed never-delivered messages as sent (#486); Failed is
+            // honest and prompts the user to resend.
             for msg in &mut conv.messages {
                 if msg.status == Some(MessageStatus::Sending) {
-                    msg.status = Some(MessageStatus::Sent);
+                    msg.status = Some(MessageStatus::Failed);
                 }
             }
 
@@ -3114,12 +3118,13 @@ impl App {
 
         let prepend_count = new_msgs.len();
 
-        // Post-process: promote stale Sending → Sent, resolve image paths
+        // Post-process: demote stale Sending → Failed (see load_from_db, #486),
+        // resolve image paths
         let mut processed: Vec<DisplayMessage> = new_msgs
             .into_iter()
             .map(|mut msg| {
                 if msg.status == Some(MessageStatus::Sending) {
-                    msg.status = Some(MessageStatus::Sent);
+                    msg.status = Some(MessageStatus::Failed);
                 }
                 if msg.body.starts_with("[image:") {
                     let path_str = if let Some(uri_pos) = msg.body.find("file:///") {
@@ -7272,6 +7277,74 @@ mod tests {
             .unwrap();
         app.load_from_db().unwrap();
         assert!(!app.store.has_more_messages.contains(conv_id));
+    }
+
+    // Reproduces #486: a row stuck in Sending means no SendTimestamp ever
+    // confirmed it. Promoting it to Sent on restart displayed never-delivered
+    // messages as sent; it must come back as Failed.
+    #[rstest]
+    fn load_from_db_demotes_stale_sending_to_failed(mut app: App) {
+        let conv_id = "+stale";
+        app.db.upsert_conversation(conv_id, "Stale", false).unwrap();
+        app.db
+            .insert_message(
+                conv_id,
+                "you",
+                "2025-01-01T00:00:00Z",
+                "never confirmed",
+                false,
+                Some(MessageStatus::Sending),
+                1000,
+            )
+            .unwrap();
+        app.load_from_db().unwrap();
+        assert_eq!(
+            app.store.conversations[conv_id].messages[0].status,
+            Some(MessageStatus::Failed)
+        );
+    }
+
+    // Reproduces #486: when dispatch_send fails locally (stdin channel closed),
+    // no SendFailed event will ever arrive, so the dispatcher calls
+    // mark_send_failed directly. It must update memory and the DB.
+    #[rstest]
+    fn mark_send_failed_updates_memory_and_db(mut app: App) {
+        let conv_id = "+1";
+        let local_ts = 1700000000000_i64;
+        app.db.upsert_conversation(conv_id, "Alice", false).unwrap();
+        app.db
+            .insert_message(
+                conv_id,
+                "you",
+                "2025-01-01T00:00:00Z",
+                "doomed",
+                false,
+                Some(MessageStatus::Sending),
+                local_ts,
+            )
+            .unwrap();
+        app.load_from_db().unwrap();
+        // load_from_db demotes stale Sending; restore an in-flight send state
+        app.store.conversations.get_mut(conv_id).unwrap().messages[0].status =
+            Some(MessageStatus::Sending);
+        app.db
+            .update_message_status(conv_id, local_ts, MessageStatus::Sending.to_i32())
+            .unwrap();
+
+        assert_eq!(app.store.conversations[conv_id].messages.len(), 1);
+        assert_eq!(
+            app.store.conversations[conv_id].messages[0].timestamp_ms,
+            local_ts
+        );
+
+        crate::handlers::signal::mark_send_failed(&mut app, conv_id, local_ts);
+
+        assert_eq!(
+            app.store.conversations[conv_id].messages[0].status,
+            Some(MessageStatus::Failed)
+        );
+        let reloaded = app.db.load_messages_page(conv_id, 10, 0).unwrap();
+        assert_eq!(reloaded[0].status, Some(MessageStatus::Failed));
     }
 
     #[rstest]

--- a/src/db.rs
+++ b/src/db.rs
@@ -590,6 +590,25 @@ impl Database {
         Ok(())
     }
 
+    /// Mark an outgoing message Failed. Needs its own method because
+    /// `update_message_status` only allows upward transitions and Failed (1)
+    /// sits below Sending (2), so a failure write through it was silently
+    /// dropped (#486). A failure is only valid from the Sending state, so
+    /// that is the guard here.
+    pub fn mark_message_failed(&self, conv_id: &str, timestamp_ms: i64) -> Result<()> {
+        self.conn.execute(
+            "UPDATE messages SET status = ?3
+             WHERE conversation_id = ?1 AND timestamp_ms = ?2 AND sender = 'you' AND status = ?4",
+            params![
+                conv_id,
+                timestamp_ms,
+                MessageStatus::Failed.to_i32(),
+                MessageStatus::Sending.to_i32()
+            ],
+        )?;
+        Ok(())
+    }
+
     /// Update timestamp_ms and status for an outgoing message when the server assigns
     /// a canonical timestamp (replacing the local one).
     pub fn update_message_timestamp_ms(

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -1340,22 +1340,30 @@ fn handle_send_failed(app: &mut App, rpc_id: &str) {
         );
     }
     if let Some((conv_id, local_ts)) = app.pending.sends.remove(rpc_id) {
-        let mut found = false;
-        if let Some(conv) = app.store.conversations.get_mut(&conv_id)
-            && let Some(idx) = conv
-                .find_msg_idx(local_ts)
-                .filter(|&idx| conv.messages[idx].is_outgoing())
-        {
-            conv.messages[idx].status = Some(MessageStatus::Failed);
-            found = true;
-        }
-        if found {
-            app.db_warn_visible(
-                app.db
-                    .update_message_status(&conv_id, local_ts, MessageStatus::Failed.to_i32()),
-                "update_message_status",
-            );
-        }
+        mark_send_failed(app, &conv_id, local_ts);
+    }
+}
+
+/// Mark an outgoing message Failed in memory and in the DB. Shared by the
+/// RPC SendFailed path above and by dispatch_send's local-failure path
+/// (stdin channel closed before the request ever reached signal-cli, #486).
+pub(crate) fn mark_send_failed(app: &mut App, conv_id: &str, local_ts: i64) {
+    let mut found = false;
+    if let Some(conv) = app.store.conversations.get_mut(conv_id)
+        && let Some(idx) = conv
+            .find_msg_idx(local_ts)
+            .filter(|&idx| conv.messages[idx].is_outgoing())
+    {
+        conv.messages[idx].status = Some(MessageStatus::Failed);
+        found = true;
+    }
+    if found {
+        // Not update_message_status: its monotonic guard rejects the
+        // Sending -> Failed transition (Failed sorts below Sending).
+        app.db_warn_visible(
+            app.db.mark_message_failed(conv_id, local_ts),
+            "mark_message_failed",
+        );
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -792,6 +792,10 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
                 }
                 Err(e) => {
                     app.status_message = format!("send error: {e}");
+                    // The request never reached signal-cli, so no SendFailed event
+                    // will ever arrive — mark the optimistic message Failed here
+                    // or it stays in Sending forever (#486).
+                    handlers::signal::mark_send_failed(app, &recipient, local_ts_ms);
                     // RPC failed to send — delete temp file immediately (signal-cli never saw it)
                     for path in &attachments {
                         if path.starts_with(&app.paste_temp_path) {
@@ -1076,6 +1080,7 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
                 }
                 Err(e) => {
                     app.status_message = format!("poll error: {e}");
+                    handlers::signal::mark_send_failed(app, &recipient, local_ts_ms);
                 }
             }
         }

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -97,9 +97,13 @@ impl SignalClient {
                                 crate::debug_log::logf(format_args!(
                                     "rpc error: method={method} error={err:?}"
                                 ));
-                                // RPC error — emit SendFailed for send requests,
-                                // surface other errors to the status bar
-                                if method == "send" {
+                                // RPC error — emit SendFailed for every method that
+                                // registers in pending.sends (dispatch_send tracks
+                                // "send" and "sendPollCreate"), surface other errors
+                                // to the status bar. Routing a tracked method to the
+                                // generic Error arm leaks the pending entry and the
+                                // local message stays in Sending forever (#486).
+                                if method == "send" || method == "sendPollCreate" {
                                     rpc_id.map(|id| SignalEvent::SendFailed { rpc_id: id })
                                 } else {
                                     Some(SignalEvent::Error(format!("{method}: {}", err.message)))


### PR DESCRIPTION
Closes #486.

Four related defects with one user-facing theme: a send that failed could end up displayed as Sent.

1. **RPC error routing:** client.rs emitted SendFailed only for method == "send". sendPollCreate errors fell to the generic Error arm, leaking the pending.sends entry; the local poll message kept its Sending glyph forever. Both tracked methods now route to SendFailed.

2. **Local dispatch failure:** when the stdin channel to signal-cli is closed (process crashed), dispatch_send only set a status message; no SendFailed will ever arrive, so the optimistic message stayed in Sending. The Message and PollCreate error arms now call a shared mark_send_failed helper (extracted from handle_send_failed).

3. **The DB write never worked (found while testing this PR):** update_message_status carries a monotonic guard (`status < ?3`) so receipts cannot downgrade Read to Delivered -- but Failed (1) sorts below Sending (2), so every Sending -> Failed write was silently dropped. The existing RPC SendFailed path has never persisted Failed. New `db.mark_message_failed` permits exactly the Sending -> Failed transition.

4. **Restart promotion:** load_from_db / load_more_messages promoted stale Sending rows to Sent ("if it is in the DB the send completed" -- false for every path above, and the dropped DB write in (3) widened the blast radius). They now demote to Failed, which is honest and prompts the user to resend.

Two regression tests: stale-Sending demotion on load, and mark_send_failed updating both memory and the DB through the new method. Clippy clean, 772 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)