### PR TITLE
fix: verify sender is the author before applying edits and remote-deletes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10835,6 +10835,115 @@ mod tests {
         assert!(conv.messages[idx].reactions.is_empty());
     }
 
+    // --- #482: only the original author may edit or remote-delete ---
+    //
+    // The Signal server does not enforce author-match on edit/delete
+    // envelopes; official clients verify client-side. Without the check,
+    // any conversation member can rewrite or delete someone else's
+    // message locally by targeting its (visible) timestamp.
+
+    #[rstest]
+    fn edit_from_non_author_is_rejected(mut app: App) {
+        let ts = 1_700_000_000_000;
+        let conv_id = seed_conv_with_msg(&mut app, "+1", "original", ts);
+
+        app.handle_signal_event(SignalEvent::EditReceived {
+            conv_id: conv_id.clone(),
+            sender: "+2".to_string(), // not the author of the target
+            sender_name: Some("Mallory".to_string()),
+            target_timestamp: ts,
+            new_body: "forged".to_string(),
+            new_timestamp: ts + 1,
+            is_outgoing: false,
+        });
+
+        let conv = &app.store.conversations[&conv_id];
+        let idx = conv.find_msg_idx(ts).expect("message present");
+        assert_eq!(conv.messages[idx].body, "original");
+        assert!(!conv.messages[idx].is_edited);
+    }
+
+    #[rstest]
+    fn remote_delete_from_non_author_is_rejected(mut app: App) {
+        let ts = 1_700_000_000_000;
+        let conv_id = seed_conv_with_msg(&mut app, "+1", "original", ts);
+
+        app.handle_signal_event(SignalEvent::RemoteDeleteReceived {
+            conv_id: conv_id.clone(),
+            sender: "+2".to_string(),
+            target_timestamp: ts,
+        });
+
+        let conv = &app.store.conversations[&conv_id];
+        let idx = conv.find_msg_idx(ts).expect("message present");
+        assert!(!conv.messages[idx].is_deleted);
+        assert_eq!(conv.messages[idx].body, "original");
+    }
+
+    #[rstest]
+    fn edit_targeting_outgoing_message_from_contact_is_rejected(mut app: App) {
+        // A contact crafts an editMessage whose targetSentTimestamp matches
+        // one of OUR outgoing messages (timestamps are visible to them).
+        let ts = 1_700_000_000_000;
+        let conv_id = seed_conv_with_msg(&mut app, "+1", "their msg", ts - 10);
+        if let Some(conv) = app.store.conversations.get_mut(&conv_id) {
+            let mut mine = conv.messages[0].clone();
+            mine.sender = "you".to_string();
+            mine.sender_id = String::new();
+            mine.status = Some(MessageStatus::Sent);
+            mine.timestamp_ms = ts;
+            mine.body = "my message".to_string();
+            conv.messages.push(mine);
+        }
+
+        app.handle_signal_event(SignalEvent::EditReceived {
+            conv_id: conv_id.clone(),
+            sender: "+1".to_string(), // the contact, NOT this account
+            sender_name: Some("Alice".to_string()),
+            target_timestamp: ts,
+            new_body: "you said this, honest".to_string(),
+            new_timestamp: ts + 1,
+            is_outgoing: false,
+        });
+
+        let conv = &app.store.conversations[&conv_id];
+        let idx = conv.find_msg_idx(ts).expect("message present");
+        assert_eq!(conv.messages[idx].body, "my message");
+        assert!(!conv.messages[idx].is_edited);
+    }
+
+    #[rstest]
+    fn own_sync_edit_of_outgoing_message_applies(mut app: App) {
+        // Editing your own message from another device: sync envelope whose
+        // sender is this account. Must still apply.
+        let ts = 1_700_000_000_000;
+        let conv_id = seed_conv_with_msg(&mut app, "+1", "their msg", ts - 10);
+        if let Some(conv) = app.store.conversations.get_mut(&conv_id) {
+            let mut mine = conv.messages[0].clone();
+            mine.sender = "you".to_string();
+            mine.sender_id = String::new();
+            mine.status = Some(MessageStatus::Sent);
+            mine.timestamp_ms = ts;
+            mine.body = "my message".to_string();
+            conv.messages.push(mine);
+        }
+
+        app.handle_signal_event(SignalEvent::EditReceived {
+            conv_id: conv_id.clone(),
+            sender: app.account.clone(),
+            sender_name: None,
+            target_timestamp: ts,
+            new_body: "my message, fixed".to_string(),
+            new_timestamp: ts + 1,
+            is_outgoing: true,
+        });
+
+        let conv = &app.store.conversations[&conv_id];
+        let idx = conv.find_msg_idx(ts).expect("message present");
+        assert_eq!(conv.messages[idx].body, "my message, fixed");
+        assert!(conv.messages[idx].is_edited);
+    }
+
     #[rstest]
     fn pin_received_sets_pinned_and_inserts_system_message(mut app: App) {
         let ts = 1_700_000_002_000;

--- a/src/db.rs
+++ b/src/db.rs
@@ -612,6 +612,35 @@ impl Database {
         Ok(())
     }
 
+    /// Author fields of the message row at `timestamp_ms`:
+    /// (sender, sender_id, is_outgoing). Used by the edit / remote-delete
+    /// author check (#482) when the target message is outside the loaded
+    /// page. Outgoing detection mirrors `DisplayMessage::is_outgoing`:
+    /// a stored status (non-zero) or the literal "you" sender.
+    pub fn message_author(
+        &self,
+        conv_id: &str,
+        timestamp_ms: i64,
+    ) -> Result<Option<(String, String, bool)>> {
+        use rusqlite::OptionalExtension;
+        let row = self
+            .conn
+            .query_row(
+                "SELECT sender, sender_id, status FROM messages
+                 WHERE conversation_id = ?1 AND timestamp_ms = ?2 LIMIT 1",
+                params![conv_id, timestamp_ms],
+                |row| {
+                    let sender: String = row.get(0)?;
+                    let sender_id: String = row.get(1)?;
+                    let status: i32 = row.get(2)?;
+                    let outgoing = status != 0 || sender == "you";
+                    Ok((sender, sender_id, outgoing))
+                },
+            )
+            .optional()?;
+        Ok(row)
+    }
+
     /// Mark an outgoing message Failed. Needs its own method because
     /// `update_message_status` only allows upward transitions and Failed (1)
     /// sits below Sending (2), so a failure write through it was silently

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -106,14 +106,14 @@ pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
         } => {
             app.store
                 .remember_contact_name(&sender, sender_name.as_deref());
-            handle_edit_received(app, &conv_id, target_timestamp, &new_body);
+            handle_edit_received(app, &conv_id, &sender, target_timestamp, &new_body);
         }
         SignalEvent::RemoteDeleteReceived {
             conv_id,
-            sender: _,
+            sender,
             target_timestamp,
         } => {
-            handle_remote_delete(app, &conv_id, target_timestamp);
+            handle_remote_delete(app, &conv_id, &sender, target_timestamp);
         }
         SignalEvent::PinReceived {
             conv_id,
@@ -921,7 +921,60 @@ fn handle_reaction(
     }
 }
 
-fn handle_edit_received(app: &mut App, conv_id: &str, target_timestamp: i64, new_body: &str) {
+/// Whether `sender` is the author of the message at `target_timestamp` and
+/// may therefore edit or remote-delete it. The Signal server does not
+/// enforce author-match on edit/delete envelopes; official clients verify
+/// client-side, and skipping the check lets any conversation member rewrite
+/// or delete someone else's message locally (#482). Checks the in-memory
+/// message first, falling back to the DB row for messages outside the
+/// loaded page; a message found nowhere yields false (nothing to mutate).
+fn sender_may_mutate(app: &App, conv_id: &str, target_timestamp: i64, sender: &str) -> bool {
+    let author = app
+        .store
+        .conversations
+        .get(conv_id)
+        .and_then(|conv| {
+            conv.find_msg_idx(target_timestamp).map(|idx| {
+                let m = &conv.messages[idx];
+                (m.sender.clone(), m.sender_id.clone(), m.is_outgoing())
+            })
+        })
+        .or_else(|| {
+            app.db
+                .message_author(conv_id, target_timestamp)
+                .ok()
+                .flatten()
+        });
+    let Some((msg_sender, msg_sender_id, outgoing)) = author else {
+        return false;
+    };
+    if outgoing {
+        // Only this account (sync from another of our devices) may touch
+        // our own messages.
+        return sender == app.account;
+    }
+    // Incoming message: the mutating sender must be its author. sender_id
+    // carries the wire id; the display-name fallbacks mirror the author
+    // check reactions already perform.
+    msg_sender_id == sender
+        || msg_sender == sender
+        || app.store.contact_names.get(sender).map(String::as_str) == Some(msg_sender.as_str())
+}
+
+fn handle_edit_received(
+    app: &mut App,
+    conv_id: &str,
+    sender: &str,
+    target_timestamp: i64,
+    new_body: &str,
+) {
+    if !sender_may_mutate(app, conv_id, target_timestamp, sender) {
+        crate::debug_log::logf(format_args!(
+            "rejected edit from non-author: conv={} ts={target_timestamp}",
+            crate::debug_log::mask_phone(conv_id)
+        ));
+        return;
+    }
     if let Some(conv) = app.store.conversations.get_mut(conv_id)
         && let Some(idx) = conv.find_msg_idx(target_timestamp)
     {
@@ -935,7 +988,14 @@ fn handle_edit_received(app: &mut App, conv_id: &str, target_timestamp: i64, new
     );
 }
 
-fn handle_remote_delete(app: &mut App, conv_id: &str, target_timestamp: i64) {
+fn handle_remote_delete(app: &mut App, conv_id: &str, sender: &str, target_timestamp: i64) {
+    if !sender_may_mutate(app, conv_id, target_timestamp, sender) {
+        crate::debug_log::logf(format_args!(
+            "rejected remote-delete from non-author: conv={} ts={target_timestamp}",
+            crate::debug_log::mask_phone(conv_id)
+        ));
+        return;
+    }
     if let Some(conv) = app.store.conversations.get_mut(conv_id)
         && let Some(idx) = conv.find_msg_idx(target_timestamp)
     {


### PR DESCRIPTION
Closes #482.

`handle_edit_received` ignored the envelope sender entirely and `handle_remote_delete` explicitly discarded it. Both located the target purely by conversation + timestamp and applied unconditionally, in memory and in the DB. Timestamps are visible to every conversation participant, so any member could craft an editMessage or remoteDelete targeting someone else''s message -- including yours -- and siggy would rewrite or delete it locally, displaying attacker text under the victim''s name with only an "(edited)" label. The Signal server does not enforce author-match on these envelopes; official clients verify client-side. Reactions already performed this check (handle_reaction); edits and deletes now do too.

Implementation: new `sender_may_mutate()` checks the in-memory message first, falling back to a DB row lookup (new `db.message_author`) for messages outside the loaded page, so the previous behavior of persisting edits for unloaded messages is preserved -- but now authorized. Own-message mutations require the envelope sender to be this account (device sync); incoming-message mutations require the sender to match the author by wire id, raw sender, or resolved display name, mirroring the reaction check. Rejected attempts are logged to the debug log.

Verification-first: three rejection tests failed against master (forged edit applied, forged delete applied, contact rewriting our own outgoing message applied); one positive test pins that sync edits from your own other devices still work. The pre-existing legitimate-edit tests pass unchanged.

Clippy clean, 791 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)