### PR TITLE
docs: move translated READMEs from repo root to translations/

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,29 +15,29 @@
 <p align="center">
   <b>English</b>
   &nbsp;|&nbsp;
-  <a href="README.da.md">Dansk</a>
+  <a href="translations/README.da.md">Dansk</a>
   &nbsp;|&nbsp;
-  <a href="README.de.md">Deutsch</a>
+  <a href="translations/README.de.md">Deutsch</a>
   &nbsp;|&nbsp;
-  <a href="README.es.md">Español</a>
+  <a href="translations/README.es.md">Español</a>
   &nbsp;|&nbsp;
-  <a href="README.fr.md">Français</a>
+  <a href="translations/README.fr.md">Français</a>
   &nbsp;|&nbsp;
-  <a href="README.it.md">Italiano</a>
+  <a href="translations/README.it.md">Italiano</a>
   &nbsp;|&nbsp;
-  <a href="README.nl.md">Nederlands</a>
+  <a href="translations/README.nl.md">Nederlands</a>
   &nbsp;|&nbsp;
-  <a href="README.pt-BR.md">Português</a>
+  <a href="translations/README.pt-BR.md">Português</a>
   &nbsp;|&nbsp;
-  <a href="README.fi.md">Suomi</a>
+  <a href="translations/README.fi.md">Suomi</a>
   &nbsp;|&nbsp;
-  <a href="README.sv.md">Svenska</a>
+  <a href="translations/README.sv.md">Svenska</a>
   &nbsp;|&nbsp;
-  <a href="README.ru.md">Русский</a>
+  <a href="translations/README.ru.md">Русский</a>
   &nbsp;|&nbsp;
-  <a href="README.uk.md">Українська</a>
+  <a href="translations/README.uk.md">Українська</a>
   &nbsp;|&nbsp;
-  <a href="README.zh-CN.md">简体中文</a>
+  <a href="translations/README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
   <a href="TRANSLATING.md">Contribute a translation</a>
 </p>

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -30,13 +30,13 @@ Other languages are welcome. If you want to contribute one not on this list, jus
 
 ## Naming convention
 
-Translated READMEs live in the repo root with a two-letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code:
+Translated READMEs live in `translations/` with a two-letter [ISO 639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) language code:
 
-- `README.md` (English, authoritative)
-- `README.de.md` (German)
-- `README.fr.md` (French)
-- `README.zh-CN.md` (Simplified Chinese - use `zh-CN` / `zh-TW` when a distinction matters)
-- `README.pt-BR.md` (Brazilian Portuguese - same rule when a regional distinction matters)
+- `README.md` (English, authoritative, repo root)
+- `translations/README.de.md` (German)
+- `translations/README.fr.md` (French)
+- `translations/README.zh-CN.md` (Simplified Chinese - use `zh-CN` / `zh-TW` when a distinction matters)
+- `translations/README.pt-BR.md` (Brazilian Portuguese - same rule when a regional distinction matters)
 
 Always link back to the English authoritative version from the top of your translation.
 
@@ -58,13 +58,13 @@ git log -1 --format=%h README.md
 
 ## Language switcher
 
-When you submit a new translation, update the switcher at the top of `README.md` to include your language. The pattern:
+When you submit a new translation, update the switcher at the top of `README.md` to include your language. The pattern in the root README:
 
 ```html
 <p align="center">
-  <a href="README.md">English</a>
+  <b>English</b>
   &nbsp;|&nbsp;
-  <a href="README.de.md">Deutsch</a>
+  <a href="translations/README.de.md">Deutsch</a>
   &nbsp;|&nbsp;
   <a href="TRANSLATING.md">Contribute a translation</a>
 </p>
@@ -72,7 +72,7 @@ When you submit a new translation, update the switcher at the top of `README.md`
 
 Use the endonym (the language's own name for itself) - `Deutsch`, `Français`, `Español`, `Українська`, `العربية`, etc. - not the English name.
 
-Mirror the same switcher in each translated README, with the current language in bold (no link).
+Mirror the same switcher in each translated README, with the current language in bold (no link). Inside `translations/`, sibling languages are linked by bare filename (`README.de.md`) while English and this guide need a parent path (`../README.md`, `../TRANSLATING.md`) - same for the banner and screenshot images (`../siggy-banner.png`, `../screenshot.png`).
 
 ## Translation quality
 
@@ -105,7 +105,7 @@ Translations drift. When the English README changes, yours will eventually go st
 ## Submitting
 
 1. Fork and branch off `master`. Branch name: `docs/translate-<lang>` (e.g. `docs/translate-de`).
-2. Copy `README.md` to `README.<lang>.md` and translate it.
+2. Copy `README.md` to `translations/README.<lang>.md` and translate it.
 3. Add the required header and update the language switcher in `README.md`.
 4. Open a PR titled `docs: add <language> README translation` and link issue #353.
 5. I will review for formatting, not linguistic accuracy - I trust the translator on the prose. I may ask another speaker of the language to sanity-check if one happens to be available.

--- a/translations/README.da.md
+++ b/translations/README.da.md
@@ -1,10 +1,10 @@
 > This is the Danish translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <b>Dansk</b>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Bidrag med en oversættelse</a>
+  <a href="../TRANSLATING.md">Bidrag med en oversættelse</a>
 </p>
 
 En terminalbaseret Signal-klient med IRC-æstetik. Bruger [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC som beskedbackend.
 
-![siggy skærmbillede](screenshot.png)
+![siggy skærmbillede](../screenshot.png)
 
 ## Installation
 
@@ -300,4 +300,4 @@ Bygget med [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/cross
 
 ## Licens
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -1,10 +1,10 @@
 > This is the German translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Eine Übersetzung beitragen</a>
+  <a href="../TRANSLATING.md">Eine Übersetzung beitragen</a>
 </p>
 
 Ein terminalbasierter Signal-Messenger-Client im IRC-Stil. Nutzt [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC als Messaging-Backend.
 
-![siggy Bildschirmfoto](screenshot.png)
+![siggy Bildschirmfoto](../screenshot.png)
 
 ## Installation
 
@@ -300,4 +300,4 @@ Gebaut mit [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/cross
 
 ## Lizenz
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.es.md
+++ b/translations/README.es.md
@@ -1,10 +1,10 @@
 > This is the Spanish translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Contribuye con una traducción</a>
+  <a href="../TRANSLATING.md">Contribuye con una traducción</a>
 </p>
 
 Un cliente de mensajería Signal para terminal con estética IRC. Envuelve [signal-cli](https://github.com/AsamK/signal-cli) mediante JSON-RPC como backend de mensajería.
 
-![Captura de pantalla de siggy](screenshot.png)
+![Captura de pantalla de siggy](../screenshot.png)
 
 ## Instalación
 
@@ -300,4 +300,4 @@ Construido con [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/c
 
 ## Licencia
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.fi.md
+++ b/translations/README.fi.md
@@ -1,10 +1,10 @@
 > This is the Finnish translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Osallistu kääntämiseen</a>
+  <a href="../TRANSLATING.md">Osallistu kääntämiseen</a>
 </p>
 
 Päätteessä toimiva Signal-viestintäsovellus IRC-henkisellä ulkoasulla. Käyttää [signal-cli](https://github.com/AsamK/signal-cli)-ohjelmaa JSON-RPC:n kautta viestinnän taustapalveluna.
 
-![Kuvakaappaus siggystä](screenshot.png)
+![Kuvakaappaus siggystä](../screenshot.png)
 
 ## Asennus
 
@@ -300,4 +300,4 @@ Toteutettu [Ratatui](https://ratatui.rs/)- ja [Crossterm](https://github.com/cro
 
 ## Lisenssi
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.fr.md
+++ b/translations/README.fr.md
@@ -1,9 +1,9 @@
 > This is the French translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -43,12 +43,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Proposez une traduction</a>
+  <a href="../TRANSLATING.md">Proposez une traduction</a>
 </p>
 
 Un client de messagerie Signal pour terminal, dans un style IRC. Enveloppe [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC pour le backend de messagerie.
 
-![siggy capture](screenshot.png)
+![siggy capture](../screenshot.png)
 
 ## Installer
 
@@ -299,4 +299,4 @@ Développé avec [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com
 
 ## License
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.it.md
+++ b/translations/README.it.md
@@ -1,10 +1,10 @@
 > This is the Italian translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Contribuisci con una traduzione</a>
+  <a href="../TRANSLATING.md">Contribuisci con una traduzione</a>
 </p>
 
 Un client Signal per il terminale, in stile IRC. Si appoggia a [signal-cli](https://github.com/AsamK/signal-cli) tramite JSON-RPC come backend di messaggistica.
 
-![Schermata di siggy](screenshot.png)
+![Schermata di siggy](../screenshot.png)
 
 ## Installazione
 
@@ -300,4 +300,4 @@ Sviluppato con [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/c
 
 ## Licenza
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.nl.md
+++ b/translations/README.nl.md
@@ -1,10 +1,10 @@
 > This is the Dutch translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Draag een vertaling bij</a>
+  <a href="../TRANSLATING.md">Draag een vertaling bij</a>
 </p>
 
 Een Signal-messengerclient voor de terminal, met een IRC-uitstraling. Gebruikt [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC als messaging-backend.
 
-![schermafbeelding van siggy](screenshot.png)
+![schermafbeelding van siggy](../screenshot.png)
 
 ## Installatie
 
@@ -300,4 +300,4 @@ Gebouwd met [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/cros
 
 ## Licentie
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.pt-BR.md
+++ b/translations/README.pt-BR.md
@@ -1,10 +1,10 @@
 > This is the Brazilian Portuguese translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Contribua com uma tradução</a>
+  <a href="../TRANSLATING.md">Contribua com uma tradução</a>
 </p>
 
 Um cliente do Signal para terminal com estética de IRC. Encapsula o [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC como backend de mensagens.
 
-![captura de tela do siggy](screenshot.png)
+![captura de tela do siggy](../screenshot.png)
 
 ## Instalação
 
@@ -300,4 +300,4 @@ Construído com [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/
 
 ## Licença
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.ru.md
+++ b/translations/README.ru.md
@@ -1,10 +1,10 @@
 > This is the Russian translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Предложить перевод</a>
+  <a href="../TRANSLATING.md">Предложить перевод</a>
 </p>
 
 Клиент мессенджера Signal для терминала в стиле IRC. Использует [signal-cli](https://github.com/AsamK/signal-cli) через JSON-RPC в качестве бэкенда обмена сообщениями.
 
-![Скриншот siggy](screenshot.png)
+![Скриншот siggy](../screenshot.png)
 
 ## Установка
 
@@ -300,4 +300,4 @@ signal-cli --> JsonRpcResponse --> SignalEvent (mpsc) --> App state --> SQLite +
 
 ## Лицензия
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.sv.md
+++ b/translations/README.sv.md
@@ -1,10 +1,10 @@
 > This is the Swedish translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Bidra med en översättning</a>
+  <a href="../TRANSLATING.md">Bidra med en översättning</a>
 </p>
 
 En terminalbaserad klient för Signal med IRC-estetik. Använder [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC som meddelandebackend.
 
-![Skärmdump av siggy](screenshot.png)
+![Skärmdump av siggy](../screenshot.png)
 
 ## Installation
 
@@ -300,4 +300,4 @@ Byggd med [Ratatui](https://ratatui.rs/) + [Crossterm](https://github.com/crosst
 
 ## Licens
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.uk.md
+++ b/translations/README.uk.md
@@ -1,10 +1,10 @@
 > This is the Ukrainian translation of the siggy README.
 > Last updated against English commit: 8b5890e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 > This translation is maintainer-provided and awaiting native-speaker review. Corrections welcome - see issue #353.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -18,7 +18,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -44,12 +44,12 @@
   &nbsp;|&nbsp;
   <a href="README.zh-CN.md">简体中文</a>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">Запропонувати переклад</a>
+  <a href="../TRANSLATING.md">Запропонувати переклад</a>
 </p>
 
 Термінальний клієнт месенджера Signal в естетиці IRC. Працює поверх [signal-cli](https://github.com/AsamK/signal-cli) через JSON-RPC як бекенд обміну повідомленнями.
 
-![знімок екрана siggy](screenshot.png)
+![знімок екрана siggy](../screenshot.png)
 
 ## Встановлення
 
@@ -300,4 +300,4 @@ signal-cli --> JsonRpcResponse --> SignalEvent (mpsc) --> App state --> SQLite +
 
 ## Ліцензія
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)

--- a/translations/README.zh-CN.md
+++ b/translations/README.zh-CN.md
@@ -1,9 +1,9 @@
 > This is the Simplified Chinese translation of the siggy README.
 > Last updated against English commit: 216023e
-> The [English version](README.md) is authoritative. If this translation has drifted, trust the English.
+> The [English version](../README.md) is authoritative. If this translation has drifted, trust the English.
 
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="../siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a>
+  <a href="../README.md">English</a>
   &nbsp;|&nbsp;
   <a href="README.da.md">Dansk</a>
   &nbsp;|&nbsp;
@@ -43,12 +43,12 @@
   &nbsp;|&nbsp;
   <b>简体中文</b>
   &nbsp;|&nbsp;
-  <a href="TRANSLATING.md">贡献翻译</a>
+  <a href="../TRANSLATING.md">贡献翻译</a>
 </p>
 
 一个基于终端的 Signal 即时通讯客户端，采用 IRC 风格设计。通过 JSON-RPC 封装 [signal-cli](https://github.com/AsamK/signal-cli) 作为消息后端。
 
-![siggy 截图](screenshot.png)
+![siggy 截图](../screenshot.png)
 
 ## 安装
 
@@ -299,4 +299,4 @@ signal-cli --> JsonRpcResponse --> SignalEvent (mpsc) --> App state --> SQLite +
 
 ## 许可证
 
-[GPL-3.0](LICENSE)
+[GPL-3.0](../LICENSE)


### PR DESCRIPTION
Moves the 12 translated READMEs out of the repo root into `translations/`, leaving root with just `README.md` and `TRANSLATING.md`. Discoverability is unaffected: readers reach translations through the language switcher, not the file listing.

Mechanics:
- `git mv` for all 12 files (history preserved as renames)
- Root README switcher hrefs now point into `translations/`
- Within translated files: English README, TRANSLATING.md, LICENSE, banner, and screenshot links gain a `../` prefix; sibling-language links stay bare filenames (same directory)
- TRANSLATING.md naming convention, switcher pattern, and submission steps updated; added a note about the parent-path rule inside translations/
- Verified zero leftover root-relative references by grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)