### PR TITLE
refactor: deduplicate message actions into shared handlers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2368,82 +2368,18 @@ impl App {
     /// Normal-mode keybinds. Exhaustive match: adding a variant to
     /// [`ActionMenuHint`] is a compiler error here until handled.
     fn execute_action_by_hint(&mut self, hint: ActionMenuHint) -> Option<SendRequest> {
+        use crate::handlers::keys;
         match hint {
-            ActionMenuHint::Reply => {
-                // Reply — same as Normal 'q'
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    let phone = msg.route_author(&self.account).to_string();
-                    let snippet: String = if msg.body.chars().count() > 50 {
-                        format!("{}…", msg.body.chars().take(50).collect::<String>())
-                    } else {
-                        msg.body.clone()
-                    };
-                    let ts = msg.timestamp_ms;
-                    self.reply_target = Some((phone, snippet, ts));
-                    self.mode = InputMode::Insert;
-                }
-                None
-            }
-            ActionMenuHint::Edit => {
-                // Edit — same as Normal 'e'
-                if let Some(msg) = self.selected_message()
-                    && msg.is_outgoing()
-                    && !msg.is_deleted
-                    && !msg.is_system
-                {
-                    let ts = msg.timestamp_ms;
-                    let body = msg.body.clone();
-                    if let Some(ref conv_id) = self.active_conversation {
-                        let conv_id = conv_id.clone();
-                        self.editing_message = Some((ts, conv_id));
-                        self.input.buffer = body;
-                        self.input.cursor = self.input.buffer.len();
-                        self.mode = InputMode::Insert;
-                    }
-                }
-                None
-            }
-            ActionMenuHint::React => {
-                // React — open reaction picker
-                if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.open_overlay(OverlayKind::ReactionPicker);
-                    self.reactions.picker_index = 0;
-                }
-                None
-            }
-            ActionMenuHint::Forward => {
-                // Forward — open conversation picker
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    self.forward.body = msg.body.clone();
-                    self.open_forward_picker();
-                }
-                None
-            }
+            ActionMenuHint::Reply => keys::execute_reply(self),
+            ActionMenuHint::Edit => keys::execute_edit(self),
+            ActionMenuHint::React => keys::execute_react(self),
+            ActionMenuHint::Forward => keys::execute_forward(self),
             ActionMenuHint::Copy => {
-                // Copy
                 self.copy_selected_message(false);
                 None
             }
-            ActionMenuHint::Delete => {
-                // Delete — open delete confirm
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    self.open_overlay(OverlayKind::DeleteConfirm);
-                }
-                None
-            }
-            ActionMenuHint::PinToggle => {
-                // Pin/Unpin
-                crate::handlers::keys::execute_pin_toggle(self)
-            }
+            ActionMenuHint::Delete => keys::execute_delete_confirm(self),
+            ActionMenuHint::PinToggle => keys::execute_pin_toggle(self),
             ActionMenuHint::Vote => {
                 // Vote on poll
                 if let Some(msg) = self.selected_message()
@@ -2582,7 +2518,7 @@ impl App {
         None
     }
 
-    fn open_forward_picker(&mut self) {
+    pub(crate) fn open_forward_picker(&mut self) {
         self.open_overlay(OverlayKind::Forward);
         self.forward.index = 0;
         self.forward.filter.clear();
@@ -2792,7 +2728,7 @@ impl App {
     }
 
     /// Jump to the next/previous search result in the active conversation.
-    fn jump_to_search_result(&mut self, forward: bool) {
+    pub(crate) fn jump_to_search_result(&mut self, forward: bool) {
         let active = self.active_conversation.as_deref();
         let action = self.search.jump_to_result(forward, active);
         self.dispatch_search_action(action);
@@ -3812,13 +3748,7 @@ impl App {
                 }
                 ('d', KeyCode::Char('d')) => {
                     // dd = delete message
-                    if let Some(msg) = self.selected_message()
-                        && !msg.is_system
-                        && !msg.is_deleted
-                    {
-                        self.open_overlay(OverlayKind::DeleteConfirm);
-                    }
-                    return None;
+                    return crate::handlers::keys::execute_delete_confirm(self);
                 }
                 (_, KeyCode::Esc) => {
                     // Esc cancels pending prefix
@@ -4005,76 +3935,18 @@ impl App {
                 self.copy_selected_message(true);
                 None
             }
-            Some(KeyAction::React) => {
-                if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.open_overlay(OverlayKind::ReactionPicker);
-                    self.reactions.picker_index = 0;
-                }
-                None
-            }
-            Some(KeyAction::Quote) => {
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    let phone = msg.route_author(&self.account).to_string();
-                    let snippet: String = if msg.body.chars().count() > 50 {
-                        format!("{}…", msg.body.chars().take(50).collect::<String>())
-                    } else {
-                        msg.body.clone()
-                    };
-                    let ts = msg.timestamp_ms;
-                    self.reply_target = Some((phone, snippet, ts));
-                    self.mode = InputMode::Insert;
-                }
-                None
-            }
-            Some(KeyAction::EditMessage) => {
-                if let Some(msg) = self.selected_message()
-                    && msg.is_outgoing()
-                    && !msg.is_deleted
-                    && !msg.is_system
-                {
-                    let ts = msg.timestamp_ms;
-                    let body = msg.body.clone();
-                    if let Some(ref conv_id) = self.active_conversation {
-                        let conv_id = conv_id.clone();
-                        self.editing_message = Some((ts, conv_id));
-                        self.input.buffer = body;
-                        self.input.cursor = self.input.buffer.len();
-                        self.mode = InputMode::Insert;
-                    }
-                }
-                None
-            }
-            Some(KeyAction::ForwardMessage) => {
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    self.forward.body = msg.body.clone();
-                    self.open_forward_picker();
-                }
-                None
-            }
+            Some(KeyAction::React) => crate::handlers::keys::execute_react(self),
+            Some(KeyAction::Quote) => crate::handlers::keys::execute_reply(self),
+            Some(KeyAction::EditMessage) => crate::handlers::keys::execute_edit(self),
+            Some(KeyAction::ForwardMessage) => crate::handlers::keys::execute_forward(self),
             Some(KeyAction::NextSearchResult) => {
-                if !self.search.results.is_empty() {
-                    self.jump_to_search_result(true);
-                }
-                None
+                crate::handlers::keys::execute_search_jump(self, true)
             }
             Some(KeyAction::PrevSearchResult) => {
-                if !self.search.results.is_empty() {
-                    self.jump_to_search_result(false);
-                }
-                None
+                crate::handlers::keys::execute_search_jump(self, false)
             }
             Some(KeyAction::OpenActionMenu) => {
-                if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.open_overlay(OverlayKind::ActionMenu);
-                    self.action_menu.index = 0;
-                }
-                None
+                crate::handlers::keys::execute_open_action_menu(self)
             }
             Some(KeyAction::PinMessage) => crate::handlers::keys::execute_pin_toggle(self),
             Some(KeyAction::JumpToQuote) => {
@@ -4199,83 +4071,19 @@ impl App {
                 self.copy_selected_message(true);
                 None
             }
-            Some(KeyAction::React) => {
-                if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.open_overlay(OverlayKind::ReactionPicker);
-                    self.reactions.picker_index = 0;
-                }
-                None
-            }
-            Some(KeyAction::Quote) => {
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    let phone = msg.route_author(&self.account).to_string();
-                    let snippet: String = if msg.body.chars().count() > 50 {
-                        format!("{}…", msg.body.chars().take(50).collect::<String>())
-                    } else {
-                        msg.body.clone()
-                    };
-                    let ts = msg.timestamp_ms;
-                    self.reply_target = Some((phone, snippet, ts));
-                }
-                None
-            }
-            Some(KeyAction::EditMessage) => {
-                if let Some(msg) = self.selected_message()
-                    && msg.is_outgoing()
-                    && !msg.is_deleted
-                    && !msg.is_system
-                {
-                    let ts = msg.timestamp_ms;
-                    let body = msg.body.clone();
-                    if let Some(ref conv_id) = self.active_conversation {
-                        let conv_id = conv_id.clone();
-                        self.editing_message = Some((ts, conv_id));
-                        self.input.buffer = body;
-                        self.input.cursor = self.input.buffer.len();
-                    }
-                }
-                None
-            }
-            Some(KeyAction::ForwardMessage) => {
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    self.forward.body = msg.body.clone();
-                    self.open_forward_picker();
-                }
-                None
-            }
-            Some(KeyAction::DeleteMessage) => {
-                if let Some(msg) = self.selected_message()
-                    && !msg.is_system
-                    && !msg.is_deleted
-                {
-                    self.open_overlay(OverlayKind::DeleteConfirm);
-                }
-                None
-            }
+            Some(KeyAction::React) => crate::handlers::keys::execute_react(self),
+            Some(KeyAction::Quote) => crate::handlers::keys::execute_reply(self),
+            Some(KeyAction::EditMessage) => crate::handlers::keys::execute_edit(self),
+            Some(KeyAction::ForwardMessage) => crate::handlers::keys::execute_forward(self),
+            Some(KeyAction::DeleteMessage) => crate::handlers::keys::execute_delete_confirm(self),
             Some(KeyAction::NextSearchResult) => {
-                if !self.search.results.is_empty() {
-                    self.jump_to_search_result(true);
-                }
-                None
+                crate::handlers::keys::execute_search_jump(self, true)
             }
             Some(KeyAction::PrevSearchResult) => {
-                if !self.search.results.is_empty() {
-                    self.jump_to_search_result(false);
-                }
-                None
+                crate::handlers::keys::execute_search_jump(self, false)
             }
             Some(KeyAction::OpenActionMenu) => {
-                if self.selected_message().is_some_and(|m| !m.is_system) {
-                    self.open_overlay(OverlayKind::ActionMenu);
-                    self.action_menu.index = 0;
-                }
-                None
+                crate::handlers::keys::execute_open_action_menu(self)
             }
             Some(KeyAction::PinMessage) => crate::handlers::keys::execute_pin_toggle(self),
             Some(KeyAction::JumpToQuote) => {

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -11,8 +11,113 @@
 use chrono::Utc;
 use crossterm::event::KeyCode;
 
-use crate::app::{App, OverlayKind, PIN_DURATIONS, PinPending, SendRequest};
+use crate::app::{App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, SendRequest};
 use crate::list_overlay::{ListKeyAction, classify_list_key};
+
+// ---------------------------------------------------------------------------
+// Shared message actions (#493)
+//
+// Each action below is reachable three ways: a Normal-mode key, an
+// Insert-mode key (in alternative keybinding profiles), and the per-message
+// action menu. They were previously copy-pasted at all three call sites with
+// subtle drift; these are the single implementations. All return
+// Option<SendRequest> so call-site match arms stay single expressions, even
+// though most never dispatch anything.
+//
+// Mode note: actions that move the user into the composer set
+// `mode = InputMode::Insert` unconditionally. From Normal mode and the
+// action menu that is the intended transition; from Insert mode it is an
+// idempotent no-op, which is why one implementation serves all three sites.
+// ---------------------------------------------------------------------------
+
+/// Start a quoted reply to the focused message and enter the composer.
+pub(crate) fn execute_reply(app: &mut App) -> Option<SendRequest> {
+    if let Some(msg) = app.selected_message()
+        && !msg.is_system
+        && !msg.is_deleted
+    {
+        let phone = msg.route_author(&app.account).to_string();
+        let snippet: String = if msg.body.chars().count() > 50 {
+            format!("{}…", msg.body.chars().take(50).collect::<String>())
+        } else {
+            msg.body.clone()
+        };
+        let ts = msg.timestamp_ms;
+        app.reply_target = Some((phone, snippet, ts));
+        app.mode = InputMode::Insert;
+    }
+    None
+}
+
+/// Start editing the focused message (own, non-deleted messages only) with
+/// its body pre-loaded into the composer.
+pub(crate) fn execute_edit(app: &mut App) -> Option<SendRequest> {
+    if let Some(msg) = app.selected_message()
+        && msg.is_outgoing()
+        && !msg.is_deleted
+        && !msg.is_system
+    {
+        let ts = msg.timestamp_ms;
+        let body = msg.body.clone();
+        if let Some(ref conv_id) = app.active_conversation {
+            let conv_id = conv_id.clone();
+            app.editing_message = Some((ts, conv_id));
+            app.input.buffer = body;
+            app.input.cursor = app.input.buffer.len();
+            app.mode = InputMode::Insert;
+        }
+    }
+    None
+}
+
+/// Open the reaction picker for the focused message.
+pub(crate) fn execute_react(app: &mut App) -> Option<SendRequest> {
+    if app.selected_message().is_some_and(|m| !m.is_system) {
+        app.open_overlay(OverlayKind::ReactionPicker);
+        app.reactions.picker_index = 0;
+    }
+    None
+}
+
+/// Open the forward-to-conversation picker for the focused message.
+pub(crate) fn execute_forward(app: &mut App) -> Option<SendRequest> {
+    if let Some(msg) = app.selected_message()
+        && !msg.is_system
+        && !msg.is_deleted
+    {
+        app.forward.body = msg.body.clone();
+        app.open_forward_picker();
+    }
+    None
+}
+
+/// Open the delete-confirmation overlay for the focused message.
+pub(crate) fn execute_delete_confirm(app: &mut App) -> Option<SendRequest> {
+    if let Some(msg) = app.selected_message()
+        && !msg.is_system
+        && !msg.is_deleted
+    {
+        app.open_overlay(OverlayKind::DeleteConfirm);
+    }
+    None
+}
+
+/// Jump to the next (`forward`) or previous search result, if any.
+pub(crate) fn execute_search_jump(app: &mut App, forward: bool) -> Option<SendRequest> {
+    if !app.search.results.is_empty() {
+        app.jump_to_search_result(forward);
+    }
+    None
+}
+
+/// Open the per-message action menu for the focused message.
+pub(crate) fn execute_open_action_menu(app: &mut App) -> Option<SendRequest> {
+    if app.selected_message().is_some_and(|m| !m.is_system) {
+        app.open_overlay(OverlayKind::ActionMenu);
+        app.action_menu.index = 0;
+    }
+    None
+}
 
 /// Toggle the pinned state of the currently focused message. For unpinning,
 /// this runs the local update immediately. For pinning, it opens the duration


### PR DESCRIPTION
Closes #493 -- flagged by the deep review''s maintainability pass as the highest-leverage refactor before further feature work.

Reply, Edit, React, Forward, Delete-confirm, search-result jump, and action-menu-open were copy-pasted across three sites (Normal-mode arms, Insert-mode arms, and the action menu''s execute_action_by_hint), roughly 200 duplicated lines with subtle drift between copies. Every new message action or guard fix required three synchronized edits, and a missed one produced a mode-specific bug no compiler error would catch.

Each action is now a single `execute_*` function in handlers/keys.rs, following the existing `execute_pin_toggle` precedent; all three call sites collapse to single-expression match arms. The one historical delta between copies -- Insert-mode Quote/Edit not setting `mode = Insert` -- turns out to be an idempotent no-op (the app is already in Insert mode), so a single implementation is behavior-identical for all three entry points.

- Behavior-neutral: clippy clean, all 792 tests pass without a single test edit
- `open_forward_picker` and `jump_to_search_result` promoted to pub(crate) (the visibility wave the review predicted)
- Future divergence now requires deliberately re-inlining a shared function, which is visible in review -- the original failure mode (silently drifting copies) is structurally gone
- Unblocks #494 (moving the action-menu/overlay key handlers out of app.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)