### PR TITLE
fix: stop scrollback pagination runaway; make older history reachable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3021,6 +3021,43 @@ impl App {
         Ok(())
     }
 
+    /// How many additional messages the render window grows by per
+    /// extend_scrollback call when older messages are already in memory.
+    const SCROLLBACK_EXTEND_CHUNK: usize = 50;
+
+    /// Extend the scrollback when the user hits the top of the render
+    /// window (#488). Prefers widening the window over already-loaded
+    /// messages; only pages from the DB when the window has reached
+    /// message 0. Each call makes the window strictly larger, so the
+    /// next draw computes a larger base_scroll and at_top stays false
+    /// until the user scrolls further up -- the previous behavior
+    /// (re-loading every 50ms tick while the viewport never moved)
+    /// cannot recur.
+    pub fn extend_scrollback(&mut self) {
+        self.scroll.at_top = false;
+        if self.scroll.can_extend_in_memory {
+            self.scroll.window_extra += Self::SCROLLBACK_EXTEND_CHUNK;
+            return;
+        }
+        // Window already reaches the oldest loaded message: page from the DB
+        // and widen the window by what arrived so the new messages are
+        // actually reachable.
+        let before = self
+            .active_conversation
+            .as_ref()
+            .and_then(|id| self.store.conversations.get(id))
+            .map(|c| c.messages.len())
+            .unwrap_or(0);
+        self.load_more_messages();
+        let after = self
+            .active_conversation
+            .as_ref()
+            .and_then(|id| self.store.conversations.get(id))
+            .map(|c| c.messages.len())
+            .unwrap_or(0);
+        self.scroll.window_extra += after.saturating_sub(before);
+    }
+
     /// Load older messages for the active conversation when scrolled to the top.
     pub fn load_more_messages(&mut self) {
         self.scroll.at_top = false;
@@ -5051,6 +5088,8 @@ impl App {
         self.reset_typing_with_stop();
         self.input.reset_for_conv_switch();
         self.sync.pin = None;
+        self.scroll.window_extra = 0;
+        self.scroll.can_extend_in_memory = false;
         self.clear_kitty_placements();
     }
 
@@ -7153,6 +7192,99 @@ mod tests {
         );
         let reloaded = app.db.load_messages_page(conv_id, 10, 0).unwrap();
         assert_eq!(reloaded[0].status, Some(MessageStatus::Failed));
+    }
+
+    // --- #488: scrollback extension ---
+    //
+    // Hitting the window top must make the render window strictly larger
+    // each time (over memory first, then DB pages), so the at_top flag
+    // cannot re-fire without further user scrolling. The old behavior
+    // (load_more_messages on every 50ms tick while at_top stayed true)
+    // streamed the entire history into RAM with the loaded messages
+    // unreachable behind a tail-anchored window.
+
+    #[rstest]
+    fn extend_scrollback_widens_window_over_memory_without_db_load(mut app: App) {
+        let conv_id = "+ext";
+        app.db.upsert_conversation(conv_id, "Ext", false).unwrap();
+        for i in 0..150 {
+            app.db
+                .insert_message(
+                    conv_id,
+                    "Alice",
+                    &format!("2025-01-01T{:02}:{:02}:00Z", i / 60, i % 60),
+                    &format!("msg{i}"),
+                    false,
+                    None,
+                    i as i64 * 1000,
+                )
+                .unwrap();
+        }
+        app.load_from_db().unwrap();
+        app.active_conversation = Some(conv_id.to_string());
+        let loaded = app.store.conversations[conv_id].messages.len();
+
+        app.scroll.at_top = true;
+        app.scroll.can_extend_in_memory = true;
+        app.extend_scrollback();
+
+        assert_eq!(app.scroll.window_extra, App::SCROLLBACK_EXTEND_CHUNK);
+        assert!(!app.scroll.at_top, "at_top must be consumed");
+        assert_eq!(
+            app.store.conversations[conv_id].messages.len(),
+            loaded,
+            "in-memory extension must not page from the DB"
+        );
+    }
+
+    #[rstest]
+    fn extend_scrollback_pages_from_db_and_makes_new_messages_reachable(mut app: App) {
+        let conv_id = "+ext2";
+        app.db.upsert_conversation(conv_id, "Ext2", false).unwrap();
+        for i in 0..150 {
+            app.db
+                .insert_message(
+                    conv_id,
+                    "Alice",
+                    &format!("2025-01-01T{:02}:{:02}:00Z", i / 60, i % 60),
+                    &format!("msg{i}"),
+                    false,
+                    None,
+                    i as i64 * 1000,
+                )
+                .unwrap();
+        }
+        app.load_from_db().unwrap();
+        app.active_conversation = Some(conv_id.to_string());
+        let loaded = app.store.conversations[conv_id].messages.len();
+        assert_eq!(loaded, App::PAGE_SIZE);
+
+        app.scroll.at_top = true;
+        app.scroll.can_extend_in_memory = false; // window already reaches msg 0
+        app.extend_scrollback();
+
+        let after = app.store.conversations[conv_id].messages.len();
+        assert_eq!(after, 150, "remaining DB page must load");
+        assert_eq!(
+            app.scroll.window_extra,
+            after - loaded,
+            "window must widen by exactly what arrived, keeping it reachable"
+        );
+        assert!(!app.scroll.at_top);
+    }
+
+    #[rstest]
+    fn conversation_switch_resets_window_extra(mut app: App) {
+        app.store
+            .get_or_create_conversation("+1", "Alice", false, &app.db);
+        app.store
+            .get_or_create_conversation("+2", "Bob", false, &app.db);
+        app.active_conversation = Some("+1".to_string());
+        app.scroll.window_extra = 250;
+        app.scroll.can_extend_in_memory = true;
+        app.next_conversation();
+        assert_eq!(app.scroll.window_extra, 0);
+        assert!(!app.scroll.can_extend_in_memory);
     }
 
     #[rstest]

--- a/src/db.rs
+++ b/src/db.rs
@@ -455,7 +455,12 @@ impl Database {
         for (i, m) in messages.iter().enumerate() {
             ts_to_idx.entry(m.timestamp_ms).or_default().push(i);
         }
-        if let Ok(reactions) = self.load_reactions(conv_id) {
+        let page_range = messages
+            .first()
+            .map(|f| (f.timestamp_ms, messages[messages.len() - 1].timestamp_ms));
+        if let Some((min_ts, max_ts)) = page_range
+            && let Ok(reactions) = self.load_reactions_in_range(conv_id, min_ts, max_ts)
+        {
             for (target_ts, target_author, emoji, sender) in reactions {
                 let idx = ts_to_idx.get(&target_ts).and_then(|idxs| {
                     idxs.iter()
@@ -752,6 +757,28 @@ impl Database {
             params![conv_id, target_ts_ms, target_author, sender],
         )?;
         Ok(())
+    }
+
+    /// Load reactions targeting messages within a timestamp range. Used by
+    /// the paged message loader so each page reads only its own reactions
+    /// instead of the conversation's full reactions table (#488); the range
+    /// query is served by idx_reactions_target.
+    pub fn load_reactions_in_range(
+        &self,
+        conv_id: &str,
+        min_ts: i64,
+        max_ts: i64,
+    ) -> Result<Vec<(i64, String, String, String)>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT target_ts_ms, target_author, emoji, sender FROM reactions
+             WHERE conversation_id = ?1 AND target_ts_ms BETWEEN ?2 AND ?3",
+        )?;
+        let rows: Vec<(i64, String, String, String)> = stmt
+            .query_map(params![conv_id, min_ts, max_ts], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        Ok(rows)
     }
 
     /// Load all reactions for a conversation.

--- a/src/domain/scroll.rs
+++ b/src/domain/scroll.rs
@@ -29,4 +29,15 @@ pub struct ScrollState {
     /// Jump-back stack: saved `(offset, focused_index)` pairs from quote-jump
     /// navigation. Esc pops to restore.
     pub jump_stack: Vec<(usize, Option<usize>)>,
+    /// Extra messages included in the render window beyond the base
+    /// `height * MSG_WINDOW_MULTIPLIER`, grown by `App::extend_scrollback`
+    /// each time the user hits the top of the window (#488). Counted in
+    /// MESSAGES, deliberately decoupled from the line-based `offset` (see
+    /// the lockstep warning at the window computation in chat_pane).
+    /// Reset when the user returns to the bottom or switches conversation.
+    pub window_extra: usize,
+    /// Set by the renderer: the current window starts after message 0, so
+    /// the scrollback can extend within already-loaded memory without a DB
+    /// page load.
+    pub can_extend_in_memory: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1432,9 +1432,11 @@ async fn run_app(
             }
         }
 
-        // Load older messages when scrolled to the top
+        // Extend the scrollback when scrolled to the top: widen the render
+        // window over loaded messages, paging from the DB only when memory
+        // is exhausted (#488).
         if app.scroll.at_top {
-            app.load_more_messages();
+            app.extend_scrollback();
             needs_redraw = true;
         }
 

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -287,11 +287,20 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     let available_height = inner.height as usize;
     let total = messages.len();
 
-    // Build lines from a fixed window of recent messages.
+    // Build lines from a window of recent messages.
     // app.scroll.offset is NOT included here; it controls the Paragraph scroll position instead.
     // Including it would expand the window by 1 message per scroll increment, growing
     // content_height and base_scroll in lockstep, keeping scroll_y constant (viewport stuck).
-    let start = total.saturating_sub(available_height * MSG_WINDOW_MULTIPLIER);
+    //
+    // window_extra grows in discrete chunks via App::extend_scrollback when
+    // the user hits the window top (#488) -- it is counted in messages and
+    // never derived from offset, so the lockstep failure above cannot recur.
+    // It resets to 0 when the user is back at the bottom.
+    if app.scroll.offset == 0 {
+        app.scroll.window_extra = 0;
+    }
+    let start =
+        total.saturating_sub(available_height * MSG_WINDOW_MULTIPLIER + app.scroll.window_extra);
     let visible = &messages[start..total];
 
     // Get last_read_index for unread marker
@@ -662,13 +671,18 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     app.scroll.offset = app.scroll.offset.min(base_scroll);
     let mut scroll_y = base_scroll - app.scroll.offset;
 
-    // Signal when user has scrolled to the top of loaded content
+    // Signal when the user has scrolled to the top of the render window and
+    // there is anywhere further up to go: unrendered in-memory messages
+    // (start > 0) or unloaded DB pages. App::extend_scrollback consumes the
+    // flag and grows the window / loads a page accordingly (#488).
+    app.scroll.can_extend_in_memory = start > 0;
     app.scroll.at_top = app.scroll.offset >= base_scroll
         && base_scroll > 0
-        && app
-            .active_conversation
-            .as_ref()
-            .is_some_and(|id| app.store.has_more_messages.contains(id));
+        && (start > 0
+            || app
+                .active_conversation
+                .as_ref()
+                .is_some_and(|id| app.store.has_more_messages.contains(id)));
 
     // Determine the focused message for highlight and full-timestamp display in Normal mode.
     // Check scroll.focused_index too so J/K navigation works even when content fits the viewport


### PR DESCRIPTION
Closes #488 -- the deep review''s one CRITICAL performance finding.

**The runaway:** scrolling to the top of the render window set `scroll.at_top`, and the main loop responded by calling `load_more_messages` every 50ms tick. The window start was anchored to the message tail (`total - height*10`), so prepending a page never changed what rendered: `at_top` recomputed true on the next draw and the loop streamed the conversation''s entire history into RAM at 20Hz -- each page also loading the conversation''s FULL reactions table -- while the loaded messages remained unreachable behind the tail-anchored window. All cost, no benefit.

**The fix:** the window now grows. `ScrollState` gains `window_extra`, counted in messages and grown in discrete chunks -- deliberately decoupled from the line-based `offset`, so the v0.6.1 lockstep failure documented at the window computation cannot recur. New `App::extend_scrollback` consumes `at_top` and:

1. widens the window over already-loaded messages first (no DB hit), and
2. only when the window reaches message 0, pages from the DB and widens by exactly what arrived, keeping the new messages reachable.

Every trigger makes the window strictly larger, so `base_scroll` grows and `at_top` stays false until the user actually scrolls further up. The runaway is structurally impossible, and deep history is now genuinely viewable by scrolling. `window_extra` resets when the user returns to the bottom and on conversation switch.

**Also in this PR:** each page load now reads only its own timestamp range from the reactions table (new `load_reactions_in_range`, served by the existing `idx_reactions_target` index) instead of every reaction in the conversation. The poll-vote per-message query remains (0-2 polls per page in practice; noted in #492''s churn list if it ever matters).

Three regression tests: in-memory extension without DB load, DB paging with exact-reachability widening, and conversation-switch reset. Clippy clean, 795 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)