### PR TITLE
fix: receipt and read-marker integrity cluster

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7818,6 +7818,104 @@ mod tests {
         assert!(app.pending.receipts.is_empty());
     }
 
+    // --- #484: receipt buffer integrity ---
+
+    #[rstest]
+    fn partial_receipt_match_buffers_only_unmatched_timestamps(mut app: App) {
+        let conv_id = "+1";
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        if let Some(conv) = app.store.conversations.get_mut(conv_id) {
+            let mut m = outgoing_sending_msg(1000, "delivered one");
+            m.status = Some(MessageStatus::Sent);
+            conv.messages.push(m);
+        }
+
+        // One timestamp matches, the sibling does not. The old per-event
+        // flag dropped the unmatched sibling outright.
+        app.handle_signal_event(SignalEvent::ReceiptReceived {
+            sender: conv_id.to_string(),
+            receipt_type: "DELIVERY".to_string(),
+            timestamps: vec![1000, 2000],
+        });
+
+        assert_eq!(
+            app.store.conversations[conv_id].messages[0].status,
+            Some(MessageStatus::Delivered)
+        );
+        assert_eq!(app.pending.receipts.len(), 1);
+        assert_eq!(app.pending.receipts[0].timestamps, vec![2000]);
+    }
+
+    #[rstest]
+    fn buffered_receipt_resolves_against_db_after_max_replays(mut app: App) {
+        // The target message exists only in the DB (outside the loaded
+        // page), so the in-memory replay can never match. The old code
+        // re-buffered such receipts forever and the DB status update was
+        // lost.
+        let conv_id = "+page";
+        let ts = 5000_i64;
+        app.db.upsert_conversation(conv_id, "Pg", false).unwrap();
+        app.db
+            .insert_message(
+                conv_id,
+                "you",
+                "2025-01-01T00:00:00Z",
+                "old outgoing",
+                false,
+                Some(MessageStatus::Sent),
+                ts,
+            )
+            .unwrap();
+
+        app.handle_signal_event(SignalEvent::ReceiptReceived {
+            sender: conv_id.to_string(),
+            receipt_type: "READ".to_string(),
+            timestamps: vec![ts],
+        });
+        assert_eq!(app.pending.receipts.len(), 1);
+
+        // Each confirmed send triggers one replay.
+        for i in 0..10 {
+            app.pending
+                .sends
+                .insert(format!("rpc-{i}"), ("+other".to_string(), 1_000_000 + i));
+            app.handle_signal_event(SignalEvent::SendTimestamp {
+                rpc_id: format!("rpc-{i}"),
+                server_ts: 2_000_000 + i,
+            });
+        }
+
+        assert!(
+            app.pending.receipts.is_empty(),
+            "buffer must drain after the replay cap"
+        );
+        let rows = app.db.load_messages_page(conv_id, 10, 0).unwrap();
+        assert_eq!(
+            rows[0].status,
+            Some(MessageStatus::Read),
+            "the receipt must reach the DB row even though it never matched in memory"
+        );
+    }
+
+    #[rstest]
+    fn mid_sync_message_does_not_persist_read_marker(mut app: App) {
+        let conv_id = "+1";
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        app.active_conversation = Some(conv_id.to_string());
+        app.sync.active = true;
+
+        let m = make_msg_with_ts(conv_id, Some("seen never"), None, false, 1000);
+        app.handle_signal_event(SignalEvent::MessageReceived(m));
+
+        assert_eq!(
+            app.db.unread_count(conv_id).unwrap(),
+            1,
+            "a crash mid-sync must not leave unseen messages marked read on disk"
+        );
+    }
+
     // --- Reaction tests ---
 
     #[rstest]

--- a/src/db.rs
+++ b/src/db.rs
@@ -646,6 +646,21 @@ impl Database {
         Ok(row)
     }
 
+    /// Upgrade an outgoing message's status by timestamp alone, across all
+    /// conversations. Fallback for buffered receipts whose target is not in
+    /// the loaded message page (#484): receipts carry no conversation id,
+    /// and outgoing timestamps are server-assigned and unique in practice.
+    /// `status > 0` restricts to outgoing rows; `status < ?2` keeps the
+    /// write upgrade-only, so a stray collision cannot downgrade anything.
+    pub fn update_outgoing_status_any_conv(&self, timestamp_ms: i64, status: i32) -> Result<()> {
+        self.conn.execute(
+            "UPDATE messages SET status = ?2
+             WHERE timestamp_ms = ?1 AND sender = 'you' AND status > 0 AND status < ?2",
+            params![timestamp_ms, status],
+        )?;
+        Ok(())
+    }
+
     /// Mark an outgoing message Failed. Needs its own method because
     /// `update_message_status` only allows upward transitions and Failed (1)
     /// sits below Sending (2), so a failure write through it was silently
@@ -713,9 +728,15 @@ impl Database {
             |row| row.get(0),
         )?;
 
+        // Incoming only (status = 0, sender filter for legacy/demo rows):
+        // your own sent messages are never "unread". Mirrors the in-memory
+        // recompute in handle_read_sync, which filters status.is_none();
+        // without this, sending N messages and restarting showed an unread
+        // badge of N with the divider above your own messages (#484).
         let count: i64 = self.conn.query_row(
             "SELECT COUNT(*) FROM messages
-             WHERE conversation_id = ?1 AND rowid > ?2 AND is_system = 0",
+             WHERE conversation_id = ?1 AND rowid > ?2 AND is_system = 0
+               AND status = 0 AND sender != 'you'",
             params![conv_id, last_read],
             |row| row.get(0),
         )?;
@@ -1134,6 +1155,36 @@ mod tests {
     #[fixture]
     fn db() -> Database {
         Database::open_in_memory().unwrap()
+    }
+
+    // #484: your own sent messages are never "unread". Without the
+    // incoming-only filter, sending N messages and restarting showed an
+    // unread badge of N with the divider above your own messages.
+    #[rstest]
+    fn unread_count_excludes_outgoing_messages(db: Database) {
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        db.insert_message(
+            "+1",
+            "Alice",
+            "2025-01-01T00:00:00Z",
+            "incoming",
+            false,
+            None,
+            1000,
+        )
+        .unwrap();
+        db.insert_message(
+            "+1",
+            "you",
+            "2025-01-01T00:01:00Z",
+            "outgoing",
+            false,
+            Some(MessageStatus::Sent),
+            2000,
+        )
+        .unwrap();
+
+        assert_eq!(db.unread_count("+1").unwrap(), 1);
     }
 
     // #489: drain_events wraps its writes in begin_batch/commit_batch. The

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -33,7 +33,7 @@ pub use overlays::{
     KeybindingsOverlayState, PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState,
     SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState, VerifyOverlayState,
 };
-pub use pending::PendingState;
+pub use pending::{BufferedReceipt, PendingState};
 pub use reaction::ReactionState;
 pub use scroll::ScrollState;
 pub use search::{SearchAction, SearchState};

--- a/src/domain/pending.rs
+++ b/src/domain/pending.rs
@@ -10,6 +10,20 @@ use std::collections::HashMap;
 
 use crate::app::SendRequest;
 
+/// A receipt that arrived before the message it targets was matchable
+/// (typically before the `SendTimestamp` that rewrites the local timestamp
+/// to the server one). Replayed after each subsequent `SendTimestamp`;
+/// `attempts` counts failed replays so an entry that can never match is
+/// eventually resolved against the DB and dropped instead of re-buffering
+/// forever (#484).
+pub struct BufferedReceipt {
+    pub sender: String,
+    pub receipt_type: String,
+    /// Only the timestamps that have not matched yet.
+    pub timestamps: Vec<i64>,
+    pub attempts: u8,
+}
+
 /// State for in-flight signal-cli work awaiting confirmation or dispatch.
 #[derive(Default)]
 pub struct PendingState {
@@ -21,9 +35,10 @@ pub struct PendingState {
     pub sends: HashMap<String, (String, i64)>,
     /// Receipts that arrived before their matching `SendTimestamp`.
     ///
-    /// Populated by `handle_receipt()` when no matching pending send exists
-    /// yet. Drained immediately after each `SendTimestamp` confirms a send.
-    pub receipts: Vec<(String, String, Vec<i64>)>,
+    /// Populated by `handle_receipt()` for timestamps with no matching
+    /// message yet. Replayed after each `SendTimestamp`; bounded by attempt
+    /// count and buffer size with a direct-DB fallback (#484).
+    pub receipts: Vec<BufferedReceipt>,
     /// Queued typing-stop request from conversation switches.
     ///
     /// Drained by the main loop.

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -707,6 +707,10 @@ fn persist_message_extras(app: &mut App, r: &ResolvedMessage) {
 /// or when the contact is blocked), advance the in-memory read marker, and
 /// persist the on-disk read marker so reloads see the new position.
 fn update_active_read_state(app: &mut App, r: &ResolvedMessage, conv_accepted: bool) {
+    // Everything here is gated on !sync.active, including the on-disk
+    // marker: persisting it mid-burst marks messages the user never saw as
+    // read if the app dies before end_sync reconciles (#484). end_sync's
+    // mark_read persists the marker once the burst completes.
     if !app.sync.active {
         if !r.is_outgoing && conv_accepted && !app.blocked_conversations.contains(&r.conv_id) {
             app.queue_single_read_receipt(&r.sender_id, r.msg_ts_ms);
@@ -716,12 +720,12 @@ fn update_active_read_state(app: &mut App, r: &ResolvedMessage, conv_accepted: b
                 .last_read_index
                 .insert(r.conv_id.clone(), conv.messages.len());
         }
-    }
-    if let Ok(Some(rowid)) = app.db.last_message_rowid(&r.conv_id) {
-        db_warn(
-            app.db.save_read_marker(&r.conv_id, rowid),
-            "save_read_marker",
-        );
+        if let Ok(Some(rowid)) = app.db.last_message_rowid(&r.conv_id) {
+            db_warn(
+                app.db.save_read_marker(&r.conv_id, rowid),
+                "save_read_marker",
+            );
+        }
     }
 }
 
@@ -1388,11 +1392,26 @@ fn handle_send_timestamp(app: &mut App, rpc_id: &str, server_ts: i64) {
             );
         }
 
-        // Replay any buffered receipts that may have arrived before this SendTimestamp
+        // Replay any buffered receipts that may have arrived before this
+        // SendTimestamp. Entries that still don't match re-buffer with a
+        // bumped attempt count; at the cap they are resolved against the DB
+        // and dropped, so a receipt whose target is outside the loaded page
+        // cannot re-buffer forever with its status update lost (#484).
         if !app.pending.receipts.is_empty() {
-            let receipts = std::mem::take(&mut app.pending.receipts);
-            for (sender, receipt_type, timestamps) in receipts {
-                handle_receipt(app, &sender, &receipt_type, &timestamps);
+            let buffered = std::mem::take(&mut app.pending.receipts);
+            for b in buffered {
+                let Some(status) = receipt_status(&b.receipt_type) else {
+                    continue;
+                };
+                let unmatched = apply_receipt(app, &b.sender, status, &b.timestamps);
+                if unmatched.is_empty() {
+                    continue;
+                }
+                if b.attempts + 1 >= MAX_RECEIPT_REPLAYS {
+                    resolve_receipt_against_db(app, status, &unmatched);
+                } else {
+                    buffer_receipt(app, &b.sender, &b.receipt_type, unmatched, b.attempts + 1);
+                }
             }
         }
     }
@@ -1464,56 +1483,113 @@ fn try_upgrade_receipt(
     false
 }
 
-fn handle_receipt(app: &mut App, sender: &str, receipt_type: &str, timestamps: &[i64]) {
-    let receipt_upper = receipt_type.to_uppercase();
-    let new_status = match receipt_upper.as_str() {
-        "DELIVERY" => MessageStatus::Delivered,
-        "READ" => MessageStatus::Read,
-        "VIEWED" => MessageStatus::Viewed,
-        _ => return,
-    };
+/// Failed replays before a buffered receipt is resolved against the DB and
+/// dropped. Each in-flight send triggers one replay, so this bounds how many
+/// other sends can confirm while a receipt's own target is still pending.
+const MAX_RECEIPT_REPLAYS: u8 = 8;
+/// Hard cap on the receipt buffer; the oldest entry is DB-resolved and
+/// evicted when full.
+const MAX_BUFFERED_RECEIPTS: usize = 64;
 
-    let mut matched_any = false;
-
-    // Try matching in the 1:1 conversation keyed by the receipt sender
-    let conv_id = sender.to_string();
-    if let Some(conv) = app.store.conversations.get_mut(&conv_id) {
-        for ts in timestamps {
-            if try_upgrade_receipt(&app.db, &conv_id, conv, *ts, new_status) {
-                matched_any = true;
-            }
-        }
+fn receipt_status(receipt_type: &str) -> Option<MessageStatus> {
+    match receipt_type.to_uppercase().as_str() {
+        "DELIVERY" => Some(MessageStatus::Delivered),
+        "READ" => Some(MessageStatus::Read),
+        "VIEWED" => Some(MessageStatus::Viewed),
+        _ => None,
     }
+}
 
-    // If no match in 1:1, scan all conversations (handles group receipts
-    // where sender is a member but conv is keyed by group ID)
-    if !matched_any {
-        for ts in timestamps {
+/// Apply a receipt to in-memory messages, per timestamp: try the 1:1
+/// conversation keyed by the receipt sender first, then scan all
+/// conversations (group receipts come from a member but the conv is keyed
+/// by group ID). Returns the timestamps that matched nothing.
+fn apply_receipt(
+    app: &mut App,
+    sender: &str,
+    new_status: MessageStatus,
+    timestamps: &[i64],
+) -> Vec<i64> {
+    let mut unmatched = Vec::new();
+    let sender_conv = sender.to_string();
+    for &ts in timestamps {
+        let mut matched = false;
+        if let Some(conv) = app.store.conversations.get_mut(&sender_conv) {
+            matched = try_upgrade_receipt(&app.db, &sender_conv, conv, ts, new_status);
+        }
+        if !matched {
             for (cid, conv) in &mut app.store.conversations {
-                if try_upgrade_receipt(&app.db, cid, conv, *ts, new_status) {
-                    matched_any = true;
+                if try_upgrade_receipt(&app.db, cid, conv, ts, new_status) {
+                    matched = true;
                     break;
                 }
             }
         }
+        if !matched {
+            unmatched.push(ts);
+        }
     }
+    unmatched
+}
 
-    // If still no match, the receipt may have arrived before the SendTimestamp
-    // that assigns the server timestamp. Buffer it for replay.
-    if !matched_any && !timestamps.is_empty() {
-        crate::debug_log::logf(format_args!(
-            "receipt: buffering {receipt_type} from {} (no matching ts)",
-            crate::debug_log::mask_phone(sender)
-        ));
-        app.pending.receipts.push((
-            sender.to_string(),
-            receipt_type.to_string(),
-            timestamps.to_vec(),
-        ));
-    } else if matched_any {
+/// Resolve a receipt that will never match in memory directly against the
+/// DB: the target may simply be outside the loaded message page (#484).
+/// The monotonic guard in the UPDATE keeps this upgrade-only.
+fn resolve_receipt_against_db(app: &App, new_status: MessageStatus, timestamps: &[i64]) {
+    for &ts in timestamps {
+        db_warn(
+            app.db
+                .update_outgoing_status_any_conv(ts, new_status.to_i32()),
+            "update_outgoing_status_any_conv",
+        );
+    }
+}
+
+/// Buffer the unmatched timestamps of a receipt for replay after the next
+/// SendTimestamp, evicting (with DB resolution) the oldest entry when full.
+fn buffer_receipt(
+    app: &mut App,
+    sender: &str,
+    receipt_type: &str,
+    timestamps: Vec<i64>,
+    attempts: u8,
+) {
+    if app.pending.receipts.len() >= MAX_BUFFERED_RECEIPTS {
+        let evicted = app.pending.receipts.remove(0);
+        if let Some(status) = receipt_status(&evicted.receipt_type) {
+            resolve_receipt_against_db(app, status, &evicted.timestamps);
+        }
+    }
+    app.pending.receipts.push(crate::domain::BufferedReceipt {
+        sender: sender.to_string(),
+        receipt_type: receipt_type.to_string(),
+        timestamps,
+        attempts,
+    });
+}
+
+fn handle_receipt(app: &mut App, sender: &str, receipt_type: &str, timestamps: &[i64]) {
+    let Some(new_status) = receipt_status(receipt_type) else {
+        return;
+    };
+
+    let unmatched = apply_receipt(app, sender, new_status, timestamps);
+
+    if unmatched.is_empty() {
         crate::debug_log::logf(format_args!(
             "receipt: {receipt_type} from {} -> {new_status:?}",
             crate::debug_log::mask_phone(sender)
         ));
+    } else {
+        // The receipt may predate the SendTimestamp that assigns the server
+        // timestamp; buffer ONLY the unmatched timestamps for replay. (The
+        // old per-event flag dropped unmatched timestamps whenever any
+        // sibling timestamp in the same event matched, #484.)
+        crate::debug_log::logf(format_args!(
+            "receipt: buffering {} unmatched {receipt_type} ts from {}",
+            unmatched.len(),
+            crate::debug_log::mask_phone(sender)
+        ));
+        buffer_receipt(app, sender, receipt_type, unmatched, 0);
     }
 }


### PR DESCRIPTION
Closes #484. Three related defects plus their most visible symptom:

**1. Partial receipt events dropped unmatched timestamps.** `handle_receipt` tracked matching with one per-event flag: when any timestamp in a multi-timestamp receipt matched, its unmatched siblings were discarded instead of buffered. Matching is now per-timestamp; only the unmatched remainder buffers.

**2. The receipt buffer re-buffered forever and lost the DB write.** A receipt targeting a message outside the loaded page can never match in memory. It re-buffered on every subsequent SendTimestamp replay, permanently, and its status never reached the DB. Buffered receipts now carry an attempt count: after 8 failed replays (or on eviction from the 64-entry cap) they resolve directly against the DB via the new `update_outgoing_status_any_conv` -- restricted to outgoing rows and upgrade-only via the monotonic guard, so a timestamp collision cannot downgrade anything. The original race this buffer exists for (receipt arriving before its SendTimestamp) still heals; the pre-existing test for it passes unchanged.

**3. The on-disk read marker advanced mid-sync.** The in-memory marker updates were correctly gated on `!sync.active` but `save_read_marker` ran unconditionally, so a crash during a long initial sync marked messages the user never saw as read. The persist now sits inside the same guard; `end_sync` reconciles once the burst completes.

**4. (Symptom fix) Own messages counted as unread after restart.** `db.unread_count` had no sender/status filter, so sending N messages and restarting showed an unread badge of N with the divider above your own messages. Now incoming-only, mirroring the in-memory recompute in `handle_read_sync`.

Four regression tests. Clippy clean, 799 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)