### PR TITLE
fix: poll routing and buffering cluster

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11107,6 +11107,36 @@ mod tests {
         );
     }
 
+    // #485: the buffer-insert used to sit inside the conversation lookup,
+    // so a poll event arriving before its conversation even existed
+    // (first-ever contact, poll event ordered before its companion
+    // message) was dropped and the poll rendered as bare text until
+    // restart.
+    #[rstest]
+    fn poll_created_before_conversation_exists_still_buffers(mut app: App) {
+        let ts = 1_700_000_013_000;
+        app.handle_signal_event(SignalEvent::PollCreated {
+            conv_id: "+brandnew".to_string(),
+            timestamp: ts,
+            poll_data: sample_poll(),
+        });
+        assert!(
+            app.poll_vote
+                .pending_polls
+                .contains_key(&("+brandnew".to_string(), ts))
+        );
+
+        let m = make_msg_with_ts("+brandnew", Some("vote!"), None, false, ts);
+        app.handle_signal_event(SignalEvent::MessageReceived(m));
+
+        let conv = &app.store.conversations["+brandnew"];
+        let idx = conv.find_msg_idx(ts).expect("message present");
+        assert!(
+            conv.messages[idx].poll_data.is_some(),
+            "poll must attach when the conversation and message arrive"
+        );
+    }
+
     #[rstest]
     fn poll_vote_received_upserts_vote(mut app: App) {
         let ts = 1_700_000_012_000;

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -1045,11 +1045,22 @@ fn handle_pin_received(
 fn handle_poll_created(app: &mut App, conv_id: &str, timestamp: i64, poll_data: PollData) {
     // The poll arrives as a regular message too — find it and attach poll_data.
     // If the message hasn't arrived yet (race), buffer the poll data so
-    // handle_message can attach it when the message arrives.
-    if let Some(conv) = app.store.conversations.get_mut(conv_id) {
-        if let Some(idx) = conv.find_msg_idx(timestamp) {
-            conv.messages[idx].poll_data = Some(poll_data.clone());
-        } else {
+    // handle_message can attach it when the message arrives. Buffer even
+    // when the CONVERSATION doesn't exist yet (first-ever contact whose
+    // poll event is ordered before its companion message), or the poll
+    // renders as bare text until restart (#485).
+    let target_idx = app
+        .store
+        .conversations
+        .get_mut(conv_id)
+        .and_then(|conv| conv.find_msg_idx(timestamp));
+    match target_idx {
+        Some(idx) => {
+            if let Some(conv) = app.store.conversations.get_mut(conv_id) {
+                conv.messages[idx].poll_data = Some(poll_data.clone());
+            }
+        }
+        None => {
             app.poll_vote
                 .pending_polls
                 .insert((conv_id.to_string(), timestamp), poll_data.clone());

--- a/src/signal/parse/message.rs
+++ b/src/signal/parse/message.rs
@@ -66,13 +66,13 @@ pub(super) fn parse_data_message(
     }
 
     if let Some(poll_create) = data.get("pollCreate") {
-        return parse_poll_create(envelope, data, poll_create);
+        return parse_poll_create(envelope, data, poll_create, None);
     }
     if let Some(poll_vote) = data.get("pollVote") {
-        return parse_poll_vote(envelope, data, poll_vote);
+        return parse_poll_vote(envelope, data, poll_vote, None);
     }
     if let Some(poll_terminate) = data.get("pollTerminate") {
-        return parse_poll_terminate(envelope, data, poll_terminate);
+        return parse_poll_terminate(envelope, data, poll_terminate, None);
     }
 
     // Shared early-return events (pin, unpin, remoteDelete, expirationUpdate, group UPDATE).
@@ -120,14 +120,17 @@ pub(super) fn parse_sent_sync(
         return parse_reaction_sync(envelope, sent, reaction);
     }
 
+    // Poll parsers need the destination: for a sync envelope the source is
+    // this account, and without the fallback a 1:1 poll event is filed
+    // under your own number (#485).
     if let Some(poll_create) = sent.get("pollCreate") {
-        return parse_poll_create(envelope, sent, poll_create);
+        return parse_poll_create(envelope, sent, poll_create, sent_destination(sent));
     }
     if let Some(poll_vote) = sent.get("pollVote") {
-        return parse_poll_vote(envelope, sent, poll_vote);
+        return parse_poll_vote(envelope, sent, poll_vote, sent_destination(sent));
     }
     if let Some(poll_terminate) = sent.get("pollTerminate") {
-        return parse_poll_terminate(envelope, sent, poll_terminate);
+        return parse_poll_terminate(envelope, sent, poll_terminate, sent_destination(sent));
     }
 
     let destination = sent_destination(sent);

--- a/src/signal/parse/mod.rs
+++ b/src/signal/parse/mod.rs
@@ -1064,6 +1064,94 @@ mod tests {
         }
     }
 
+    // #485: a sync'd 1:1 poll event's envelope source is YOUR OWN account;
+    // the conversation is the destination. Routing by source filed the poll
+    // under a conversation keyed by your own number.
+    #[test]
+    fn parse_poll_create_sync_routes_to_destination() {
+        let resp = make_resp(json!({
+            "envelope": {
+                "sourceNumber": "+15551234567", // this account
+                "timestamp": 1700000000000i64,
+                "syncMessage": {
+                    "sentMessage": {
+                        "timestamp": 1700000000000i64,
+                        "destinationNumber": "+15559876543",
+                        "pollCreate": {
+                            "question": "Lunch?",
+                            "allowMultiple": false,
+                            "options": [
+                                {"id": 0, "optionText": "Yes"},
+                                {"id": 1, "optionText": "No"}
+                            ]
+                        }
+                    }
+                }
+            }
+        }));
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::PollCreated { conv_id, .. } => {
+                assert_eq!(conv_id, "+15559876543");
+            }
+            _ => panic!("Expected PollCreated, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_poll_vote_sync_routes_to_destination() {
+        let resp = make_resp(json!({
+            "envelope": {
+                "sourceNumber": "+15551234567",
+                "timestamp": 1700000001000i64,
+                "syncMessage": {
+                    "sentMessage": {
+                        "timestamp": 1700000001000i64,
+                        "destinationNumber": "+15559876543",
+                        "pollVote": {
+                            "targetSentTimestamp": 1700000000000i64,
+                            "optionIndexes": [1],
+                            "voteCount": 1
+                        }
+                    }
+                }
+            }
+        }));
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::PollVoteReceived { conv_id, .. } => {
+                assert_eq!(conv_id, "+15559876543");
+            }
+            _ => panic!("Expected PollVoteReceived, got {event:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_poll_terminate_sync_routes_to_destination() {
+        let resp = make_resp(json!({
+            "envelope": {
+                "sourceNumber": "+15551234567",
+                "timestamp": 1700000002000i64,
+                "syncMessage": {
+                    "sentMessage": {
+                        "timestamp": 1700000002000i64,
+                        "destinationNumber": "+15559876543",
+                        "pollTerminate": {
+                            "targetSentTimestamp": 1700000000000i64
+                        }
+                    }
+                }
+            }
+        }));
+        let event = parse_signal_event(&resp, std::path::Path::new("/tmp")).unwrap();
+        match event {
+            SignalEvent::PollTerminated { conv_id, .. } => {
+                assert_eq!(conv_id, "+15559876543");
+            }
+            _ => panic!("Expected PollTerminated, got {event:?}"),
+        }
+    }
+
     #[test]
     fn parse_poll_vote_basic() {
         let resp = make_resp(json!({

--- a/src/signal/parse/poll.rs
+++ b/src/signal/parse/poll.rs
@@ -9,6 +9,7 @@ pub(super) fn parse_poll_create(
     envelope: &serde_json::Value,
     data: &serde_json::Value,
     poll_create: &serde_json::Value,
+    destination: Option<String>,
 ) -> Option<SignalEvent> {
     let question = poll_create
         .get("question")
@@ -37,9 +38,13 @@ pub(super) fn parse_poll_create(
         .get("groupInfo")
         .and_then(|g| g.get("groupId"))
         .and_then(|v| v.as_str());
+    // Conversation fallback chain: group_id -> destination -> sender. For a
+    // sync envelope the source is this account, so without the destination
+    // a 1:1 poll event would be filed under your own number (#485).
     let sender = envelope_source(envelope);
     let conv_id = group_id
         .map(|g| g.to_string())
+        .or(destination)
         .unwrap_or_else(|| sender.clone());
     let timestamp = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
 
@@ -62,6 +67,7 @@ pub(super) fn parse_poll_vote(
     envelope: &serde_json::Value,
     data: &serde_json::Value,
     poll_vote: &serde_json::Value,
+    destination: Option<String>,
 ) -> Option<SignalEvent> {
     let target_timestamp = poll_vote
         .get("targetSentTimestamp")
@@ -90,9 +96,13 @@ pub(super) fn parse_poll_vote(
         .get("groupInfo")
         .and_then(|g| g.get("groupId"))
         .and_then(|v| v.as_str());
+    // Conversation fallback chain: group_id -> destination -> sender. For a
+    // sync envelope the source is this account, so without the destination
+    // a 1:1 poll event would be filed under your own number (#485).
     let sender = envelope_source(envelope);
     let conv_id = group_id
         .map(|g| g.to_string())
+        .or(destination)
         .unwrap_or_else(|| sender.clone());
 
     Some(SignalEvent::PollVoteReceived {
@@ -109,6 +119,7 @@ pub(super) fn parse_poll_terminate(
     envelope: &serde_json::Value,
     data: &serde_json::Value,
     poll_terminate: &serde_json::Value,
+    destination: Option<String>,
 ) -> Option<SignalEvent> {
     let target_timestamp = poll_terminate
         .get("targetSentTimestamp")
@@ -117,9 +128,13 @@ pub(super) fn parse_poll_terminate(
         .get("groupInfo")
         .and_then(|g| g.get("groupId"))
         .and_then(|v| v.as_str());
+    // Conversation fallback chain: group_id -> destination -> sender. For a
+    // sync envelope the source is this account, so without the destination
+    // a 1:1 poll event would be filed under your own number (#485).
     let sender = envelope_source(envelope);
     let conv_id = group_id
         .map(|g| g.to_string())
+        .or(destination)
         .unwrap_or_else(|| sender.clone());
 
     Some(SignalEvent::PollTerminated {


### PR DESCRIPTION
Closes #485. Two defects in poll event handling:

**1. Sync''d 1:1 poll events routed to your own conversation.** The three poll parsers computed `conv_id = group_id -> envelope_source`, but for a sync envelope (a poll you created/voted/terminated from your phone) the source is this account. The rest of `parse_sent_sync` already threads `sent_destination` as the fallback; the poll parsers were written before that and never received it. Result: 1:1 poll activity from your other devices was filed under a conversation keyed by your own phone number, never rendered in the actual chat, and could spawn a ghost self-conversation. The parsers now take the destination with the fallback chain group_id -> destination -> sender, mirroring `parse_data_payload_event`.

**2. Poll data dropped when PollCreated preceded its conversation.** The `pending_polls` race-buffer insert sat inside `conversations.get_mut`, so a first-ever contact whose poll event arrived before its companion message lost the poll outright -- it rendered as bare text until a restart reloaded poll_data from the DB. The buffer now fills regardless of whether the conversation exists yet.

Verification-first: the three sync-routing tests failed on master with `conv_id` equal to the sender''s own number, exactly as the review traced. Plus a regression test for the no-conversation buffer case (the existing conversation-exists race test passes unchanged). Clippy clean, 799 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)