### PR TITLE
[codex] Tune Sixel image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ Outside tmux, siggy auto-detects Kitty / iTerm2 / WezTerm / Ghostty and renders 
 
 If `SIGGY_IMAGE_PROTOCOL` is unset, the existing auto-detection runs (correct outside tmux, falls back to halfblock inside it). Sixel passes through tmux 3.4+ natively and does not need the env var.
 
+For larger Sixel previews, keep `image_mode = "native"` and raise the terminal-cell
+limits in `config.toml`:
+
+```toml
+image_max_width = 80
+image_max_height = 45
+sixel_max_colors = 256
+sixel_diffusion = 0.875
+```
+
 ## Features
 
 - **Messaging** -- Send and receive 1:1 and group messages

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -29,6 +29,11 @@ desktop_notifications = false
 notification_preview = "full"
 clipboard_clear_seconds = 30
 image_mode = "halfblock"
+image_max_width = 40
+preview_image_max_width = 30
+image_max_height = 30
+sixel_max_colors = 256
+sixel_diffusion = 0.875
 show_link_previews = true
 date_separators = true
 show_receipts = true
@@ -59,6 +64,11 @@ proxy = ""
 | `notification_preview` | string | `"full"` | Notification content level: `full`, `sender`, or `minimal` |
 | `clipboard_clear_seconds` | int | `30` | Seconds before clipboard auto-clears after copying (0 = disabled) |
 | `image_mode` | string | `"halfblock"` | Image rendering mode: `native` (Kitty / iTerm2 / Sixel), `halfblock` (universal Unicode fallback), or `none` |
+| `image_max_width` | int | `40` | Maximum attachment image width in terminal cells |
+| `preview_image_max_width` | int | `30` | Maximum link preview thumbnail width in terminal cells |
+| `image_max_height` | int | `30` | Maximum image height in terminal cell rows |
+| `sixel_max_colors` | int | `256` | Maximum Sixel palette colors (`2`-`256`) |
+| `sixel_diffusion` | float | `0.875` | Sixel Floyd-Steinberg diffusion strength (`0.0`-`1.0`) |
 | `show_link_previews` | bool | `true` | Show link preview cards for URLs in messages |
 | `date_separators` | bool | `true` | Show date separator lines between messages from different days |
 | `show_receipts` | bool | `true` | Show delivery/read receipt status symbols |

--- a/src/app.rs
+++ b/src/app.rs
@@ -924,6 +924,11 @@ impl App {
         config.settings_profile = self.settings_profiles.name.clone();
         config.notification_preview = self.notifications.notification_preview;
         config.image_mode = Some(self.image.image_mode);
+        config.image_max_width = self.image.image_max_width;
+        config.preview_image_max_width = self.image.preview_image_max_width;
+        config.image_max_height = self.image.image_max_height;
+        config.sixel_max_colors = self.image.sixel_encode.max_colors;
+        config.sixel_diffusion = self.image.sixel_encode.diffusion;
         config.sidebar_width = self.sidebar_width;
         for def in SETTINGS {
             if let Some(save_fn) = def.save {
@@ -966,13 +971,10 @@ impl App {
                 }
                 // Pre-populate native image caches from background task
                 if let Some((path, b64, pw, ph)) = result.pre_native_png {
-                    self.image
-                        .native_image_cache
-                        .entry(path)
-                        .or_insert((b64, pw, ph));
+                    self.image.native_image_cache.insert(path, (b64, pw, ph));
                 }
                 if let Some((path, sixel)) = result.pre_sixel {
-                    self.image.sixel_cache.entry(path).or_insert(sixel);
+                    self.image.sixel_cache.insert(path, sixel);
                 }
                 drained = true;
             }
@@ -992,50 +994,110 @@ impl App {
         if len == 0 {
             return drained;
         }
+        let is_native = self.image.image_mode == crate::domain::ImageMode::Native;
+        let is_sixel = self.image.image_protocol == image_render::ImageProtocol::Sixel;
+        let pane_width_cap = if self.image.render_width_cap > 0 {
+            self.image.render_width_cap
+        } else {
+            self.image.image_max_width
+        };
+        let image_max_width = self.image.image_max_width.min(pane_width_cap).max(1);
+        let preview_image_max_width = self
+            .image
+            .preview_image_max_width
+            .min(pane_width_cap)
+            .max(1);
         let end = len
             .saturating_sub(self.scroll.offset.saturating_sub(5))
             .min(len);
         let start = end.saturating_sub(60);
 
-        // Collect work items to avoid borrow conflicts: (timestamp, path, max_width, is_preview)
-        let mut work: Vec<(i64, String, u32, bool)> = Vec::new();
+        // Collect work items to avoid borrow conflicts:
+        // (timestamp, path, max_width, max_height_cells, is_preview)
+        let mut work: Vec<(i64, String, u32, u32, bool)> = Vec::new();
         for msg in &conv.messages[start..end] {
             if self.image.image_render_in_flight.len() + work.len() >= 4 {
                 break;
             }
             if msg.body.starts_with("[image:")
-                && msg.image_lines.is_none()
                 && let Some(ref p) = msg.image_path
             {
+                let has_rendered_lines = msg
+                    .image_lines
+                    .as_ref()
+                    .is_some_and(|lines| !lines.is_empty());
+                let image_too_wide = msg.image_lines.as_ref().is_some_and(|lines| {
+                    lines
+                        .first()
+                        .is_some_and(|line| line.width().saturating_sub(2) as u32 > image_max_width)
+                });
+                let native_cache_missing = is_native
+                    && has_rendered_lines
+                    && if is_sixel {
+                        !self.image.sixel_cache.contains_key(p)
+                    } else {
+                        !self.image.native_image_cache.contains_key(p)
+                    };
                 let key = (id.clone(), msg.timestamp_ms, false);
-                if !self.image.image_render_in_flight.contains(&key) {
-                    work.push((msg.timestamp_ms, p.clone(), 40, false));
+                if (msg.image_lines.is_none() || image_too_wide || native_cache_missing)
+                    && !self.image.image_render_in_flight.contains(&key)
+                {
+                    work.push((
+                        msg.timestamp_ms,
+                        p.clone(),
+                        image_max_width,
+                        self.image.image_max_height,
+                        false,
+                    ));
                 }
             }
             if self.image.show_link_previews
-                && msg.preview_image_lines.is_none()
                 && let Some(ref preview) = msg.preview
                 && let Some(ref p) = preview.image_path
             {
+                let has_rendered_lines = msg
+                    .preview_image_lines
+                    .as_ref()
+                    .is_some_and(|lines| !lines.is_empty());
+                let image_too_wide = msg.preview_image_lines.as_ref().is_some_and(|lines| {
+                    lines.first().is_some_and(|line| {
+                        line.width().saturating_sub(2) as u32 > preview_image_max_width
+                    })
+                });
+                let native_cache_missing = is_native
+                    && has_rendered_lines
+                    && if is_sixel {
+                        !self.image.sixel_cache.contains_key(p)
+                    } else {
+                        !self.image.native_image_cache.contains_key(p)
+                    };
                 let key = (id.clone(), msg.timestamp_ms, true);
-                if !self.image.image_render_in_flight.contains(&key) {
-                    work.push((msg.timestamp_ms, p.clone(), 30, true));
+                if (msg.preview_image_lines.is_none() || image_too_wide || native_cache_missing)
+                    && !self.image.image_render_in_flight.contains(&key)
+                {
+                    work.push((
+                        msg.timestamp_ms,
+                        p.clone(),
+                        preview_image_max_width,
+                        self.image.image_max_height,
+                        true,
+                    ));
                 }
             }
         }
 
         // Spawn background render tasks
-        let is_native = self.image.image_mode == crate::domain::ImageMode::Native;
-        let is_sixel = self.image.image_protocol == image_render::ImageProtocol::Sixel;
         let cell_px = self.image.cell_px;
-        for (ts, path, max_width, is_preview) in work {
+        let sixel_encode = self.image.sixel_encode;
+        for (ts, path, max_width, max_height, is_preview) in work {
             self.image
                 .image_render_in_flight
                 .insert((id.clone(), ts, is_preview));
             let tx = self.image.image_render_tx.clone();
             let cid = id.clone();
             tokio::task::spawn_blocking(move || {
-                let lines = image_render::render_image(Path::new(&path), max_width);
+                let lines =
+                    image_render::render_image_with_limits(Path::new(&path), max_width, max_height);
 
                 // Pre-encode PNG (all native protocols) and Sixel alongside halfblock
                 // so caches are populated before the image first appears in the viewport.
@@ -1056,6 +1118,7 @@ impl App {
                                     cell_w as u16,
                                     cell_h as u16,
                                     cell_px,
+                                    sixel_encode,
                                 )
                             })
                         } else {
@@ -3375,9 +3438,9 @@ impl App {
     /// Full image state reset: clear both terminal placements and base64 caches.
     /// Call on terminal resize (cell dimensions change, so cached PNGs need re-encoding).
     ///
-    /// Sixel caches survive resize: encoding depends on cell_px (from config,
-    /// not terminal size) and halfblock dimensions (fixed at max_width=40).
-    /// Only screen positions change, which ratatui recomputes automatically.
+    /// Sixel caches survive resize: encoding depends on cell_px and configured
+    /// preview dimensions, not the terminal's current cell grid. Only screen
+    /// positions change, which ratatui recomputes automatically.
     pub fn clear_kitty_state(&mut self) {
         self.clear_kitty_placements();
         if self.image.image_protocol != ImageProtocol::Sixel {

--- a/src/config.rs
+++ b/src/config.rs
@@ -126,6 +126,26 @@ pub struct Config {
     #[serde(default)]
     pub cell_pixel_height: u16,
 
+    /// Maximum inline image attachment width in terminal cells
+    #[serde(default = "default_image_max_width")]
+    pub image_max_width: u32,
+
+    /// Maximum link preview thumbnail width in terminal cells
+    #[serde(default = "default_preview_image_max_width")]
+    pub preview_image_max_width: u32,
+
+    /// Maximum inline image height in terminal cell rows
+    #[serde(default = "default_image_max_height")]
+    pub image_max_height: u32,
+
+    /// Maximum colors for Sixel encoding (2-256)
+    #[serde(default = "default_sixel_max_colors")]
+    pub sixel_max_colors: u16,
+
+    /// Floyd-Steinberg diffusion strength for Sixel encoding (0.0-1.0)
+    #[serde(default = "default_sixel_diffusion")]
+    pub sixel_diffusion: f32,
+
     /// Legacy: show inline halfblock image previews (migrated to image_mode)
     #[serde(default = "default_true", skip_serializing)]
     pub inline_images: bool,
@@ -223,6 +243,26 @@ fn default_sidebar_width() -> u16 {
     22
 }
 
+fn default_image_max_width() -> u32 {
+    40
+}
+
+fn default_preview_image_max_width() -> u32 {
+    30
+}
+
+fn default_image_max_height() -> u32 {
+    30
+}
+
+fn default_sixel_max_colors() -> u16 {
+    256
+}
+
+fn default_sixel_diffusion() -> f32 {
+    0.875
+}
+
 fn default_signal_cli_path() -> String {
     "signal-cli".to_string()
 }
@@ -247,6 +287,11 @@ impl Default for Config {
             image_mode: Some(ImageMode::Halfblock),
             cell_pixel_width: 0,
             cell_pixel_height: 0,
+            image_max_width: default_image_max_width(),
+            preview_image_max_width: default_preview_image_max_width(),
+            image_max_height: default_image_max_height(),
+            sixel_max_colors: default_sixel_max_colors(),
+            sixel_diffusion: default_sixel_diffusion(),
             inline_images: true,
             show_link_previews: true,
             native_images: false,

--- a/src/domain/image.rs
+++ b/src/domain/image.rs
@@ -16,7 +16,7 @@ use std::sync::mpsc;
 pub use crate::config::ImageMode;
 
 use crate::app::{ImageRenderResult, VisibleImage};
-use crate::image_render::ImageProtocol;
+use crate::image_render::{ImageProtocol, SixelEncodeSettings};
 use crate::ui::LinkRegion;
 
 /// State for image rendering, caching, and link overlay tracking.
@@ -33,6 +33,16 @@ pub struct ImageState {
     pub image_protocol: ImageProtocol,
     /// Cell pixel dimensions (width, height) for Sixel encoding
     pub cell_px: (u16, u16),
+    /// Maximum attachment preview width in terminal cells
+    pub image_max_width: u32,
+    /// Maximum link preview thumbnail width in terminal cells
+    pub preview_image_max_width: u32,
+    /// Maximum preview height in terminal cell rows
+    pub image_max_height: u32,
+    /// Current chat pane image width cap in terminal cells
+    pub render_width_cap: u32,
+    /// Sixel palette and dithering options
+    pub sixel_encode: SixelEncodeSettings,
     /// Images visible on screen for native protocol overlay (cleared each frame)
     pub visible_images: Vec<VisibleImage>,
     /// Previous scroll offset for Sixel stale pixel detection
@@ -75,6 +85,11 @@ impl ImageState {
             link_url_map: HashMap::new(),
             image_protocol: image_render::detect_protocol(),
             cell_px: image_render::detect_cell_pixel_size(),
+            image_max_width: 40,
+            preview_image_max_width: 30,
+            image_max_height: 30,
+            render_width_cap: 0,
+            sixel_encode: SixelEncodeSettings::default(),
             visible_images: Vec::new(),
             sixel_prev_scroll: 0,
             prev_visible_images: Vec::new(),

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -374,7 +374,11 @@ fn build_outgoing_attachment_body(
     let (img_lines, img_path) =
         if is_image && app.image.image_mode != crate::domain::ImageMode::None {
             (
-                image_render::render_image(path, 40),
+                image_render::render_image_with_limits(
+                    path,
+                    app.image.image_max_width,
+                    app.image.image_max_height,
+                ),
                 Some(path.to_string_lossy().into_owned()),
             )
         } else {

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -430,10 +430,13 @@ fn resolve_incoming(app: &App, msg: &SignalMessage) -> Option<ResolvedMessage> {
             .map(|p| format!("({})", path_to_file_uri(p)))
             .unwrap_or_default();
         if is_image {
-            let rendered = att
-                .local_path
-                .as_deref()
-                .and_then(|p| image_render::render_image(Path::new(p), 40));
+            let rendered = att.local_path.as_deref().and_then(|p| {
+                image_render::render_image_with_limits(
+                    Path::new(p),
+                    app.image.image_max_width,
+                    app.image.image_max_height,
+                )
+            });
             entries.push(ResolvedEntry {
                 body: format!("[image: {label}]{path_info}"),
                 image_lines: rendered,
@@ -686,7 +689,11 @@ fn persist_message_extras(app: &mut App, r: &ResolvedMessage) {
             && let Some(ref p) = preview.image_path
         {
             (
-                image_render::render_image(Path::new(p), 30),
+                image_render::render_image_with_limits(
+                    Path::new(p),
+                    app.image.preview_image_max_width,
+                    app.image.image_max_height,
+                ),
                 Some(p.clone()),
             )
         } else {

--- a/src/image_render.rs
+++ b/src/image_render.rs
@@ -28,6 +28,24 @@ pub enum ImageProtocol {
     Halfblock,
 }
 
+/// Quality settings for Sixel encoding.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SixelEncodeSettings {
+    /// Maximum colors in the generated Sixel palette.
+    pub max_colors: u16,
+    /// Floyd-Steinberg error diffusion strength.
+    pub diffusion: f32,
+}
+
+impl Default for SixelEncodeSettings {
+    fn default() -> Self {
+        Self {
+            max_colors: 256,
+            diffusion: 0.875,
+        }
+    }
+}
+
 /// Detect the best available image protocol by checking environment variables.
 ///
 /// Honors an explicit `SIGGY_IMAGE_PROTOCOL` override
@@ -148,13 +166,17 @@ pub fn detect_cell_pixel_size() -> (u16, u16) {
 
 /// Encode a pre-sized image as a Sixel DCS string (CPU-bound).
 ///
-/// Decodes the base64 PNG, resizes to fill the target cell area, and
-/// Sixel-encodes.  Designed to run on a blocking thread via `spawn_blocking`.
+/// Decodes the base64 PNG, resizes down to the target cell area if needed, and
+/// Sixel-encodes. Designed to run on a blocking thread via `spawn_blocking`.
+/// The input PNG is already capped to the inline preview dimensions; do not
+/// upscale it here or a bad cell-pixel override can make the Sixel overlay
+/// much larger than the text-cell placeholder.
 pub fn encode_sixel(
     b64_png: &str,
     width_cells: u16,
     height_cells: u16,
     cell_px: (u16, u16),
+    settings: SixelEncodeSettings,
 ) -> Option<String> {
     use base64::Engine;
     let bytes = base64::engine::general_purpose::STANDARD
@@ -169,20 +191,19 @@ pub fn encode_sixel(
     let target_w = (width_cells as u32 * cell_px.0 as u32).max(1);
     let target_h = (height_cells as u32 * cell_px.1 as u32).max(1);
 
-    let scale = f64::min(target_w as f64 / w as f64, target_h as f64 / h as f64);
+    let scale = f64::min(target_w as f64 / w as f64, target_h as f64 / h as f64).min(1.0);
     let new_w = ((w as f64 * scale).round() as u32).max(1);
     let new_h = ((h as f64 * scale).round() as u32).max(1);
 
     let resized = img.resize_exact(new_w, new_h, image::imageops::FilterType::Triangle);
     let rgba = resized.to_rgba8().into_raw();
+    let opts = icy_sixel::EncodeOptions {
+        max_colors: settings.max_colors.clamp(2, 256),
+        diffusion: settings.diffusion.clamp(0.0, 1.0),
+        quantize_method: icy_sixel::QuantizeMethod::Wu,
+    };
 
-    icy_sixel::sixel_encode(
-        &rgba,
-        new_w as usize,
-        new_h as usize,
-        &icy_sixel::EncodeOptions::default(),
-    )
-    .ok()
+    icy_sixel::sixel_encode(&rgba, new_w as usize, new_h as usize, &opts).ok()
 }
 
 /// Slice a cached full-size Sixel DCS string to extract only the visible bands.
@@ -421,7 +442,8 @@ pub fn kitty_id_color(image_id: u32) -> Color {
     Color::Rgb(r, g, b)
 }
 
-/// Render an image file as halfblock-character lines for display in a terminal.
+/// Render an image file as halfblock-character lines for display in a terminal
+/// using explicit terminal-cell dimensions.
 ///
 /// Each terminal cell represents two vertical pixels using the upper-half-block
 /// character (▀) with the top pixel as foreground and bottom pixel as background.
@@ -429,16 +451,20 @@ pub fn kitty_id_color(image_id: u32) -> Color {
 /// Returns `None` if the image cannot be loaded or decoded, or if the source
 /// image exceeds `MAX_INPUT_DIM` on either axis. The size cap is defensive:
 /// a pathological link-preview og:image (e.g. a 30000×30000 promotional poster)
-/// can pin a `spawn_blocking` thread for minutes inside the resize step, and
-/// the output is at most a 30-cell column anyway. See issue #408.
-pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
+/// can pin a `spawn_blocking` thread for minutes inside the resize step. See
+/// issue #408.
+pub fn render_image_with_limits(
+    path: &Path,
+    max_width: u32,
+    max_height_cells: u32,
+) -> Option<Vec<Line<'static>>> {
     /// Largest input dimension we'll attempt to decode. Anything over this
     /// is treated as a broken / hostile image and silently skipped.
     const MAX_INPUT_DIM: u32 = 8192;
 
     let start = Instant::now();
     crate::debug_log::logf(format_args!(
-        "render_image start: path={} max_width={max_width}",
+        "render_image start: path={} max_width={max_width} max_height_cells={max_height_cells}",
         path.display()
     ));
 
@@ -459,8 +485,8 @@ pub fn render_image(path: &Path, max_width: u32) -> Option<Vec<Line<'static>>> {
         }
     };
 
-    let cap_width = max_width;
-    let cap_height: u32 = 60; // 30 cell-rows × 2 pixels per row
+    let cap_width = max_width.max(1);
+    let cap_height = max_height_cells.max(1).saturating_mul(2);
 
     let (orig_w, orig_h) = img.dimensions();
     if orig_w == 0 || orig_h == 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -564,6 +564,31 @@ fn emit_passthrough_seq(
     }
 }
 
+/// Overwrite previously drawn Sixel image rectangles with spaces.
+///
+/// This is much cheaper than clearing the whole terminal and avoids re-sending
+/// current image rectangles before every Sixel payload.
+fn erase_sixel_rects(
+    backend: &mut CrosstermBackend<io::Stdout>,
+    images: &[app::VisibleImage],
+) -> Result<()> {
+    if images.is_empty() {
+        return Ok(());
+    }
+    queue!(backend, Hide, SavePosition)?;
+    for img in images {
+        if img.width == 0 || img.height == 0 {
+            continue;
+        }
+        let blank = " ".repeat(img.width as usize);
+        for row in 0..img.height {
+            queue!(backend, MoveTo(img.x, img.y + row), Print(blank.as_str()))?;
+        }
+    }
+    queue!(backend, RestorePosition, Show)?;
+    Ok(())
+}
+
 /// Write native terminal image protocol escape sequences.
 ///
 /// For Kitty: process `kitty_pending_transmits` — transmit image data and create
@@ -633,20 +658,25 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
     if protocol == image_render::ImageProtocol::Sixel {
         if app.has_overlay() || app.image.visible_images.is_empty() {
             app.image.visible_images.clear();
+            app.image.prev_visible_images.clear();
             return Ok(());
         }
 
-        // Dedup: skip Sixel emit when images haven't moved (avoids cursor
-        // flash from large Sixel writes on every mouse-move/redraw).
         if app.image.visible_images == app.image.prev_visible_images {
             app.image.visible_images.clear();
             return Ok(());
         }
 
         let images = std::mem::take(&mut app.image.visible_images);
+        let all_cached = images
+            .iter()
+            .all(|img| app.image.sixel_cache.contains_key(&img.path));
         queue!(backend, Hide, SavePosition)?;
 
         for img in &images {
+            if img.width == 0 || img.height == 0 {
+                continue;
+            }
             if let Some(full_sixel) = app.image.sixel_cache.get(&img.path) {
                 let sliced = image_render::slice_sixel_bands(
                     full_sixel,
@@ -663,7 +693,11 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
         }
 
         queue!(backend, RestorePosition, Show)?;
-        app.image.prev_visible_images = images;
+        if all_cached {
+            app.image.prev_visible_images = images;
+        } else {
+            app.image.prev_visible_images.clear();
+        }
         return Ok(());
     }
 
@@ -1260,6 +1294,13 @@ async fn run_app(
     app.notifications.clipboard_clear_seconds = config.clipboard_clear_seconds;
     app.image.image_mode = config.image_mode.unwrap_or_default();
     app.image.show_link_previews = config.show_link_previews;
+    app.image.image_max_width = config.image_max_width.clamp(1, 240);
+    app.image.preview_image_max_width = config.preview_image_max_width.clamp(1, 240);
+    app.image.image_max_height = config.image_max_height.clamp(1, 120);
+    app.image.sixel_encode = image_render::SixelEncodeSettings {
+        max_colors: config.sixel_max_colors.clamp(2, 256),
+        diffusion: config.sixel_diffusion.clamp(0.0, 1.0),
+    };
     app.incognito = incognito;
     app.download_dir = config.download_dir.clone();
     app.date_separators = config.date_separators;
@@ -1360,8 +1401,15 @@ async fn run_app(
             queue!(terminal.backend_mut(), BeginSynchronizedUpdate)?;
 
             // Force full redraw when active conversation changes (clears native image artifacts)
-            if native && app.active_conversation != app.prev_active_conversation {
+            let conversation_changed =
+                native && app.active_conversation != app.prev_active_conversation;
+            let scroll_changed = sixel_mode && app.scroll.offset != app.image.sixel_prev_scroll;
+            let clear_previous_sixels =
+                sixel_mode && (conversation_changed || scroll_changed || app.has_overlay());
+
+            if conversation_changed {
                 app.prev_active_conversation = app.active_conversation.clone();
+                app.image.visible_images.clear();
                 terminal.clear()?;
             }
             // Sixel: force full redraw when scroll changes so ratatui resends
@@ -1369,10 +1417,14 @@ async fn run_app(
             // buffer, then after EndSync our Sixel overlays at the new positions.
             // Without this, stale Sixel pixels persist at old image positions
             // because ratatui's diff only sends changed cells.
-            if sixel_mode && app.scroll.offset != app.image.sixel_prev_scroll {
+            if scroll_changed {
                 app.image.sixel_prev_scroll = app.scroll.offset;
-                app.image.prev_visible_images.clear();
+                app.image.visible_images.clear();
                 terminal.clear()?;
+            }
+            if clear_previous_sixels {
+                erase_sixel_rects(terminal.backend_mut(), &app.image.prev_visible_images)?;
+                app.image.prev_visible_images.clear();
             }
             terminal.draw(|frame| ui::draw(frame, &mut app))?;
             // Post-draw work that needs cursor hidden: OSC8 links use MoveTo,

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -36,6 +36,10 @@ use crate::signal::types::{PollData, PollVote, Reaction, TrustLevel};
 use crate::theme::Theme;
 use ratatui::layout::Alignment;
 
+fn sixel_placeholder_line(line: &Line<'static>) -> Line<'static> {
+    Line::from(Span::raw(" ".repeat(line.width())))
+}
+
 /// Convert emoji in a string to text emoticons or :shortcodes:.
 /// Common emoji get classic emoticons (e.g. :) <3), others get :shortcode: format.
 fn emoji_to_text(input: &str) -> String {
@@ -265,6 +269,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 
     app.mouse.messages_area = inner;
+    app.image.render_width_cap = u32::from(inner.width.saturating_sub(2).max(1));
 
     let messages = match &app.active_conversation {
         Some(id) => {
@@ -318,6 +323,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     // Track images for native protocol overlay: (first_line_index, line_count, path)
     let use_native = app.image.image_mode == crate::domain::ImageMode::Native
         && app.image.image_protocol != ImageProtocol::Halfblock;
+    let use_sixel = use_native && app.image.image_protocol == ImageProtocol::Sixel;
     let mut image_records: Vec<(usize, usize, String)> = Vec::new();
 
     for (i, msg) in visible.iter().enumerate() {
@@ -506,7 +512,11 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 let first_idx = lines.len();
                 let count = image_lines.len();
                 for line in image_lines {
-                    lines.push(line.clone());
+                    if use_sixel {
+                        lines.push(sixel_placeholder_line(line));
+                    } else {
+                        lines.push(line.clone());
+                    }
                     line_msg_idx.push(Some(msg_index));
                 }
                 // Record for native protocol overlay
@@ -556,7 +566,11 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                     let first_idx = lines.len();
                     let count = img_lines.len();
                     for line in img_lines {
-                        lines.push(line.clone());
+                        if use_sixel {
+                            lines.push(sixel_placeholder_line(line));
+                        } else {
+                            lines.push(line.clone());
+                        }
                         line_msg_idx.push(Some(msg_index));
                     }
                     if use_native && let Some(ref path) = msg.preview_image_path {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -160,12 +160,12 @@ pub(super) fn centered_popup(
 }
 
 pub fn draw(frame: &mut Frame, app: &mut App) {
+    app.image.link_url_map.clear();
+    app.image.visible_images.clear();
     if app.lock.is_locked() {
         crate::ui::overlays::lock_screen::draw_lock_screen(frame, app, frame.area());
         return;
     }
-    app.image.link_url_map.clear();
-    app.image.visible_images.clear();
     let size = frame.area();
     let terminal_width = size.width;
 


### PR DESCRIPTION
## Summary

Adds Sixel-specific image rendering controls and fixes the native Sixel overlay behavior so it works better in browser-backed terminals such as ttyd.

- Adds config fields for inline image dimensions and Sixel palette/diffusion tuning.
- Clamps generated image previews to the current chat pane width so native overlays do not drift away from wrapped placeholders.
- Prevents Sixel encoding from upscaling beyond the already capped preview PNG.
- Uses blank reserved rows for Sixel placeholders instead of rendering halfblock art underneath the Sixel overlay.
- Clears only previous Sixel rectangles on geometry changes and skips re-sending unchanged Sixel payloads to reduce flicker and ttyd network traffic.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --tests -- -D warnings` passes
- [x] `bash scripts/check-app-field-count.sh` passes
- [x] `cargo test` passes
- [x] Tested manually in the TUI via ttyd/Sixel iteration on `monolith`
