### PR TITLE
chore(release): bump version to 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.8.0                                  │t too                   │
+                     ││[0│  siggy v1.9.0                                  │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
Version bump for the v1.9.0 release (Cargo.toml, Cargo.lock, about-overlay snapshot).

Security, reliability, and performance release. Since v1.8.0:

**Security**
- "Open attachment" now vets paths: download-dir containment + file-type allowlist before shell-opening (#505)
- Incoming edits and remote-deletes verify the sender is the message author (#512)

**Reliability**
- Edit/reply targets no longer leak across conversation switches (#507)
- Rapid consecutive sends no longer stick on "sending" forever (#511)
- Failed sends display as Failed, not Sent, after restart (#509)
- Disappearing-message expiry no longer shifts focus, read markers, or the delete-confirm target (#517)
- Receipt buffering integrity; your own messages no longer count as unread (#518)
- Polls created/voted from your other devices route to the right conversation (#519)
- Malformed custom theme files no longer crash startup (#508)

**Performance**
- Scroll-to-top pagination runaway eliminated, and older history is now actually reachable by scrolling (#516)
- Initial device sync no longer pays one fsync per message (#510)

**Docs**
- README available in 12 languages with a native-speaker review pipeline (#478, #479, #514)

After merge: tag v1.9.0, push the tag (release.yml builds the 4 platform binaries), then cargo publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)