### PR TITLE
fix(install): locate signal-cli binary in native tarball root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,7 +87,12 @@ else
     curl -fsSL -o "$TMPDIR/$SCLI_ARCHIVE" "$SCLI_URL" || error "signal-cli download failed: $SCLI_URL"
 
     tar xzf "$TMPDIR/$SCLI_ARCHIVE" -C "$TMPDIR"
-    cp "$TMPDIR/signal-cli-${SCLI_VERSION}-Linux-native/bin/signal-cli" "$INSTALL_DIR/signal-cli"
+    # The native build extracts a single signal-cli executable at the archive
+    # root (unlike the JVM build's signal-cli-<ver>/bin/ layout). Locate it
+    # rather than assuming a fixed path so we survive future layout changes.
+    SCLI_BIN="$(find "$TMPDIR" -type f -name signal-cli | head -1)"
+    [ -n "$SCLI_BIN" ] || error "signal-cli binary not found in extracted archive"
+    cp "$SCLI_BIN" "$INSTALL_DIR/signal-cli"
     chmod +x "$INSTALL_DIR/signal-cli"
 
     info "Installed signal-cli to $INSTALL_DIR/signal-cli"


### PR DESCRIPTION
## Summary

Fixes the signal-cli native auto-install in `install.sh`, which aborted on a fresh Linux box with no signal-cli present:

```
:: Installing signal-cli native build (no Java required)...
:: Downloading signal-cli v0.14.5 native build...
cp: cannot stat '/tmp/tmp.XXXX/signal-cli-0.14.5-Linux-native/bin/signal-cli': No such file or directory
```

**Cause:** the native `-Linux-native.tar.gz` extracts a single `signal-cli` executable at the archive root — it does *not* use the JVM build's `signal-cli-<ver>/bin/` layout that the script assumed. So `install.sh:90` referenced a path that never exists.

**Fix:** `find` the `signal-cli` executable in the extraction dir instead of hardcoding the path, and `error` with a clear message if it's missing (resilient to future upstream layout changes).

closes #523

## Verification

- Downloaded the real `signal-cli-0.14.5-Linux-native.tar.gz`; confirmed it contains a single `signal-cli` at the root (no `bin/` subdir).
- Confirmed the `find` lookup locates the binary in the extracted tree.
- `bash -n install.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxFxGtGmsyfh8C7Hxw6XNv)_