### PR TITLE
chore(release): bump version to 1.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,7 +2503,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.9.0"
+version = "1.9.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.9.0"
+version = "1.9.1"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.9.0                                  │t too                   │
+                     ││[0│  siggy v1.9.1                                  │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
Patch release.

Carries the `install.sh` native signal-cli fix from #524 (closes #523), which unblocked the fresh-Linux install path (`cp: cannot stat .../bin/signal-cli`).

After this merges, tag `v1.9.1` to trigger `release.yml` (clippy/tests → 4-target binaries → GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxFxGtGmsyfh8C7Hxw6XNv)_