### PR TITLE
ci(release): allow manual workflow_dispatch with a tag input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to create and publish (e.g. v1.9.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -28,6 +34,8 @@ jobs:
     name: Build (${{ matrix.target }})
     needs: check
     runs-on: ${{ matrix.runner }}
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
     strategy:
       matrix:
         include:
@@ -66,25 +74,27 @@ jobs:
         if: matrix.archive == 'tar.gz'
         run: |
           cd target/${{ matrix.target }}/release
-          tar czf ../../../siggy-${{ github.ref_name }}-${{ matrix.target }}.tar.gz siggy
+          tar czf ../../../siggy-${TAG}-${{ matrix.target }}.tar.gz siggy
           cd ../../..
 
       - name: Package (Windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Compress-Archive -Path "target/${{ matrix.target }}/release/siggy.exe" -DestinationPath "siggy-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/siggy.exe" -DestinationPath "siggy-${env:TAG}-${{ matrix.target }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: siggy-${{ matrix.target }}
-          path: siggy-${{ github.ref_name }}-${{ matrix.target }}.*
+          path: siggy-${{ env.TAG }}-${{ matrix.target }}.*
 
   release:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -93,6 +103,10 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          # On workflow_dispatch the tag does not exist yet; the action
+          # creates it at the workflow's checkout commit (default branch HEAD).
+          # On a tag push this matches the pushed tag (a no-op create).
+          tag_name: ${{ env.TAG }}
           generate_release_notes: true
           files: siggy-*
 
@@ -105,5 +119,5 @@ jobs:
 
       - uses: ./.github/actions/update-homebrew
         with:
-          tag: ${{ github.ref_name }}
+          tag: ${{ inputs.tag || github.ref_name }}
           tap-token: ${{ secrets.TAP_TOKEN }}


### PR DESCRIPTION
## Why

The release workflow only triggered on tag pushes (`on: push: tags`). In environments where tag pushes aren't available, there was no way to cut a release. This adds a manual `workflow_dispatch` trigger with a `tag` input.

## What

- Add `workflow_dispatch` with a required `tag` input (e.g. `v1.9.1`).
- Resolve the effective tag as `inputs.tag || github.ref_name`, so **existing tag-push releases are completely unchanged**.
- Pass `tag_name` to `softprops/action-gh-release`, which creates the tag at the checkout commit (default-branch HEAD) when it doesn't already exist.

## Immediate use

Needed to cut **v1.9.1** (the `install.sh` native signal-cli fix, #523/#524) — `Cargo.toml` is already at `1.9.1` on `master`. After this merges I'll dispatch the workflow with `tag=v1.9.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VxFxGtGmsyfh8C7Hxw6XNv)_