### PR TITLE
chore: trim published crate to source-only via include allowlist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,18 @@ description = "Terminal-based Signal messenger client with vim keybindings"
 repository = "https://github.com/johnsideserf/siggy"
 keywords = ["signal", "tui", "terminal", "messenger", "ratatui"]
 categories = ["command-line-utilities"]
+# Ship only what's needed to build and install. Without this allowlist the
+# package balloons to ~5.5 MiB (docs/ screenshots, banner/logos, translations,
+# CI config), which both wastes every `cargo install` and stalls the upload at
+# the crates.io CDN edge.
+include = [
+    "src/**/*",
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md",
+    "LICENSE",
+    "rust-toolchain.toml",
+]
 
 [dependencies]
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }


### PR DESCRIPTION
The published crate was ~5.5 MiB compressed because, with no `include`/`exclude`, cargo packaged everything not gitignored: `docs/` (44 files of mdBook screenshots, six over 500 KiB), the root banner/logo/screenshot images, `translations/`, `.github/`, and the install scripts. None of it is needed to build or `cargo install` the binary.

It also explains why publishing v1.9.0 kept failing with a 503 "backend write error": crates.io itself is healthy (status page shows 100% uptime; reads work), but the oversized upload stalls at their CDN edge. Small package, clean upload.

Adds an `include` allowlist shipping only `src/`, the manifests, README, LICENSE, and the toolchain pin. Result: **5.5 MiB -> 307 KiB compressed** (106 files, verified with `cargo package`).

Note: the crates.io README still references images by relative path, which crates.io does not render from package contents. Switching those to absolute raw.githubusercontent URLs is a small follow-up so the crate page shows the banner/screenshot.

After this merges I will publish v1.9.0 from master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)