### PR TITLE
chore: gate dead load_reactions behind cfg(test)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -804,6 +804,11 @@ impl Database {
 
     /// Load all reactions for a conversation.
     /// Returns (target_ts_ms, target_author, emoji, sender) tuples.
+    ///
+    /// Test-only: production paging uses `load_reactions_in_range` (#488), so
+    /// the unbounded variant now exists purely as a convenience for tests that
+    /// assert reaction storage across a whole conversation.
+    #[cfg(test)]
     pub fn load_reactions(&self, conv_id: &str) -> Result<Vec<(i64, String, String, String)>> {
         let mut stmt = self.conn.prepare(
             "SELECT target_ts_ms, target_author, emoji, sender FROM reactions


### PR DESCRIPTION
Since #488 switched reaction paging to `load_reactions_in_range`, the unbounded `load_reactions` lost its production caller. Only test modules reference it now, so it emitted a `dead_code` warning in every non-test build, including the `cargo publish` verify step for v1.9.1.

Marks it `#[cfg(test)]` so it compiles only for the tests that still use it (a few db.rs reaction tests and one app.rs test). No behaviour change; normal build is now warning-free and clippy stays clean. All 809 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)