### PR TITLE
chore: fix crates.io README images; ignore local sprint docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ signal-tui-debug.log
 screenshots/
 .worktrees/
 .context/
+# Local sprint/working docs (kept out of git and the published crate)
+PLAN.md
+REVIEW.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="siggy-banner.png" alt="siggy" width="600">
+  <img src="https://raw.githubusercontent.com/johnsideserf/siggy/master/siggy-banner.png" alt="siggy" width="600">
 </p>
 
 <p align="center">
@@ -44,7 +44,7 @@
 
 A terminal-based Signal messenger client with an IRC aesthetic. Wraps [signal-cli](https://github.com/AsamK/signal-cli) via JSON-RPC for the messaging backend.
 
-![siggy screenshot](screenshot.png)
+![siggy screenshot](https://raw.githubusercontent.com/johnsideserf/siggy/master/screenshot.png)
 
 ## Install
 


### PR DESCRIPTION
Post-release housekeeping, both small:

1. **crates.io README images.** The crate page renders the root README but does not resolve relative image paths from package contents, and #531 (the package trim) removed the image files from the crate anyway. The banner and screenshot now use absolute `raw.githubusercontent.com/.../master/...` URLs, so the crates.io page for 1.9.1+ shows them. Renders identically on the GitHub repo page.
2. **Ignore PLAN.md / REVIEW.md.** These are local sprint/review working docs, never tracked, that tripped `cargo publish`''s clean-tree check on every run. Gitignoring them removes that papercut and keeps them out of any future package. Easily reversible if you ever want them in the repo.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)