### PR TITLE
feat: clearer hints for outdated/failing signal-cli; sync troubleshooting

### DIFF
--- a/docs/src/user-guide/troubleshooting.md
+++ b/docs/src/user-guide/troubleshooting.md
@@ -54,6 +54,30 @@ the install script uses the native signal-cli build which does not require Java.
    signal-cli -a +15551234567 receive
    ```
 
+## Messages from other devices aren't syncing
+
+**Symptom:** messages you send or receive on your phone (or another linked
+device) while siggy is closed do not show up when you reopen siggy, and the
+status bar briefly shows a signal-cli error such as `getServerGuid(...) must
+not be null` or `Method not implemented`.
+
+**Why:** siggy receives messages only while it is running, because it runs
+signal-cli as a child process. Nothing syncs while siggy is closed. On reopen,
+signal-cli drains the messages the server queued for it. If signal-cli is
+outdated or its session has drifted, it can fail to process some of those
+queued messages, and they never reach siggy.
+
+**Fix:**
+
+1. Upgrade signal-cli to the latest version. siggy uses newer signal-cli
+   features, and an older build is also more likely to fail decrypting queued
+   messages. Check your version with `signal-cli --version`.
+2. If it persists, re-link the device by re-running `siggy --setup`. Re-linking
+   resets the session. Note that it does not back-fill history, and messages
+   that were already dropped will not reappear.
+3. Linked devices only receive while connected, so for uninterrupted history
+   keep siggy (or another always-on signal-cli client) running.
+
 ## Images not rendering
 
 **Symptom:** images show as `[attachment: image.jpg]` instead of inline previews.

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -33,6 +33,66 @@ fn path_to_file_uri(path: &str) -> String {
     }
 }
 
+/// Actionable hint for a known class of signal-cli error (#530).
+///
+/// signal-cli surfaces low-level failures as `SignalEvent::Error` with cryptic
+/// text (e.g. `getServerGuid(...) must not be null`) and emits them one per bad
+/// envelope, so a burst of four flashes the raw exception four times and tells
+/// the user nothing. This maps the recognized classes to one clear message;
+/// the raw error always still goes to the debug log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SignalCliHint {
+    /// signal-cli lacks a JSON-RPC method siggy called: the build is outdated.
+    Outdated,
+    /// signal-cli threw while processing an incoming envelope, so the message
+    /// never reached siggy. Typically an outdated build or a drifted session.
+    UnprocessableMessage,
+}
+
+impl SignalCliHint {
+    /// Classify an error string, or `None` to fall back to showing it raw.
+    fn classify(err: &str) -> Option<Self> {
+        if err.contains("Method not implemented") {
+            return Some(Self::Outdated);
+        }
+        const MARKERS: &[&str] = &[
+            "getServerGuid",
+            "must not be null",
+            "InvalidMessage",
+            "ProtocolInvalidMessage",
+            "No valid sessions",
+            "InvalidKey",
+        ];
+        if MARKERS.iter().any(|m| err.contains(m)) {
+            return Some(Self::UnprocessableMessage);
+        }
+        None
+    }
+
+    fn message(self) -> &'static str {
+        match self {
+            Self::Outdated => {
+                "signal-cli looks outdated (missing a feature siggy uses); upgrade it to the latest version"
+            }
+            Self::UnprocessableMessage => {
+                "signal-cli could not process an incoming message, so some messages may not appear; upgrade signal-cli, and re-link with --setup if it persists"
+            }
+        }
+    }
+
+    /// Per-session, per-category "already warned" flag so a burst shows the
+    /// hint once rather than flickering it repeatedly.
+    fn warned_flag(self) -> &'static std::sync::atomic::AtomicBool {
+        use std::sync::atomic::AtomicBool;
+        static OUTDATED: AtomicBool = AtomicBool::new(false);
+        static UNPROCESSABLE: AtomicBool = AtomicBool::new(false);
+        match self {
+            Self::Outdated => &OUTDATED,
+            Self::UnprocessableMessage => &UNPROCESSABLE,
+        }
+    }
+}
+
 /// Dispatch a `SignalEvent` from the signal-cli backend to the appropriate handler.
 pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
     match event {
@@ -218,7 +278,21 @@ pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
         SignalEvent::IdentityList(identities) => handle_identity_list(app, identities),
         SignalEvent::Error(ref err) => {
             crate::debug_log::logf(format_args!("signal event error: {err}"));
-            app.status_message = format!("error: {err}");
+            match SignalCliHint::classify(err) {
+                Some(hint) => {
+                    // Show the actionable hint once per session per category;
+                    // signal-cli emits these in bursts, all kept in the log.
+                    if !hint
+                        .warned_flag()
+                        .swap(true, std::sync::atomic::Ordering::Relaxed)
+                    {
+                        app.status_message = hint.message().to_string();
+                    }
+                }
+                None => {
+                    app.status_message = format!("error: {err}");
+                }
+            }
         }
     }
 }
@@ -1602,5 +1676,48 @@ fn handle_receipt(app: &mut App, sender: &str, receipt_type: &str, timestamps: &
             crate::debug_log::mask_phone(sender)
         ));
         buffer_receipt(app, sender, receipt_type, unmatched, 0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SignalCliHint;
+
+    // #530: the exact errors from the bug report classify into actionable hints.
+    #[test]
+    fn classifies_outdated_signal_cli() {
+        assert_eq!(
+            SignalCliHint::classify("sendTypingIndicator: Method not implemented"),
+            Some(SignalCliHint::Outdated)
+        );
+    }
+
+    #[test]
+    fn classifies_unprocessable_message() {
+        assert_eq!(
+            SignalCliHint::classify("signal-cli: getServerGuid(...) must not be null"),
+            Some(SignalCliHint::UnprocessableMessage)
+        );
+    }
+
+    #[test]
+    fn classifies_decrypt_failures_as_unprocessable() {
+        for err in [
+            "signal-cli: No valid sessions",
+            "signal-cli: ProtocolInvalidMessageException",
+            "signal-cli: InvalidKeyException",
+        ] {
+            assert_eq!(
+                SignalCliHint::classify(err),
+                Some(SignalCliHint::UnprocessableMessage),
+                "expected UnprocessableMessage for {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn generic_errors_fall_through_to_raw() {
+        assert_eq!(SignalCliHint::classify("connection lost"), None);
+        assert_eq!(SignalCliHint::classify("some other thing"), None);
     }
 }


### PR DESCRIPTION
Addresses the diagnosis from #530 (chat history not syncing).

**Root cause (not a siggy logic bug):** when signal-cli cannot process an incoming envelope it raises an exception, which siggy surfaces as `SignalEvent::Error` (`envelope.rs`). The message is dropped at the signal-cli layer before siggy ever sees it. The reporter''s log shows `getServerGuid(...) must not be null` (a libsignal processing failure, common with an outdated build or drifted session) and `sendTypingIndicator: Method not implemented` (their signal-cli predates a method siggy calls, i.e. it is outdated). siggy was flashing the raw text once per bad envelope and telling the user nothing useful.

**This PR (the siggy-side improvements):**

- Classifies two recognizable error families and shows one clear, actionable status hint, deduped to once per session (the raw text still goes to the debug log):
  - outdated signal-cli (`Method not implemented`) -> upgrade signal-cli
  - unprocessable incoming message (`getServerGuid`, `must not be null`, `No valid sessions`, `InvalidMessage`/`InvalidKey`, ...) -> some messages may not appear; upgrade signal-cli and re-link if it persists
- Adds a Troubleshooting entry ("Messages from other devices aren''t syncing") explaining the while-running limitation and the upgrade/re-link fix.

Burst dedupe uses per-session statics (no new `App` field, ratchet stays 66). Classifier is unit-tested against the exact strings from the report. Clippy clean, 813 tests pass.

Does not attempt to fix signal-cli itself; the actual recovery for the reporter is upgrading signal-cli (and re-linking if needed), which the new hint and docs now point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)