### PR TITLE
ci: auto-merge low-risk dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+# Auto-merge low-risk dependabot bumps once required CI passes. "Low-risk" is
+# semver patch and minor (Cargo deps and GitHub Actions alike); major bumps are
+# left open for manual review. master's ruleset requires the CI status checks
+# but no approvals, so enabling auto-merge is enough -- the merge only happens
+# after those checks go green.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch and minor updates
+        if: >-
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up automatic merging of low-risk dependabot PRs, so routine bumps stop needing hands-on triage.

**Behaviour:**
- On any dependabot PR, reads the update metadata and, for **semver patch or minor** updates (Cargo deps and GitHub Actions alike), enables GitHub auto-merge (squash). The PR then merges itself once the required CI checks pass.
- **Major** bumps are deliberately left open for manual review (this is where breaking changes live).

**Why this shape:**
- master''s ruleset requires the CI status checks but **no approvals**, so enabling auto-merge is all that''s needed; the merge waits for green CI.
- Uses the `pull_request` event with an explicit `permissions` block (GitHub''s documented dependabot pattern), not `pull_request_target`, so no PR code ever runs with write-scoped secrets.
- "Allow auto-merge" has been turned on in repo settings to support this.

If you ever add a required-approvals rule, this will need an approve step added (a one-liner) since auto-merge alone won''t satisfy it. For now, status-checks-only means it just works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)