### PR TITLE
refactor: type receipts as ReceiptKind enum

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -6394,8 +6394,8 @@ mod tests {
     use super::*;
     use crate::db::Database;
     use crate::signal::types::{
-        Attachment, Contact, Group, IdentityInfo, Mention, PollData, PollOption, SignalEvent,
-        SignalMessage, StyleType, TextStyle, TrustLevel,
+        Attachment, Contact, Group, IdentityInfo, Mention, PollData, PollOption, ReceiptKind,
+        SignalEvent, SignalMessage, StyleType, TextStyle, TrustLevel,
     };
     use crossterm::event::{KeyCode, KeyModifiers};
     use rstest::{fixture, rstest};
@@ -7560,7 +7560,7 @@ mod tests {
         // Delivery receipt
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: conv_id.to_string(),
-            receipt_type: "DELIVERY".to_string(),
+            receipt_type: ReceiptKind::Delivery,
             timestamps: vec![ts_ms],
         });
         assert_eq!(
@@ -7571,7 +7571,7 @@ mod tests {
         // Read receipt — should upgrade
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: conv_id.to_string(),
-            receipt_type: "READ".to_string(),
+            receipt_type: ReceiptKind::Read,
             timestamps: vec![ts_ms],
         });
         assert_eq!(
@@ -7619,7 +7619,7 @@ mod tests {
         // Delivery receipt after Read — should NOT downgrade
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: conv_id.to_string(),
-            receipt_type: "DELIVERY".to_string(),
+            receipt_type: ReceiptKind::Delivery,
             timestamps: vec![ts_ms],
         });
         assert_eq!(
@@ -7972,7 +7972,7 @@ mod tests {
         // Receipt arrives BEFORE SendTimestamp (references server_ts which we don't know yet)
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: conv_id.to_string(),
-            receipt_type: "DELIVERY".to_string(),
+            receipt_type: ReceiptKind::Delivery,
             timestamps: vec![server_ts],
         });
 
@@ -8014,7 +8014,7 @@ mod tests {
         // flag dropped the unmatched sibling outright.
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: conv_id.to_string(),
-            receipt_type: "DELIVERY".to_string(),
+            receipt_type: ReceiptKind::Delivery,
             timestamps: vec![1000, 2000],
         });
 
@@ -8049,7 +8049,7 @@ mod tests {
 
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: conv_id.to_string(),
-            receipt_type: "READ".to_string(),
+            receipt_type: ReceiptKind::Read,
             timestamps: vec![ts],
         });
         assert_eq!(app.pending.receipts.len(), 1);
@@ -11560,7 +11560,7 @@ mod tests {
 
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: "+1".to_string(),
-            receipt_type: "VIEWED".to_string(),
+            receipt_type: ReceiptKind::Viewed,
             timestamps: vec![ts],
         });
 
@@ -11582,7 +11582,7 @@ mod tests {
 
         app.handle_signal_event(SignalEvent::ReceiptReceived {
             sender: "+2".to_string(),
-            receipt_type: "READ".to_string(),
+            receipt_type: ReceiptKind::Read,
             timestamps: vec![ts],
         });
 

--- a/src/domain/pending.rs
+++ b/src/domain/pending.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use crate::app::SendRequest;
+use crate::signal::types::ReceiptKind;
 
 /// A receipt that arrived before the message it targets was matchable
 /// (typically before the `SendTimestamp` that rewrites the local timestamp
@@ -18,7 +19,7 @@ use crate::app::SendRequest;
 /// forever (#484).
 pub struct BufferedReceipt {
     pub sender: String,
-    pub receipt_type: String,
+    pub receipt_type: ReceiptKind,
     /// Only the timestamps that have not matched yet.
     pub timestamps: Vec<i64>,
     pub attempts: u8,

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -20,7 +20,7 @@ use crate::db::Database;
 use crate::image_render;
 use crate::signal::types::{
     Contact, Group, IdentityInfo, LinkPreview, Mention, MessageStatus, PollData, PollVote,
-    Reaction, SignalEvent, SignalMessage, StyleType,
+    Reaction, ReceiptKind, SignalEvent, SignalMessage, StyleType,
 };
 
 /// Convert a local file path to a file:/// URI (forward slashes, for terminal Ctrl+Click).
@@ -102,7 +102,7 @@ pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
             receipt_type,
             timestamps,
         } => {
-            handle_receipt(app, &sender, &receipt_type, &timestamps);
+            handle_receipt(app, &sender, receipt_type, &timestamps);
         }
         SignalEvent::SendTimestamp { rpc_id, server_ts } => {
             handle_send_timestamp(app, &rpc_id, server_ts);
@@ -1485,9 +1485,7 @@ fn handle_send_timestamp(app: &mut App, rpc_id: &str, server_ts: i64) {
         if !app.pending.receipts.is_empty() {
             let buffered = std::mem::take(&mut app.pending.receipts);
             for b in buffered {
-                let Some(status) = receipt_status(&b.receipt_type) else {
-                    continue;
-                };
+                let status = b.receipt_type.status();
                 let unmatched = apply_receipt(app, &b.sender, status, &b.timestamps);
                 if unmatched.is_empty() {
                     continue;
@@ -1495,7 +1493,7 @@ fn handle_send_timestamp(app: &mut App, rpc_id: &str, server_ts: i64) {
                 if b.attempts + 1 >= MAX_RECEIPT_REPLAYS {
                     resolve_receipt_against_db(app, status, &unmatched);
                 } else {
-                    buffer_receipt(app, &b.sender, &b.receipt_type, unmatched, b.attempts + 1);
+                    buffer_receipt(app, &b.sender, b.receipt_type, unmatched, b.attempts + 1);
                 }
             }
         }
@@ -1576,15 +1574,6 @@ const MAX_RECEIPT_REPLAYS: u8 = 8;
 /// evicted when full.
 const MAX_BUFFERED_RECEIPTS: usize = 64;
 
-fn receipt_status(receipt_type: &str) -> Option<MessageStatus> {
-    match receipt_type.to_uppercase().as_str() {
-        "DELIVERY" => Some(MessageStatus::Delivered),
-        "READ" => Some(MessageStatus::Read),
-        "VIEWED" => Some(MessageStatus::Viewed),
-        _ => None,
-    }
-}
-
 /// Apply a receipt to in-memory messages, per timestamp: try the 1:1
 /// conversation keyed by the receipt sender first, then scan all
 /// conversations (group receipts come from a member but the conv is keyed
@@ -1635,34 +1624,31 @@ fn resolve_receipt_against_db(app: &App, new_status: MessageStatus, timestamps: 
 fn buffer_receipt(
     app: &mut App,
     sender: &str,
-    receipt_type: &str,
+    receipt_type: ReceiptKind,
     timestamps: Vec<i64>,
     attempts: u8,
 ) {
     if app.pending.receipts.len() >= MAX_BUFFERED_RECEIPTS {
         let evicted = app.pending.receipts.remove(0);
-        if let Some(status) = receipt_status(&evicted.receipt_type) {
-            resolve_receipt_against_db(app, status, &evicted.timestamps);
-        }
+        resolve_receipt_against_db(app, evicted.receipt_type.status(), &evicted.timestamps);
     }
     app.pending.receipts.push(crate::domain::BufferedReceipt {
         sender: sender.to_string(),
-        receipt_type: receipt_type.to_string(),
+        receipt_type,
         timestamps,
         attempts,
     });
 }
 
-fn handle_receipt(app: &mut App, sender: &str, receipt_type: &str, timestamps: &[i64]) {
-    let Some(new_status) = receipt_status(receipt_type) else {
-        return;
-    };
+fn handle_receipt(app: &mut App, sender: &str, receipt_type: ReceiptKind, timestamps: &[i64]) {
+    let new_status = receipt_type.status();
 
     let unmatched = apply_receipt(app, sender, new_status, timestamps);
 
     if unmatched.is_empty() {
         crate::debug_log::logf(format_args!(
-            "receipt: {receipt_type} from {} -> {new_status:?}",
+            "receipt: {} from {} -> {new_status:?}",
+            receipt_type.as_str(),
             crate::debug_log::mask_phone(sender)
         ));
     } else {
@@ -1671,8 +1657,9 @@ fn handle_receipt(app: &mut App, sender: &str, receipt_type: &str, timestamps: &
         // old per-event flag dropped unmatched timestamps whenever any
         // sibling timestamp in the same event matched, #484.)
         crate::debug_log::logf(format_args!(
-            "receipt: buffering {} unmatched {receipt_type} ts from {}",
+            "receipt: buffering {} unmatched {} ts from {}",
             unmatched.len(),
+            receipt_type.as_str(),
             crate::debug_log::mask_phone(sender)
         ));
         buffer_receipt(app, sender, receipt_type, unmatched, 0);

--- a/src/signal/parse/envelope.rs
+++ b/src/signal/parse/envelope.rs
@@ -201,33 +201,19 @@ fn parse_typing_indicator(envelope: &serde_json::Value) -> Option<SignalEvent> {
 fn parse_receipt_message(envelope: &serde_json::Value) -> Option<SignalEvent> {
     let receipt = envelope.get("receiptMessage")?;
     let sender = envelope_source(envelope);
-    // signal-cli uses boolean fields: isDelivery, isRead, isViewed
-    let receipt_type = if receipt
-        .get("isRead")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        "READ"
-    } else if receipt
-        .get("isViewed")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        "VIEWED"
-    } else if receipt
-        .get("isDelivery")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        "DELIVERY"
+    // signal-cli uses boolean fields: isDelivery, isRead, isViewed.
+    let bool_field = |k: &str| receipt.get(k).and_then(|v| v.as_bool()).unwrap_or(false);
+    let receipt_type = if bool_field("isRead") {
+        ReceiptKind::Read
+    } else if bool_field("isViewed") {
+        ReceiptKind::Viewed
+    } else if bool_field("isDelivery") {
+        ReceiptKind::Delivery
     } else {
-        // Fallback: try "type" string field (older signal-cli versions)
-        receipt
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or("UNKNOWN")
-    }
-    .to_string();
+        // Fallback: the "type" string field on older signal-cli. An
+        // unrecognized value yields no event rather than a dropped UNKNOWN.
+        ReceiptKind::from_wire(receipt.get("type").and_then(|v| v.as_str())?)?
+    };
     let timestamps: Vec<i64> = receipt
         .get("timestamps")
         .and_then(|v| v.as_array())

--- a/src/signal/parse/mod.rs
+++ b/src/signal/parse/mod.rs
@@ -223,13 +223,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case(true, false, false, "DELIVERY", 2)]
-    #[case(false, true, false, "READ", 1)]
+    #[case(true, false, false, ReceiptKind::Delivery, 2)]
+    #[case(false, true, false, ReceiptKind::Read, 1)]
+    #[case(false, false, true, ReceiptKind::Viewed, 1)]
     fn parse_receipt_event(
         #[case] is_delivery: bool,
         #[case] is_read: bool,
         #[case] is_viewed: bool,
-        #[case] expected_type: &str,
+        #[case] expected_type: ReceiptKind,
         #[case] expected_count: usize,
     ) {
         let mut timestamps = vec![json!(1700000000001_i64)];

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -46,6 +46,49 @@ impl MessageStatus {
     }
 }
 
+/// Kind of delivery receipt from signal-cli. Replaces a stringly-typed
+/// `receipt_type` whose conversion to [`MessageStatus`] had a silent
+/// `_ => return` for any unrecognized value (#500): a casing or spelling drift
+/// between the parser and the handler dropped receipts silently. The mapping to
+/// `MessageStatus` is now total.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReceiptKind {
+    Delivery,
+    Read,
+    Viewed,
+}
+
+impl ReceiptKind {
+    /// The outgoing-message status this receipt upgrades to.
+    pub fn status(self) -> MessageStatus {
+        match self {
+            Self::Delivery => MessageStatus::Delivered,
+            Self::Read => MessageStatus::Read,
+            Self::Viewed => MessageStatus::Viewed,
+        }
+    }
+
+    /// Wire label, for logging and the older signal-cli `type` string field.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Delivery => "DELIVERY",
+            Self::Read => "READ",
+            Self::Viewed => "VIEWED",
+        }
+    }
+
+    /// Parse the older signal-cli `type` string (case-insensitive), or `None`
+    /// for an unrecognized value.
+    pub fn from_wire(s: &str) -> Option<Self> {
+        match s.to_ascii_uppercase().as_str() {
+            "DELIVERY" => Some(Self::Delivery),
+            "READ" => Some(Self::Read),
+            "VIEWED" => Some(Self::Viewed),
+            _ => None,
+        }
+    }
+}
+
 /// Trust level for a contact's identity key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TrustLevel {
@@ -119,7 +162,7 @@ pub enum SignalEvent {
     MessageReceived(SignalMessage),
     ReceiptReceived {
         sender: String,
-        receipt_type: String,
+        receipt_type: ReceiptKind,
         timestamps: Vec<i64>,
     },
     SendTimestamp {
@@ -233,7 +276,8 @@ impl SignalEvent {
                 receipt_type,
                 timestamps,
             } => format!(
-                "ReceiptReceived({receipt_type} from={}, count={})",
+                "ReceiptReceived({} from={}, count={})",
+                receipt_type.as_str(),
                 mask_phone(sender),
                 timestamps.len(),
             ),


### PR DESCRIPTION
Closes #500 (the `GroupMenuHint` half landed in #540).

`receipt_type` flowed as a `String` from the parser, through `SignalEvent::ReceiptReceived` and the `BufferedReceipt` replay buffer, and was converted to `MessageStatus` only at the handler via `to_uppercase()` with a silent `_ => return`. A casing or spelling drift between the parser and the handler dropped receipts silently, with no status upgrade and no log -- the same stringly-typed bug class `ActionMenuHint`/`GroupMenuHint` were introduced to remove.

Introduces `ReceiptKind { Delivery, Read, Viewed }` at the parse boundary:
- Total `status()` mapping to `MessageStatus` (no more `Option`/silent-drop in the handler).
- The parser emits no receipt event for an unrecognized type, rather than a dropped `"UNKNOWN"`; the older signal-cli `type` string fallback is preserved via `from_wire` (case-insensitive).
- `SignalEvent` and `BufferedReceipt` carry the enum; `receipt_status` is deleted.

The parse test gains a `Viewed` case. Behavior is unchanged for valid receipts; clippy clean, 826 tests pass, ratchet 66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)