### PR TITLE
test(fuzz): fuzz the real cursor helpers; add fuzz_theme_toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [fuzz_command_parse, fuzz_input_edit, fuzz_json_rpc, fuzz_key_combo]
+        target: [fuzz_command_parse, fuzz_input_edit, fuzz_json_rpc, fuzz_key_combo, fuzz_theme_toml]
     env:
       # cargo-fuzz needs nightly. RUSTUP_TOOLCHAIN overrides
       # rust-toolchain.toml's stable pin for this job only.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 serde_json = "1"
+toml = "1"
 crossterm = "0.28"
 
 [dependencies.siggy]
@@ -39,6 +40,13 @@ bench = false
 [[bin]]
 name = "fuzz_command_parse"
 path = "fuzz_targets/fuzz_command_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_theme_toml"
+path = "fuzz_targets/fuzz_theme_toml.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_input_edit.rs
+++ b/fuzz/fuzz_targets/fuzz_input_edit.rs
@@ -1,20 +1,8 @@
 #![no_main]
 use libfuzzer_sys::fuzz_target;
-
-/// Replicate the cursor helpers from app.rs to fuzz the same logic.
-fn next_char_pos(buf: &str, pos: usize) -> usize {
-    if pos >= buf.len() {
-        return buf.len();
-    }
-    pos + buf[pos..].chars().next().map_or(1, |c| c.len_utf8())
-}
-
-fn prev_char_pos(buf: &str, pos: usize) -> usize {
-    if pos == 0 {
-        return 0;
-    }
-    pos - buf[..pos].chars().next_back().map_or(1, |c| c.len_utf8())
-}
+// Fuzz the real cursor helpers, not a copy: a divergence in siggy's
+// implementation must show up here (#501).
+use siggy::input::{next_char_pos, prev_char_pos};
 
 fuzz_target!(|data: &[u8]| {
     // Need at least 1 byte for the operation selector

--- a/fuzz/fuzz_targets/fuzz_theme_toml.rs
+++ b/fuzz/fuzz_targets/fuzz_theme_toml.rs
@@ -1,0 +1,11 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+// Custom theme files are user-edited TOML parsed at startup. A malformed value
+// must produce an error, never a panic (e.g. the multibyte-hex slice panic
+// fixed in #487). This fuzzes the real Theme deserializer (#501).
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = toml::from_str::<siggy::theme::Theme>(s);
+    }
+});

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ use crate::domain::{
 use crate::image_render;
 use crate::image_render::ImageProtocol;
 use crate::input::COMMANDS;
+use crate::input::{next_char_pos, prev_char_pos};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
 use crate::list_overlay::{self, ListKeyAction, classify_list_key};
 use crate::mute::MuteState;
@@ -43,22 +44,6 @@ pub const PASTE_CLEANUP_SENTINEL_SECS: u64 = 3600;
 
 /// How long after send confirmation to wait before deleting a paste temp file.
 pub(crate) const PASTE_CLEANUP_DELAY_SECS: u64 = 10;
-
-/// Find the byte position one character forward from `pos` in `buf`.
-fn next_char_pos(buf: &str, pos: usize) -> usize {
-    if pos >= buf.len() {
-        return buf.len();
-    }
-    pos + buf[pos..].chars().next().map_or(1, |c| c.len_utf8())
-}
-
-/// Find the byte position one character backward from `pos` in `buf`.
-fn prev_char_pos(buf: &str, pos: usize) -> usize {
-    if pos == 0 {
-        return 0;
-    }
-    pos - buf[..pos].chars().next_back().map_or(1, |c| c.len_utf8())
-}
 
 /// Snap a byte position to the nearest valid char boundary at or before `pos`.
 fn floor_char_boundary(buf: &str, pos: usize) -> usize {

--- a/src/input.rs
+++ b/src/input.rs
@@ -3,7 +3,25 @@
 //! Translates the user's typed input buffer into an [`InputAction`] enum
 //! consumed by the event loop. Slash commands (`/join`, `/part`, `/quit`,
 //! `/sidebar`, `/help`, ...) live in [`COMMANDS`] alongside their
-//! autocomplete metadata.
+//! autocomplete metadata. Also home to the composer's UTF-8 cursor-movement
+//! helpers, exported via `lib.rs` so the `fuzz_input_edit` harness drives the
+//! real code instead of a hand-copied duplicate.
+
+/// Find the byte position one character forward from `pos` in `buf`.
+pub fn next_char_pos(buf: &str, pos: usize) -> usize {
+    if pos >= buf.len() {
+        return buf.len();
+    }
+    pos + buf[pos..].chars().next().map_or(1, |c| c.len_utf8())
+}
+
+/// Find the byte position one character backward from `pos` in `buf`.
+pub fn prev_char_pos(buf: &str, pos: usize) -> usize {
+    if pos == 0 {
+        return 0;
+    }
+    pos - buf[..pos].chars().next_back().map_or(1, |c| c.len_utf8())
+}
 
 /// Metadata for a slash command (used for autocomplete + help)
 pub struct CommandInfo {
@@ -501,6 +519,28 @@ pub fn replace_shortcodes(input: &str) -> String {
 mod tests {
     use super::*;
     use rstest::rstest;
+
+    // --- Cursor helpers (fuzzed by fuzz_input_edit; #501) ---
+
+    #[test]
+    fn next_char_pos_steps_over_multibyte() {
+        // "a" + 4-byte emoji + "b"
+        let s = "a\u{1F600}b";
+        assert_eq!(next_char_pos(s, 0), 1); // past 'a'
+        assert_eq!(next_char_pos(s, 1), 5); // past the 4-byte emoji
+        assert_eq!(next_char_pos(s, 5), 6); // past 'b'
+        assert_eq!(next_char_pos(s, 6), 6); // clamps at end
+        assert_eq!(next_char_pos("", 0), 0);
+    }
+
+    #[test]
+    fn prev_char_pos_steps_over_multibyte() {
+        let s = "a\u{1F600}b";
+        assert_eq!(prev_char_pos(s, 6), 5); // before 'b'
+        assert_eq!(prev_char_pos(s, 5), 1); // before the emoji
+        assert_eq!(prev_char_pos(s, 1), 0); // before 'a'
+        assert_eq!(prev_char_pos(s, 0), 0); // clamps at start
+    }
 
     // --- No-arg commands: 19 cases → 1 parameterized test ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! The main binary has its own module tree; this surface re-exports only
 //! what fuzz harnesses need ([`config`], [`input`], [`keybindings`],
-//! [`signal`]).
+//! [`signal`], [`theme`]).
 
 pub mod config;
 #[allow(dead_code)]
@@ -11,3 +11,4 @@ pub mod fs_migrate;
 pub mod input;
 pub mod keybindings;
 pub mod signal;
+pub mod theme;


### PR DESCRIPTION
Closes #501.

**fuzz_input_edit fuzzed dead code.** It carried a hand-copied duplicate of `app.rs`''s `next_char_pos` / `prev_char_pos`, so the harness''s guarantee silently expired the moment the real code diverged (likely during the #352 InputState extraction) -- and UTF-8 cursor handling is exactly where this project has had real bugs. Moves the two helpers into the lib-exported `input` module, points both `app.rs` (10 call sites) and the fuzz target at them, and deletes the copy. Adds unit tests for the multibyte step-over cases.

**Added fuzz_theme_toml.** Custom theme files are user-edited TOML parsed at startup, and a malformed value must produce an error, not a panic -- exactly the multibyte-hex slice panic fixed in #487. Exposes `pub mod theme` from `lib.rs` (the only reason this target could not exist before), so the harness fuzzes the real `Theme` deserializer. Registered in `fuzz/Cargo.toml` (with a `toml` dep) and added to the CI fuzz matrix.

Main crate: clippy clean, 849 tests pass. The fuzz builds/runs are validated by the CI fuzz jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)