### PR TITLE
refactor: dedup the type-to-filter contact/member pickers

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1692,23 +1692,15 @@ impl App {
 
     /// Build the filtered contacts list from contact_names using the current filter.
     pub fn refresh_contacts_filter(&mut self) {
-        let filter_lower = self.contacts_overlay.filter.to_lowercase();
-        let mut contacts: Vec<(String, String)> = self
+        let pairs: Vec<(String, String)> = self
             .store
             .contact_names
             .iter()
             .filter(|(_, name)| !name.is_empty())
-            .filter(|(number, name)| {
-                if filter_lower.is_empty() {
-                    return true;
-                }
-                name.to_lowercase().contains(&filter_lower)
-                    || number.to_lowercase().contains(&filter_lower)
-            })
             .map(|(number, name)| (number.clone(), name.clone()))
             .collect();
-        contacts.sort_by_key(|a| a.1.to_lowercase());
-        self.contacts_overlay.filtered = contacts;
+        self.contacts_overlay.filtered =
+            list_overlay::filter_name_number_pairs(pairs, &self.contacts_overlay.filter);
         list_overlay::clamp_index(
             &mut self.contacts_overlay.index,
             self.contacts_overlay.filtered.len(),
@@ -1761,47 +1753,34 @@ impl App {
 
     /// Build filtered contacts list for the "Add member" picker (excludes existing group members).
     pub fn refresh_group_add_filter(&mut self) {
-        let filter_lower = self.group_menu.filter.to_lowercase();
         let existing_members: HashSet<&str> = self
             .active_conversation
             .as_ref()
             .and_then(|id| self.store.groups.get(id))
             .map(|g| g.members.iter().map(|s| s.as_str()).collect())
             .unwrap_or_default();
-        let mut contacts: Vec<(String, String)> = self
+        let pairs: Vec<(String, String)> = self
             .store
             .contact_names
             .iter()
             .filter(|(_, name)| !name.is_empty())
             .filter(|(number, _)| !existing_members.contains(number.as_str()))
-            .filter(|(number, name)| {
-                if filter_lower.is_empty() {
-                    return true;
-                }
-                name.to_lowercase().contains(&filter_lower)
-                    || number.to_lowercase().contains(&filter_lower)
-            })
             .map(|(number, name)| (number.clone(), name.clone()))
             .collect();
-        contacts.sort_by_key(|a| a.1.to_lowercase());
-        self.group_menu.filtered = contacts;
-        if self.group_menu.filtered.is_empty() {
-            self.group_menu.index = 0;
-        } else if self.group_menu.index >= self.group_menu.filtered.len() {
-            self.group_menu.index = self.group_menu.filtered.len() - 1;
-        }
+        self.group_menu.filtered =
+            list_overlay::filter_name_number_pairs(pairs, &self.group_menu.filter);
+        list_overlay::clamp_index(&mut self.group_menu.index, self.group_menu.filtered.len());
     }
 
     /// Build filtered member list for the "Remove member" picker (excludes self).
     pub fn refresh_group_remove_filter(&mut self) {
-        let filter_lower = self.group_menu.filter.to_lowercase();
         let members: Vec<String> = self
             .active_conversation
             .as_ref()
             .and_then(|id| self.store.groups.get(id))
             .map(|g| g.members.clone())
             .unwrap_or_default();
-        let mut result: Vec<(String, String)> = members
+        let pairs: Vec<(String, String)> = members
             .into_iter()
             .filter(|phone| *phone != self.account)
             .map(|phone| {
@@ -1813,21 +1792,10 @@ impl App {
                     .unwrap_or_else(|| phone.clone());
                 (phone, name)
             })
-            .filter(|(phone, name)| {
-                if filter_lower.is_empty() {
-                    return true;
-                }
-                name.to_lowercase().contains(&filter_lower)
-                    || phone.to_lowercase().contains(&filter_lower)
-            })
             .collect();
-        result.sort_by_key(|a| a.1.to_lowercase());
-        self.group_menu.filtered = result;
-        if self.group_menu.filtered.is_empty() {
-            self.group_menu.index = 0;
-        } else if self.group_menu.index >= self.group_menu.filtered.len() {
-            self.group_menu.index = self.group_menu.filtered.len() - 1;
-        }
+        self.group_menu.filtered =
+            list_overlay::filter_name_number_pairs(pairs, &self.group_menu.filter);
+        list_overlay::clamp_index(&mut self.group_menu.index, self.group_menu.filtered.len());
     }
 
     /// Handle a key press while the group management menu is open.

--- a/src/list_overlay.rs
+++ b/src/list_overlay.rs
@@ -92,6 +92,28 @@ pub fn append_footer(
     )));
 }
 
+/// Filter `(id, name)` pairs by a case-insensitive substring match on either
+/// field (an empty filter matches all), sorted by name. This is the shared
+/// body of the contacts / add-member / remove-member type-to-filter pickers
+/// (#499); callers pre-build the source pairs with their own exclusions
+/// (non-empty name, existing members, self) and pass them in.
+pub fn filter_name_number_pairs(
+    pairs: impl IntoIterator<Item = (String, String)>,
+    filter: &str,
+) -> Vec<(String, String)> {
+    let filter = filter.to_lowercase();
+    let mut out: Vec<(String, String)> = pairs
+        .into_iter()
+        .filter(|(number, name)| {
+            filter.is_empty()
+                || name.to_lowercase().contains(&filter)
+                || number.to_lowercase().contains(&filter)
+        })
+        .collect();
+    out.sort_by_key(|(_, name)| name.to_lowercase());
+    out
+}
+
 /// Clamp a selection index to stay within list bounds.
 pub fn clamp_index(index: &mut usize, list_len: usize) {
     if list_len == 0 {
@@ -188,6 +210,31 @@ mod tests {
         let (visible, offset) = scroll_layout(10, 2, 10);
         assert_eq!(visible, 8);
         assert_eq!(offset, 3); // 10 - 8 + 1
+    }
+
+    #[test]
+    fn filter_name_number_pairs_matches_name_or_number_and_sorts() {
+        let pairs = vec![
+            ("+199".to_string(), "Zoe".to_string()),
+            ("+1234".to_string(), "Alice".to_string()),
+            ("+1999".to_string(), "Bob".to_string()),
+        ];
+        // Empty filter: all, sorted by name.
+        let all = filter_name_number_pairs(pairs.clone(), "");
+        assert_eq!(
+            all.iter().map(|(_, n)| n.as_str()).collect::<Vec<_>>(),
+            ["Alice", "Bob", "Zoe"]
+        );
+        // Name match (case-insensitive).
+        let by_name = filter_name_number_pairs(pairs.clone(), "ALI");
+        assert_eq!(by_name.len(), 1);
+        assert_eq!(by_name[0].1, "Alice");
+        // Number match: "+199" appears in Zoe (+199) and Bob (+1999).
+        let by_num = filter_name_number_pairs(pairs, "+199");
+        assert_eq!(
+            by_num.iter().map(|(_, n)| n.as_str()).collect::<Vec<_>>(),
+            ["Bob", "Zoe"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Part of #499.

`refresh_contacts_filter`, `refresh_group_add_filter`, and `refresh_group_remove_filter` each open-coded the same logic: case-insensitive substring match on name-or-number (empty filter matches all), then sort by name. Extracts that into `list_overlay::filter_name_number_pairs`; each caller now builds only its source pairs (with its own exclusions: non-empty name, existing members, self) and delegates the filter+sort.

The two group pickers also replace their hand-rolled empty/overflow index clamp with the shared `list_overlay::clamp_index`, closing the inconsistent-empty-list-guard bug class that #461 fixed elsewhere.

`update_forward_filter` is deliberately left alone: it matches on name only, preserves `conversation_order`, and does not sort, so folding it into the shared helper would change its behavior. The remaining hand-rolled j/k nav in a few overlay key handlers (the other half of #499) is a follow-up, so #499 stays open.

Behavior-preserving; new unit test for the helper, clippy clean, 854 tests pass, ratchet 66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)