### PR TITLE
fix(security): strip control chars from exports, debug log, notifications

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -214,6 +214,11 @@ pub(crate) fn show_desktop_notification(
         NotificationPreview::Sender => (sender_title(), "New message".to_string()),
         NotificationPreview::Full => (sender_title(), body.chars().take(100).collect()),
     };
+    // Sender/group names and message bodies are remote-controlled; strip
+    // control chars before handing them to the OS notification daemon, some of
+    // which interpret embedded escapes or markup (#504).
+    let title = crate::debug_log::strip_control_chars(&title, false);
+    let preview = crate::debug_log::strip_control_chars(&preview, false);
 
     tokio::task::spawn_blocking(move || {
         let _ = notify_rust::Notification::new()
@@ -5690,6 +5695,12 @@ impl App {
                 }
             }
         }
+
+        // Strip control characters from the assembled export (message bodies
+        // and names are remote-controlled) so the saved file cannot inject
+        // terminal escapes when viewed with cat/less (#504). Structural
+        // newlines and tabs are preserved.
+        let output = crate::debug_log::strip_control_chars(&output, true);
 
         // Write to download dir or home
         let dir = dirs::download_dir()

--- a/src/debug_log.rs
+++ b/src/debug_log.rs
@@ -95,9 +95,24 @@ pub fn mask_phone(phone: &str) -> String {
 /// Summarize a message body for redacted logging: "hello world" → "[msg: 11 chars]"
 pub fn mask_body(body: &str) -> String {
     if !redact() {
-        return body.to_string();
+        // --debug-full writes the raw body to a file a user may later cat;
+        // strip control chars so it cannot inject terminal escapes (#504).
+        return strip_control_chars(body, false);
     }
     format!("[msg: {} chars]", body.len())
+}
+
+/// Remove terminal control characters from attacker-controlled text before it
+/// is written somewhere that may later be viewed in a terminal (chat exports,
+/// the debug log, desktop notifications). Without this, a crafted message body
+/// or contact name can carry escape sequences that execute when the file is
+/// cat'd or the notification rendered (#504). `keep_newlines` preserves `\n`
+/// and `\t` for multi-line file output; everything else in the control range
+/// (including ESC and DEL) is dropped.
+pub fn strip_control_chars(s: &str, keep_newlines: bool) -> String {
+    s.chars()
+        .filter(|&c| (keep_newlines && (c == '\n' || c == '\t')) || !c.is_control())
+        .collect()
 }
 
 pub fn log(msg: &str) {
@@ -136,5 +151,34 @@ pub fn warnf(args: std::fmt::Arguments<'_>) {
     {
         let now = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.3f");
         let _ = writeln!(f, "[{now}] {msg}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_control_chars;
+
+    #[test]
+    fn strips_escape_and_control_chars() {
+        // ESC-based OSC 52 clipboard-injection attempt plus a bare CR.
+        let evil = "hi\u{1b}]52;c;ZWxz\u{7}\rthere\u{1b}[2J";
+        let cleaned = strip_control_chars(evil, false);
+        assert_eq!(cleaned, "hi]52;c;ZWxzthere[2J");
+        assert!(!cleaned.contains('\u{1b}'));
+        assert!(!cleaned.contains('\r'));
+    }
+
+    #[test]
+    fn keep_newlines_preserves_structure() {
+        let s = "line1\nline2\tcol\u{1b}x";
+        assert_eq!(strip_control_chars(s, true), "line1\nline2\tcolx");
+        // Without keep_newlines, the newline and tab go too.
+        assert_eq!(strip_control_chars(s, false), "line1line2colx");
+    }
+
+    #[test]
+    fn leaves_plain_and_unicode_text_untouched() {
+        let s = "Hello, world! caf\u{e9} \u{1f600}";
+        assert_eq!(strip_control_chars(s, false), s);
     }
 }


### PR DESCRIPTION
Part of #504 (SEC-3 and SEC-4).

Message bodies and contact/group names are remote-controlled and retain their control characters in memory and SQLite (ratatui only filters them at render time). Three sinks wrote them verbatim:

- **Chat export** (`/export`) and the **`--debug-full` log** are plain files a user may later `cat`/`less -R`, at which point embedded escapes execute (cursor manipulation, OSC 52 clipboard writes, title spoofing).
- **Desktop notifications** pass the title/body to the OS daemon, some of which interpret escapes or markup.

Adds `debug_log::strip_control_chars(s, keep_newlines)` and applies it to the assembled export (preserving structural `\n`/`\t`), the unredacted `mask_body` log path, and the notification title + preview. Unit tests cover ESC/OSC/CR stripping, newline preservation, and plain/unicode passthrough.

Notes: SEC-2 (session lock is a screen lock, not at-rest encryption; DB is plaintext) is already documented in `docs/src/user-guide/security.md`, so no change there. SEC-5 (Windows DACLs on the lock hash / DB / debug log, currently Unix-only `0600`/`0700`) is the remaining piece of #504.

Clippy clean, 850 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)