### PR TITLE
perf: cap composer input history

### DIFF
--- a/src/domain/input.rs
+++ b/src/domain/input.rs
@@ -4,6 +4,10 @@
 //! `buffer`, the `cursor` byte offset, and the Up/Down history stack
 //! (`history`, `history_index`, `history_draft`).
 
+/// Cap on retained submitted-input history. A long-running session would
+/// otherwise grow `history` without bound (#492); older entries are dropped.
+const MAX_INPUT_HISTORY: usize = 500;
+
 /// State for the message composer: current draft and history recall.
 #[derive(Default)]
 pub struct InputState {
@@ -29,5 +33,36 @@ impl InputState {
         self.cursor = 0;
         self.history_index = None;
         self.history_draft.clear();
+    }
+
+    /// Record a submitted line for Up/Down recall, bounded at
+    /// `MAX_INPUT_HISTORY` so the stack cannot grow without limit over a long
+    /// session (#492). The oldest entries are dropped first.
+    pub fn push_history(&mut self, entry: String) {
+        self.history.push(entry);
+        if self.history.len() > MAX_INPUT_HISTORY {
+            let overflow = self.history.len() - MAX_INPUT_HISTORY;
+            self.history.drain(..overflow);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn push_history_bounds_at_cap_keeping_newest() {
+        let mut input = InputState::default();
+        for i in 0..(MAX_INPUT_HISTORY + 10) {
+            input.push_history(format!("msg{i}"));
+        }
+        assert_eq!(input.history.len(), MAX_INPUT_HISTORY);
+        // Oldest dropped, newest retained.
+        assert_eq!(
+            input.history.last().unwrap(),
+            &format!("msg{}", MAX_INPUT_HISTORY + 9)
+        );
+        assert_eq!(input.history.first().unwrap(), "msg10");
     }
 }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -23,7 +23,7 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
     let input = app.input.buffer.clone();
     let trimmed = input.trim();
     if !trimmed.is_empty() {
-        app.input.history.push(trimmed.to_string());
+        app.input.push_history(trimmed.to_string());
     }
     app.input.history_index = None;
     app.input.buffer.clear();


### PR DESCRIPTION
Part of #492.

`InputState.history` grew without bound: `handle_input` pushed every submitted line and never trimmed, so a long-lived session accumulated history indefinitely (kilobytes per day).

Adds `InputState::push_history`, which bounds the stack at `MAX_INPUT_HISTORY` (500) and drops the oldest entries on overflow; `handle_input` now calls it instead of `history.push`. Up/Down recall behavior is unchanged for the retained entries. Test covers the cap and newest-kept/oldest-dropped behavior.

The image-cache LRU bounds (`native_image_cache` / `sixel_cache` / `iterm2_crop_cache`) -- the larger half of #492 -- are deliberately sequenced after the contributor Sixel PR (#520) to avoid double-rebasing the image code, so #492 stays open.

Clippy clean, 860 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)