### PR TITLE
perf: gate per-tick image viewport scan behind a signature (#492)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1058,6 +1058,26 @@ impl App {
         if len == 0 {
             return drained;
         }
+
+        // Skip the viewport scan when nothing that affects it has changed since
+        // the last scan. ensure_active_images runs every 50ms tick; without this
+        // gate it rescans up to 60 messages and rebuilds probe keys on every idle
+        // frame (#492). The signature observes the scan's inputs directly (conv,
+        // scroll, message count, image settings) so it can't miss a trigger the
+        // way per-mutation dirty flags can. A completed background render
+        // (`drained`) frees an in-flight slot, so always rescan after one.
+        let signature = (
+            id.clone(),
+            self.scroll.offset,
+            len,
+            self.image.image_mode,
+            self.image.show_link_previews,
+        );
+        if !drained && self.image.scan_signature.as_ref() == Some(&signature) {
+            return drained;
+        }
+        self.image.scan_signature = Some(signature);
+
         let end = len
             .saturating_sub(self.scroll.offset.saturating_sub(5))
             .min(len);
@@ -7410,6 +7430,67 @@ mod tests {
             "focus must follow the same message after the shift"
         );
         assert_eq!(conv.messages[1].body, "newest");
+    }
+
+    #[rstest]
+    fn ensure_active_images_scan_is_gated_by_signature(mut app: App) {
+        let conv_id = "+1";
+        app.store
+            .get_or_create_conversation(conv_id, "Alice", false, &app.db);
+        if let Some(conv) = app.store.conversations.get_mut(conv_id) {
+            // Plain (non-image) message: the scan finds no work and spawns
+            // nothing, so no tokio runtime is needed for this test.
+            conv.messages.push(outgoing_sending_msg(1000, "hi"));
+        }
+        app.active_conversation = Some(conv_id.to_string());
+        app.image.image_mode = crate::domain::ImageMode::Halfblock;
+        app.image.show_link_previews = true;
+        app.scroll.offset = 0;
+
+        // First scan records the signature of its inputs.
+        assert!(app.image.scan_signature.is_none());
+        app.ensure_active_images();
+        assert_eq!(
+            app.image.scan_signature,
+            Some((
+                conv_id.to_string(),
+                0,
+                1,
+                crate::domain::ImageMode::Halfblock,
+                true
+            ))
+        );
+
+        // Scrolling changes the signature on the next scan.
+        app.scroll.offset = 3;
+        app.ensure_active_images();
+        assert_eq!(
+            app.image.scan_signature,
+            Some((
+                conv_id.to_string(),
+                3,
+                1,
+                crate::domain::ImageMode::Halfblock,
+                true
+            ))
+        );
+
+        // None mode short-circuits before the signature is touched, so a
+        // subsequent scroll while disabled does not update it.
+        app.image.image_mode = crate::domain::ImageMode::None;
+        app.scroll.offset = 9;
+        app.ensure_active_images();
+        assert_eq!(
+            app.image.scan_signature,
+            Some((
+                conv_id.to_string(),
+                3,
+                1,
+                crate::domain::ImageMode::Halfblock,
+                true
+            )),
+            "None mode returns before recording a new signature"
+        );
     }
 
     #[rstest]

--- a/src/domain/image.rs
+++ b/src/domain/image.rs
@@ -59,6 +59,11 @@ pub struct ImageState {
     pub image_render_rx: mpsc::Receiver<ImageRenderResult>,
     /// In-flight background renders: (conv_id, timestamp, is_preview)
     pub image_render_in_flight: HashSet<(String, i64, bool)>,
+    /// Cached inputs of the last viewport scan in `ensure_active_images`:
+    /// (conv_id, scroll_offset, message_count, image_mode, show_link_previews).
+    /// When unchanged and no render just completed, the per-tick scan is
+    /// skipped to avoid idle CPU churn (#492).
+    pub scan_signature: Option<(String, usize, usize, ImageMode, bool)>,
 }
 
 impl ImageState {
@@ -88,6 +93,7 @@ impl ImageState {
             image_render_tx,
             image_render_rx,
             image_render_in_flight: HashSet::new(),
+            scan_signature: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

Part of #492 (idle CPU churn). `ensure_active_images` runs on every ~50ms event-loop tick. It always drains completed background renders, but it also rescans up to 60 viewport messages and rebuilds probe keys on every tick even when nothing relevant has changed, which wastes CPU on an idle client.

This gates the viewport scan behind a cheap signature of the scan's actual inputs:

- active conversation id
- scroll offset
- message count
- image mode
- link-preview setting

When the signature is unchanged and no background render just completed, the scan is skipped. The channel drain still runs every tick (it is a cheap non-blocking `try_recv`), and a completed render forces a rescan so the freed in-flight slot gets refilled.

## Why a signature instead of a dirty flag

A signature observes the scan inputs directly, so it cannot miss a trigger the way a per-mutation-site dirty flag could (scroll changes alone happen in many handlers). New messages bump the count, scrolling bumps the offset, switching conversations changes the id, and toggling image settings changes those fields, so every case that could surface new render work re-triggers the scan.

## Notes

- The new field lives on `ImageState` (a `src/domain/` sub-struct), so the `App` field-count ratchet is unaffected (still 66/66).
- Added a unit test covering signature recording, scroll-driven re-trigger, and the None-mode short-circuit.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (649 bin + 212 lib)
- field-count ratchet: 66/66