### PR TITLE
test: cover the bug-prone scroll, phone, and QR seams (#503)

### DIFF
--- a/src/link.rs
+++ b/src/link.rs
@@ -324,3 +324,62 @@ fn centered_rect(
         .areas(centered);
     centered
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- render_qr_lines (#503) ---
+    //
+    // A rendering bug here produces an unscannable QR, which is indistinguishable
+    // from a linking failure to the user. These assert the structure CI can check
+    // without a camera: dimensions, the quiet-zone border, and the glyph set.
+
+    #[test]
+    fn render_qr_lines_dimensions_and_quiet_zone() {
+        let qr = qrcode::QrCode::new(b"sgnl://linkdevice?uuid=test").unwrap();
+        let width = qr.width();
+        let total = width + 4; // 2-module quiet zone on each side
+        let lines = render_qr_lines(&qr);
+
+        // Two grid rows are packed per text line via half-blocks.
+        assert_eq!(lines.len(), total.div_ceil(2));
+
+        for line in &lines {
+            let spans: Vec<&str> = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            // Each line spans the full padded width.
+            assert_eq!(spans.len(), total);
+            // Only the four expected glyphs appear.
+            for ch in &spans {
+                assert!(
+                    matches!(*ch, "\u{2588}" | "\u{2580}" | "\u{2584}" | " "),
+                    "unexpected glyph: {ch:?}"
+                );
+            }
+            // The 2-module quiet columns on each side are always blank.
+            assert_eq!(spans[0], " ");
+            assert_eq!(spans[1], " ");
+            assert_eq!(spans[total - 2], " ");
+            assert_eq!(spans[total - 1], " ");
+        }
+
+        // Top quiet zone: the first line packs grid rows 0 and 1, both blank.
+        let first: Vec<&str> = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            first.iter().all(|c| *c == " "),
+            "top quiet row must be blank"
+        );
+    }
+
+    #[test]
+    fn render_qr_lines_contains_dark_modules() {
+        // A real QR has finder patterns; at least some non-blank glyphs must render.
+        let qr = qrcode::QrCode::new(b"sgnl://linkdevice?uuid=test").unwrap();
+        let lines = render_qr_lines(&qr);
+        let any_dark = lines
+            .iter()
+            .flat_map(|l| &l.spans)
+            .any(|s| s.content.as_ref() != " ");
+        assert!(any_dark, "expected dark modules in a real QR code");
+    }
+}

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -883,4 +883,52 @@ mod tests {
         let display = display.unwrap();
         assert!(display.starts_with("cargo"));
     }
+
+    // --- validate_phone (#503) ---
+
+    #[test]
+    fn validate_phone_accepts_e164() {
+        assert!(validate_phone("+15551234567").is_ok());
+        // Leading/trailing whitespace is trimmed before validation.
+        assert!(validate_phone("  +15551234567  ").is_ok());
+        // Minimum accepted length is 8 chars including the '+'.
+        assert!(validate_phone("+1234567").is_ok());
+    }
+
+    #[test]
+    fn validate_phone_rejects_empty() {
+        assert_eq!(
+            validate_phone("   ").unwrap_err(),
+            "Phone number cannot be empty"
+        );
+    }
+
+    #[test]
+    fn validate_phone_requires_plus_prefix() {
+        assert_eq!(
+            validate_phone("15551234567").unwrap_err(),
+            "Must start with + (E.164 format)"
+        );
+    }
+
+    #[test]
+    fn validate_phone_rejects_too_short() {
+        assert_eq!(
+            validate_phone("+123").unwrap_err(),
+            "Phone number too short"
+        );
+    }
+
+    #[test]
+    fn validate_phone_rejects_non_digits() {
+        assert_eq!(
+            validate_phone("+1555abc4567").unwrap_err(),
+            "Only digits allowed after +"
+        );
+        // A second '+' after the first is also a non-digit.
+        assert_eq!(
+            validate_phone("+1555+234567").unwrap_err(),
+            "Only digits allowed after +"
+        );
+    }
 }

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -328,8 +328,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     if app.scroll.offset == 0 {
         app.scroll.window_extra = 0;
     }
-    let start =
-        total.saturating_sub(available_height * MSG_WINDOW_MULTIPLIER + app.scroll.window_extra);
+    let start = window_start(total, available_height, app.scroll.window_extra);
     let visible = &messages[start..total];
 
     // Get last_read_index for unread marker
@@ -709,9 +708,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     }
 
     // Bottom-align by default; app.scroll.offset shifts the view upward
-    let base_scroll = content_height.saturating_sub(available_height);
-    app.scroll.offset = app.scroll.offset.min(base_scroll);
-    let mut scroll_y = base_scroll - app.scroll.offset;
+    let (base_scroll, clamped_offset, mut scroll_y) =
+        bottom_align_scroll(content_height, available_height, app.scroll.offset);
+    app.scroll.offset = clamped_offset;
 
     // Signal when the user has scrolled to the top of the render window and
     // there is anywhere further up to go: unrendered in-memory messages
@@ -751,17 +750,12 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 }
                 cumul += h;
             }
-            if let Some(start) = msg_start {
-                if start < scroll_y {
-                    // Message is above viewport — scroll up
-                    app.scroll.offset = base_scroll.saturating_sub(start);
-                    scroll_y = base_scroll - app.scroll.offset;
-                } else if msg_end > scroll_y + available_height {
-                    // Message is below viewport — scroll down
-                    let new_scroll_y = msg_end.saturating_sub(available_height);
-                    app.scroll.offset = base_scroll.saturating_sub(new_scroll_y);
-                    scroll_y = base_scroll - app.scroll.offset;
-                }
+            if let Some(start) = msg_start
+                && let Some((offset, new_scroll_y)) =
+                    ensure_focus_visible(start, msg_end, base_scroll, scroll_y, available_height)
+            {
+                app.scroll.offset = offset;
+                scroll_y = new_scroll_y;
             }
             app.scroll.focused_time = messages.get(fi).map(|m| m.timestamp);
             render_focus = Some(fi);
@@ -1081,6 +1075,64 @@ fn compute_sync_pin_offset(
     Some(pin_offset_at_capture.saturating_add(lines_below_pin))
 }
 
+/// Index of the first message to render in the bottom-anchored window.
+///
+/// `window_extra` grows in discrete chunks via `App::extend_scrollback` (#488)
+/// and is counted in *messages*, never derived from the scroll offset. Keeping
+/// the start offset-independent is what prevents the v0.6.1 stuck-viewport bug:
+/// folding the offset in here would expand the window by one message per scroll
+/// increment, growing `content_height` in lockstep so `scroll_y` never moves.
+pub(crate) fn window_start(total: usize, available_height: usize, window_extra: usize) -> usize {
+    total.saturating_sub(available_height * MSG_WINDOW_MULTIPLIER + window_extra)
+}
+
+/// Bottom-aligned scroll math. Given the total wrapped `content_height`, the
+/// `available_height` viewport, and the user's `offset` (lines up from the
+/// bottom), returns `(base_scroll, clamped_offset, scroll_y)`.
+///
+/// `base_scroll` is the maximum upward travel; the offset is clamped to it so it
+/// can never push past the oldest content, and `scroll_y` is the resulting
+/// Paragraph scroll row. This is the second half of the v0.6.1 surface: with an
+/// offset-independent window start (see [`window_start`]), `scroll_y` actually
+/// decreases as the offset grows instead of staying pinned.
+pub(crate) fn bottom_align_scroll(
+    content_height: usize,
+    available_height: usize,
+    offset: usize,
+) -> (usize, usize, usize) {
+    let base_scroll = content_height.saturating_sub(available_height);
+    let clamped_offset = offset.min(base_scroll);
+    let scroll_y = base_scroll - clamped_offset;
+    (base_scroll, clamped_offset, scroll_y)
+}
+
+/// Adjust the scroll so the focused message's line span `[msg_start, msg_end)`
+/// is fully visible, returning the new `(offset, scroll_y)` or `None` if it
+/// already fits within `[scroll_y, scroll_y + available_height)`.
+///
+/// Mirrors the J/K "ensure focused message visible" path: when the message sits
+/// above the viewport we scroll up so its first line is at the top; when it sits
+/// below we scroll down so its last line is at the bottom. Both branches recover
+/// the offset from `base_scroll` so the caller's `scroll_y` stays consistent.
+pub(crate) fn ensure_focus_visible(
+    msg_start: usize,
+    msg_end: usize,
+    base_scroll: usize,
+    scroll_y: usize,
+    available_height: usize,
+) -> Option<(usize, usize)> {
+    if msg_start < scroll_y {
+        let offset = base_scroll.saturating_sub(msg_start);
+        Some((offset, base_scroll - offset))
+    } else if msg_end > scroll_y + available_height {
+        let new_scroll_y = msg_end.saturating_sub(available_height);
+        let offset = base_scroll.saturating_sub(new_scroll_y);
+        Some((offset, base_scroll - offset))
+    } else {
+        None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1232,6 +1284,73 @@ mod tests {
     }
 
     // --- end compute_sync_pin_offset ---
+
+    // --- scroll windowing (#503) ---
+
+    #[test]
+    fn window_start_anchors_to_bottom_window() {
+        // Plenty of headroom: start clamps to 0 (render everything).
+        assert_eq!(window_start(5, 10, 0), 0);
+        // 1000 messages, height 10, multiplier 10 -> window of 100, start at 900.
+        assert_eq!(window_start(1000, 10, 0), 1000 - 10 * MSG_WINDOW_MULTIPLIER);
+        // window_extra widens the window (moves start earlier) by message count.
+        assert_eq!(
+            window_start(1000, 10, 50),
+            1000 - (10 * MSG_WINDOW_MULTIPLIER + 50)
+        );
+        // window_extra larger than the remaining history saturates to 0.
+        assert_eq!(window_start(20, 10, 1000), 0);
+    }
+
+    #[test]
+    fn bottom_align_content_fits_viewport() {
+        // Content shorter than the viewport: no scroll, offset clamps to 0.
+        // This is the regression guard from v0.6.1 where J/K could strand the
+        // viewport even when everything fit.
+        let (base, offset, scroll_y) = bottom_align_scroll(5, 10, 3);
+        assert_eq!(base, 0);
+        assert_eq!(offset, 0, "offset must clamp to base_scroll (0)");
+        assert_eq!(scroll_y, 0);
+    }
+
+    #[test]
+    fn bottom_align_scrolls_up_by_offset() {
+        // content 100, viewport 10 -> base_scroll 90 (bottom-aligned).
+        let (base, offset, scroll_y) = bottom_align_scroll(100, 10, 0);
+        assert_eq!((base, offset, scroll_y), (90, 0, 90), "at bottom");
+        // Scrolling up by 30 must actually move scroll_y, not pin it (v0.6.1).
+        let (base, offset, scroll_y) = bottom_align_scroll(100, 10, 30);
+        assert_eq!((base, offset, scroll_y), (90, 30, 60));
+        // Scrolling past the top clamps offset to base_scroll and pins scroll_y=0.
+        let (base, offset, scroll_y) = bottom_align_scroll(100, 10, 999);
+        assert_eq!((base, offset, scroll_y), (90, 90, 0));
+    }
+
+    #[test]
+    fn ensure_focus_visible_noop_when_already_in_view() {
+        // Focused message lines 12..15, viewport [10, 20): fully visible.
+        assert_eq!(ensure_focus_visible(12, 15, 90, 10, 10), None);
+    }
+
+    #[test]
+    fn ensure_focus_visible_scrolls_up_to_top() {
+        // Focus starts at line 5, above the viewport [10, 20).
+        // Expect scroll_y to land on the message start (5).
+        let (offset, scroll_y) = ensure_focus_visible(5, 8, 90, 10, 10).unwrap();
+        assert_eq!(scroll_y, 5, "first line of focus sits at the top");
+        assert_eq!(offset, 85, "offset = base_scroll - scroll_y");
+    }
+
+    #[test]
+    fn ensure_focus_visible_scrolls_down_to_bottom() {
+        // Focus ends at line 35, below the viewport [10, 20).
+        // Expect the last line at the bottom: scroll_y = 35 - 10 = 25.
+        let (offset, scroll_y) = ensure_focus_visible(30, 35, 90, 10, 10).unwrap();
+        assert_eq!(scroll_y, 25, "last line of focus sits at the bottom");
+        assert_eq!(offset, 65, "offset = base_scroll - scroll_y");
+    }
+
+    // --- end scroll windowing ---
 
     #[test]
     fn reaction_summary_counts() {


### PR DESCRIPTION
## Summary

First pass at the #503 test-gap list. The pattern there is "high-value test gap blocked by a missing seam," so this extracts the pure pieces of the chat-pane scroll path into named functions and table-tests the known bug cases, then adds direct tests for two functions that were already pure but untested.

### Chat-pane scroll windowing (part 1)

This is the v0.6.1 stuck-viewport / broken-J/K bug class, which had zero direct coverage (all snapshots render at default scroll). Extracted three pure functions from `draw_messages` and rewired the call sites (behavior unchanged):

- `window_start(total, available_height, window_extra)` - bottom-anchored first index, deliberately offset-independent so the window cannot grow in lockstep with the scroll offset.
- `bottom_align_scroll(content_height, available_height, offset)` - returns `(base_scroll, clamped_offset, scroll_y)`; the offset clamps to `base_scroll` so `scroll_y` actually moves instead of staying pinned.
- `ensure_focus_visible(...)` - the J/K "keep the focused message visible" adjustment.

### setup::validate_phone (part 3)

Pure and previously untested. rstest covers empty, missing `+`, too-short, non-digit, and valid E.164.

### link::render_qr_lines (part 4)

Pure and previously untested. A render bug here produces an unscannable QR, indistinguishable from a linking failure and uncatchable by CI. Asserts line count, full padded width, the 2-module quiet-zone border, the four-glyph set, and that a real QR renders dark modules.

## Deferred

The larger extractions in #503 remain for a follow-up PR:
- `signal/client.rs` stdout reader (`handle_stdout_line` seam)
- the wizard `Step` machine and `link::run_linking_flow` (`advance(step, event)` seam)

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (662 bin + 212 lib, +13 new)
- `cargo fmt` applied
- field-count ratchet unaffected (no new App fields)