### PR TITLE
docs: document Windows file-permission reliance and on-write sanitization (#504)

### DIFF
--- a/docs/src/user-guide/security.md
+++ b/docs/src/user-guide/security.md
@@ -58,6 +58,22 @@ Platform config directories:
 - **Linux / macOS**: `~/.config/siggy/`
 - **Windows**: `%APPDATA%\siggy\`
 
+### File permissions
+
+On **Unix** (Linux / macOS), siggy creates its sensitive files and directories
+with restrictive permissions: the lock hash, debug log, and their parent
+directories are set to owner-only (`0600` for files, `0700` for directories).
+
+On **Windows** there is no portable equivalent of `chmod`, so siggy does not set
+an explicit DACL. Instead it relies on the default per-user ACLs that Windows
+applies to the profile directories these files live in (`%APPDATA%`,
+`%USERPROFILE%`, `%LOCALAPPDATA%`). Under those defaults other standard user
+accounts cannot read your siggy files, but **local administrators still can**.
+If that is part of your threat model, enable BitLocker (full-volume encryption)
+or store your profile on an encrypted volume. This is a deliberate choice over
+manipulating Win32 security descriptors, which could lock you out of your own
+files if it went wrong.
+
 ## Privacy features
 
 ### Incognito mode
@@ -93,7 +109,14 @@ Debug logging is **opt-in only** and disabled by default.
 
 Debug logs are written to `~/.cache/siggy/debug.log` with 10 MB rotation. On
 Unix systems, the log file and directory are created with restrictive permissions
-(0600 / 0700).
+(0600 / 0700). See [File permissions](#file-permissions) for how this differs on
+Windows.
+
+Chat exports (`/export`) and the unredacted `--debug-full` log have terminal
+control characters stripped on write (newlines and tabs are kept), so opening
+either with `cat`/`type` cannot execute escape sequences embedded in a message
+body. Desktop notification titles and previews are likewise stripped of control
+characters before being handed to the OS notifier.
 
 ### Clipboard
 
@@ -126,8 +149,12 @@ at-rest protection for the message DB, rely on full-disk encryption.
 - **Set `notification_preview = "sender"` or `"minimal"`** if you're concerned
   about notification content being visible on lock screens or in screen recordings.
 - **Use a screen lock** to prevent physical access to your terminal session.
-- **On shared systems**, restrict file permissions on the config directory
+- **On shared Unix systems**, restrict file permissions on the config directory
   (`chmod 700 ~/.config/siggy`).
+- **On Windows**, the config and cache directories inherit your user profile's
+  default ACLs (other standard users cannot read them; local administrators can).
+  Enable BitLocker if you need protection beyond that. See
+  [File permissions](#file-permissions).
 
 ## Reporting vulnerabilities
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,6 +68,13 @@ fn set_file_permissions(path: &std::path::Path) {
     let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
 }
 
+// On Windows there is no portable chmod equivalent, so siggy relies on the
+// default per-user ACLs that Windows applies to the profile directories these
+// files live under (%APPDATA%, %USERPROFILE%, %LOCALAPPDATA%): other standard
+// users cannot read them, though local administrators still can. Setting an
+// owner-only DACL would mean linking the Win32 security APIs and could lock a
+// user out of their own files if SID resolution failed, so the reliance is
+// documented in docs/src/user-guide/security.md instead (#504).
 #[cfg(not(unix))]
 fn set_file_permissions(_path: &std::path::Path) {}
 
@@ -78,6 +85,7 @@ fn set_dir_permissions(path: &std::path::Path) {
     let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700));
 }
 
+// No-op on Windows for the same reason as `set_file_permissions` above.
 #[cfg(not(unix))]
 fn set_dir_permissions(_path: &std::path::Path) {}
 


### PR DESCRIPTION
## Summary

Closes the two remaining hardening items from the #504 audit. (Items 2 and 3, control-char stripping for chat exports, the `--debug-full` log, and desktop notifications, shipped earlier in #545.)

### Item 4: Windows file permissions

The `set_file_permissions` / `set_dir_permissions` helpers are no-ops on Windows because there is no portable `chmod` equivalent. Setting an owner-only DACL would mean linking the Win32 security APIs, cannot be exercised by the Linux CI runners, and could lock a user out of their own files if SID resolution went wrong. The issue explicitly allows documenting the reliance as an alternative, so this PR does that:

- A new "File permissions" section in the Security guide explaining that on Windows siggy relies on the default per-user profile ACLs (other standard users cannot read the files; local administrators can) and recommending BitLocker for stronger protection.
- A Windows entry under Recommendations.
- Explaining comments on the `cfg(not(unix))` no-op helpers in `main.rs` so the gap reads as deliberate.

### Item 1: lock is a screen lock, not encryption

Already covered by the existing "Session lock" threat-model section (the DB is cleartext even while locked, and `--reset-lock` removes the hash). The export / debug / notification sanitization from #545 is now also noted in the Debug logging section.

## Notes

- Code change is comment-only (`main.rs`); the rest is docs.
- No em dashes in the docs or PR text.

## Testing

- `cargo build` clean