### PR TITLE
refactor: make domain a leaf layer by relocating shared value types (#495)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,6 @@
 use chrono::{DateTime, Utc};
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
-use ratatui::text::Line;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
@@ -28,6 +27,12 @@ use crate::domain::{
     SearchAction, SearchState, SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState,
     TypingState, VerifyOverlayState,
 };
+// These value types were relocated into `domain` so the domain layer is a leaf
+// (#495). Re-export them here so existing `crate::app::*` references across the
+// handlers, UI, and main loop keep resolving unchanged.
+pub use crate::domain::{
+    GroupMenuState, ImageRenderResult, PinPending, PollVotePending, SendRequest, VisibleImage,
+};
 use crate::image_render;
 use crate::image_render::ImageProtocol;
 use crate::input::COMMANDS;
@@ -35,7 +40,7 @@ use crate::input::{next_char_pos, prev_char_pos};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
 use crate::list_overlay::{self, ListKeyAction, classify_list_key};
 use crate::mute::MuteState;
-use crate::signal::types::{MessageStatus, PollOption, Reaction, SignalEvent, TrustLevel};
+use crate::signal::types::{MessageStatus, Reaction, SignalEvent, TrustLevel};
 use crate::theme::{self, Theme};
 
 /// Sentinel lifetime for paste temp files awaiting send confirmation from signal-cli.
@@ -263,32 +268,8 @@ pub enum OverlayKind {
     Autocomplete,
 }
 
-/// An image visible on screen, for native protocol overlay rendering.
-#[derive(PartialEq, Eq)]
-pub struct VisibleImage {
-    pub x: u16,
-    pub y: u16,
-    pub width: u16,
-    pub height: u16,
-    /// Total image height in cells (before viewport clipping).
-    pub full_height: u16,
-    /// Cells cropped from the top when the image is partially scrolled out.
-    pub crop_top: u16,
-    pub path: String,
-}
-
-/// Result from a background image render task.
-pub struct ImageRenderResult {
-    pub conv_id: String,
-    pub timestamp_ms: i64,
-    pub is_preview: bool,
-    pub lines: Option<Vec<Line<'static>>>,
-    pub image_path: Option<String>,
-    /// Pre-encoded PNG for native_image_cache: (path, base64, pixel_w, pixel_h)
-    pub pre_native_png: Option<(String, String, u32, u32)>,
-    /// Pre-encoded full Sixel for sixel_cache: (path, sixel_string)
-    pub pre_sixel: Option<(String, String)>,
-}
+// VisibleImage and ImageRenderResult moved to `domain::image` (#495);
+// re-exported from `crate::domain` below.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
@@ -296,17 +277,7 @@ pub enum InputMode {
     Insert,
 }
 
-/// Which sub-overlay of the /group menu is currently active.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum GroupMenuState {
-    Menu,         // top-level flyout
-    Members,      // read-only member list
-    AddMember,    // contact picker (type-to-filter)
-    RemoveMember, // member picker (type-to-filter)
-    Rename,       // text input (pre-filled)
-    Create,       // text input (empty)
-    LeaveConfirm, // y/n confirmation
-}
+// GroupMenuState moved to `domain::overlays` (#495); re-exported below.
 
 /// An item in the group-menu overlay (Manage members / Rename / Leave / ...).
 pub struct GroupMenuItem {
@@ -427,23 +398,8 @@ impl ActionMenuHint {
     }
 }
 
-/// Context saved when the pin duration picker is open (remembers which message is being pinned).
-pub struct PinPending {
-    pub conv_id: String,
-    pub is_group: bool,
-    pub target_author: String,
-    pub target_timestamp: i64,
-}
-
-/// Context saved when the poll vote overlay is open.
-pub struct PollVotePending {
-    pub conv_id: String,
-    pub is_group: bool,
-    pub poll_author: String,
-    pub poll_timestamp: i64,
-    pub allow_multiple: bool,
-    pub options: Vec<PollOption>,
-}
+// PinPending and PollVotePending moved to `domain::overlays` (#495);
+// re-exported below.
 
 /// Tracks the initial sync burst when the app starts.
 /// During sync, notifications and viewport jumps are suppressed.
@@ -663,134 +619,8 @@ pub const PIN_DURATIONS: &[(i64, &str)] = &[
     (2592000, "30 days"),
 ];
 
-/// A request from the UI to the main loop to send something.
-pub enum SendRequest {
-    Message {
-        recipient: String,
-        body: String,
-        is_group: bool,
-        local_ts_ms: i64,
-        mentions: Vec<(usize, String)>,
-        attachment: Option<PathBuf>,
-        quote_timestamp: Option<i64>,
-        quote_author: Option<String>,
-        quote_body: Option<String>,
-    },
-    Reaction {
-        conv_id: String,
-        emoji: String,
-        is_group: bool,
-        target_author: String,
-        target_timestamp: i64,
-        remove: bool,
-    },
-    Edit {
-        recipient: String,
-        body: String,
-        is_group: bool,
-        edit_timestamp: i64,
-        local_ts_ms: i64,
-        mentions: Vec<(usize, String)>,
-        quote_timestamp: Option<i64>,
-        quote_author: Option<String>,
-        quote_body: Option<String>,
-    },
-    RemoteDelete {
-        recipient: String,
-        is_group: bool,
-        target_timestamp: i64,
-    },
-    Typing {
-        recipient: String,
-        is_group: bool,
-        stop: bool,
-    },
-    ReadReceipt {
-        recipient: String,
-        timestamps: Vec<i64>,
-    },
-    UpdateExpiration {
-        conv_id: String,
-        is_group: bool,
-        seconds: i64,
-    },
-    CreateGroup {
-        name: String,
-    },
-    AddGroupMembers {
-        group_id: String,
-        members: Vec<String>,
-    },
-    RemoveGroupMembers {
-        group_id: String,
-        members: Vec<String>,
-    },
-    RenameGroup {
-        group_id: String,
-        name: String,
-    },
-    LeaveGroup {
-        group_id: String,
-    },
-    MessageRequestResponse {
-        recipient: String,
-        is_group: bool,
-        response_type: String,
-    },
-    Block {
-        recipient: String,
-        is_group: bool,
-    },
-    Unblock {
-        recipient: String,
-        is_group: bool,
-    },
-    Pin {
-        recipient: String,
-        is_group: bool,
-        target_author: String,
-        target_timestamp: i64,
-        pin_duration: i64,
-    },
-    Unpin {
-        recipient: String,
-        is_group: bool,
-        target_author: String,
-        target_timestamp: i64,
-    },
-    PollCreate {
-        recipient: String,
-        is_group: bool,
-        question: String,
-        options: Vec<String>,
-        allow_multiple: bool,
-        local_ts_ms: i64,
-    },
-    PollVote {
-        recipient: String,
-        is_group: bool,
-        poll_author: String,
-        poll_timestamp: i64,
-        option_indexes: Vec<i64>,
-        vote_count: i64,
-    },
-    PollTerminate {
-        recipient: String,
-        is_group: bool,
-        poll_timestamp: i64,
-    },
-    ListIdentities,
-    TrustIdentity {
-        recipient: String,
-        safety_number: String,
-    },
-    UpdateProfile {
-        given_name: String,
-        family_name: String,
-        about: String,
-        about_emoji: String,
-    },
-}
+// SendRequest moved to `domain::send` so domain stays a leaf layer (#495).
+// Re-exported below from `crate::domain` alongside the other moved value types.
 
 /// A single settings toggle entry: label, getter, setter, and optional config
 /// persistence. `save` (App -> Config) and `load` (Config -> App) are a pair:

--- a/src/domain/image.rs
+++ b/src/domain/image.rs
@@ -13,11 +13,51 @@ use std::collections::{HashMap, HashSet};
 
 use std::sync::mpsc;
 
+use ratatui::style::Color;
+use ratatui::text::Line;
+
 pub use crate::config::ImageMode;
 
-use crate::app::{ImageRenderResult, VisibleImage};
 use crate::image_render::ImageProtocol;
-use crate::ui::LinkRegion;
+
+/// An image visible on screen, for native protocol overlay rendering.
+#[derive(PartialEq, Eq)]
+pub struct VisibleImage {
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+    /// Total image height in cells (before viewport clipping).
+    pub full_height: u16,
+    /// Cells cropped from the top when the image is partially scrolled out.
+    pub crop_top: u16,
+    pub path: String,
+}
+
+/// Result from a background image render task.
+pub struct ImageRenderResult {
+    pub conv_id: String,
+    pub timestamp_ms: i64,
+    pub is_preview: bool,
+    pub lines: Option<Vec<Line<'static>>>,
+    pub image_path: Option<String>,
+    /// Pre-encoded PNG for native_image_cache: (path, base64, pixel_w, pixel_h)
+    pub pre_native_png: Option<(String, String, u32, u32)>,
+    /// Pre-encoded full Sixel for sixel_cache: (path, sixel_string)
+    pub pre_sixel: Option<(String, String)>,
+}
+
+/// A clickable link region detected in the rendered buffer.
+pub struct LinkRegion {
+    pub x: u16,
+    pub y: u16,
+    pub url: String,
+    pub text: String,
+    /// Display width in terminal columns (may differ from text.len() for Unicode).
+    pub width: u16,
+    /// Background color from the buffer cell, if non-default (e.g. highlight).
+    pub bg: Option<Color>,
+}
 
 /// State for image rendering, caching, and link overlay tracking.
 pub struct ImageState {

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -18,11 +18,12 @@ mod pending;
 mod reaction;
 mod scroll;
 mod search;
+mod send;
 mod typing;
 
 pub use emoji_picker::{CATEGORIES, EmojiPickerAction, EmojiPickerSource, EmojiPickerState};
 pub use file_picker::{FilePickerOutcome, FilePickerState};
-pub use image::{ImageMode, ImageState};
+pub use image::{ImageMode, ImageRenderResult, ImageState, LinkRegion, VisibleImage};
 pub use input::InputState;
 pub use lock::{LockPhase, LockState};
 pub use lock::{hash_passphrase, load_hash, lock_hash_path, save_hash, verify_passphrase};
@@ -30,11 +31,13 @@ pub use mouse::MouseState;
 pub use notification::{NotificationPreview, NotificationState};
 pub use overlays::{
     ActionMenuState, ContactsOverlayState, ForwardOverlayState, GroupMenuOverlayState,
-    KeybindingsOverlayState, PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState,
-    SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState, VerifyOverlayState,
+    GroupMenuState, KeybindingsOverlayState, PinDurationOverlayState, PinPending,
+    PollVoteOverlayState, PollVotePending, ProfileOverlayState, SettingsOverlayState,
+    SettingsProfileOverlayState, ThemePickerState, VerifyOverlayState,
 };
 pub use pending::{BufferedReceipt, PendingState};
 pub use reaction::ReactionState;
 pub use scroll::ScrollState;
 pub use search::{SearchAction, SearchState};
+pub use send::SendRequest;
 pub use typing::TypingState;

--- a/src/domain/overlays.rs
+++ b/src/domain/overlays.rs
@@ -12,11 +12,40 @@
 
 use std::collections::HashMap;
 
-use crate::app::{GroupMenuState, PinPending, PollVotePending};
 use crate::keybindings::{KeyAction, KeyCombo};
 use crate::settings_profile::SettingsProfile;
-use crate::signal::types::{IdentityInfo, PollData};
+use crate::signal::types::{IdentityInfo, PollData, PollOption};
 use crate::theme::Theme;
+
+/// Which sub-overlay of the /group menu is currently active.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GroupMenuState {
+    Menu,         // top-level flyout
+    Members,      // read-only member list
+    AddMember,    // contact picker (type-to-filter)
+    RemoveMember, // member picker (type-to-filter)
+    Rename,       // text input (pre-filled)
+    Create,       // text input (empty)
+    LeaveConfirm, // y/n confirmation
+}
+
+/// Context saved when the pin duration picker is open (remembers which message is being pinned).
+pub struct PinPending {
+    pub conv_id: String,
+    pub is_group: bool,
+    pub target_author: String,
+    pub target_timestamp: i64,
+}
+
+/// Context saved when the poll vote overlay is open.
+pub struct PollVotePending {
+    pub conv_id: String,
+    pub is_group: bool,
+    pub poll_author: String,
+    pub poll_timestamp: i64,
+    pub allow_multiple: bool,
+    pub options: Vec<PollOption>,
+}
 
 /// State for the message action menu overlay.
 #[derive(Default)]

--- a/src/domain/pending.rs
+++ b/src/domain/pending.rs
@@ -8,7 +8,7 @@
 
 use std::collections::HashMap;
 
-use crate::app::SendRequest;
+use super::send::SendRequest;
 use crate::signal::types::ReceiptKind;
 
 /// A receipt that arrived before the message it targets was matchable

--- a/src/domain/send.rs
+++ b/src/domain/send.rs
@@ -1,0 +1,138 @@
+//! Outgoing-request value type.
+//!
+//! [`SendRequest`] is the message the input/overlay handlers hand back to the
+//! main loop, which routes each variant to its `SignalClient` RPC method
+//! (`dispatch_send` in `main.rs`). It is pure data with no `App` coupling, so it
+//! lives in `domain` as a leaf type that `app`, `handlers`, and the main loop
+//! import from.
+
+use std::path::PathBuf;
+
+/// A request from the UI to the main loop to send something.
+pub enum SendRequest {
+    Message {
+        recipient: String,
+        body: String,
+        is_group: bool,
+        local_ts_ms: i64,
+        mentions: Vec<(usize, String)>,
+        attachment: Option<PathBuf>,
+        quote_timestamp: Option<i64>,
+        quote_author: Option<String>,
+        quote_body: Option<String>,
+    },
+    Reaction {
+        conv_id: String,
+        emoji: String,
+        is_group: bool,
+        target_author: String,
+        target_timestamp: i64,
+        remove: bool,
+    },
+    Edit {
+        recipient: String,
+        body: String,
+        is_group: bool,
+        edit_timestamp: i64,
+        local_ts_ms: i64,
+        mentions: Vec<(usize, String)>,
+        quote_timestamp: Option<i64>,
+        quote_author: Option<String>,
+        quote_body: Option<String>,
+    },
+    RemoteDelete {
+        recipient: String,
+        is_group: bool,
+        target_timestamp: i64,
+    },
+    Typing {
+        recipient: String,
+        is_group: bool,
+        stop: bool,
+    },
+    ReadReceipt {
+        recipient: String,
+        timestamps: Vec<i64>,
+    },
+    UpdateExpiration {
+        conv_id: String,
+        is_group: bool,
+        seconds: i64,
+    },
+    CreateGroup {
+        name: String,
+    },
+    AddGroupMembers {
+        group_id: String,
+        members: Vec<String>,
+    },
+    RemoveGroupMembers {
+        group_id: String,
+        members: Vec<String>,
+    },
+    RenameGroup {
+        group_id: String,
+        name: String,
+    },
+    LeaveGroup {
+        group_id: String,
+    },
+    MessageRequestResponse {
+        recipient: String,
+        is_group: bool,
+        response_type: String,
+    },
+    Block {
+        recipient: String,
+        is_group: bool,
+    },
+    Unblock {
+        recipient: String,
+        is_group: bool,
+    },
+    Pin {
+        recipient: String,
+        is_group: bool,
+        target_author: String,
+        target_timestamp: i64,
+        pin_duration: i64,
+    },
+    Unpin {
+        recipient: String,
+        is_group: bool,
+        target_author: String,
+        target_timestamp: i64,
+    },
+    PollCreate {
+        recipient: String,
+        is_group: bool,
+        question: String,
+        options: Vec<String>,
+        allow_multiple: bool,
+        local_ts_ms: i64,
+    },
+    PollVote {
+        recipient: String,
+        is_group: bool,
+        poll_author: String,
+        poll_timestamp: i64,
+        option_indexes: Vec<i64>,
+        vote_count: i64,
+    },
+    PollTerminate {
+        recipient: String,
+        is_group: bool,
+        poll_timestamp: i64,
+    },
+    ListIdentities,
+    TrustIdentity {
+        recipient: String,
+        safety_number: String,
+    },
+    UpdateProfile {
+        given_name: String,
+        family_name: String,
+        about: String,
+        about_emoji: String,
+    },
+}

--- a/src/ui/links.rs
+++ b/src/ui/links.rs
@@ -20,20 +20,9 @@ use ratatui::{
     text::Span,
 };
 
+use crate::domain::LinkRegion;
 use crate::signal::types::StyleType;
 use crate::theme::Theme;
-
-/// A clickable link region detected in the rendered buffer.
-pub struct LinkRegion {
-    pub x: u16,
-    pub y: u16,
-    pub url: String,
-    pub text: String,
-    /// Display width in terminal columns (may differ from text.len() for Unicode).
-    pub width: u16,
-    /// Background color from the buffer cell, if non-default (e.g. highlight).
-    pub bg: Option<Color>,
-}
 
 /// Extract a URL from link-styled text.
 fn extract_url(text: &str) -> String {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -16,7 +16,9 @@ mod welcome;
 
 use autocomplete::draw_autocomplete;
 use chat_pane::draw_chat_area;
-pub use links::LinkRegion;
+// LinkRegion now lives in `domain` (#495); keep `crate::ui::LinkRegion` working
+// for existing callers by re-exporting it here.
+pub use crate::domain::LinkRegion;
 use links::collect_link_regions;
 use overlays::about::draw_about;
 use overlays::action_menu::{draw_action_menu, draw_delete_confirm};


### PR DESCRIPTION
## Summary

The intended dependency arrow is `app -> domain`, but three `domain` modules pointed back at `app::` (and one at `ui::`), inverting the layering. This moves the pure value types they needed into `domain` so the layer stops depending on its own dependents.

Relocations:

- `SendRequest` -> new `domain/send.rs`
- `VisibleImage`, `ImageRenderResult`, `LinkRegion` -> `domain/image.rs`
- `GroupMenuState`, `PinPending`, `PollVotePending` -> `domain/overlays.rs`

`domain/image.rs`, `domain/pending.rs`, and `domain/overlays.rs` now import these from within `domain` instead of from `app::` / `ui::`.

## Compatibility

To avoid a large mechanical churn across every call site, `app.rs` re-exports the relocated types (`pub use crate::domain::...`) and `ui::mod` re-exports `LinkRegion`. Every existing `crate::app::*` and `crate::ui::LinkRegion` reference across the handlers, UI, and main loop keeps resolving unchanged. The types are pure data with no methods, so nothing else moved.

After this, the only `domain -> app` reference left is a doc-comment link. This is the "cheap and unblocks the rest of the #352 extraction" change the issue describes.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66
- verified no `domain` source module imports `crate::app` or `crate::ui` (only a doc link remains)