### PR TITLE
refactor: move verify and profile key handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2339,50 +2339,7 @@ impl App {
 
     /// Handle a key press while the safety-number verify overlay is open.
     pub fn handle_verify_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        let action = classify_list_key(code, false);
-        // Any navigation cancels a pending confirmation, matching the original
-        // per-key reset.
-        if list_overlay::apply_nav(
-            &action,
-            &mut self.verify.index,
-            self.verify.identities.len(),
-        ) {
-            self.verify.confirming = false;
-            return None;
-        }
-        if action == ListKeyAction::Close {
-            self.verify.confirming = false;
-            self.close_overlay();
-            return None;
-        }
-        // 'v' and Enter both trigger verification; every other key cancels a
-        // pending confirm.
-        if action == ListKeyAction::Select || code == KeyCode::Char('v') {
-            if let Some(id) = self.verify.identities.get(self.verify.index) {
-                if id.safety_number.is_empty() {
-                    self.status_message = "Safety number not available — cannot verify".to_string();
-                    return None;
-                }
-                if self.verify.confirming {
-                    // Second press: actually trust with the specific safety number
-                    if let Some(ref number) = id.number {
-                        let recipient = number.clone();
-                        let safety_number = id.safety_number.clone();
-                        self.verify.confirming = false;
-                        return Some(SendRequest::TrustIdentity {
-                            recipient,
-                            safety_number,
-                        });
-                    }
-                } else {
-                    // First press: ask for confirmation
-                    self.verify.confirming = true;
-                }
-            }
-        } else {
-            self.verify.confirming = false;
-        }
-        None
+        crate::handlers::keys::handle_verify_key(self, code)
     }
 
     pub(crate) fn open_forward_picker(&mut self) {
@@ -4331,66 +4288,7 @@ impl App {
 
     /// Handle keys in the profile editor overlay.
     pub fn handle_profile_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        const FIELD_COUNT: usize = 4;
-        const SAVE_INDEX: usize = FIELD_COUNT;
-
-        if self.profile.editing {
-            // Editing a field
-            match code {
-                KeyCode::Esc => {
-                    // Cancel edit, discard buffer
-                    self.profile.editing = false;
-                }
-                KeyCode::Enter => {
-                    // Confirm edit, write buffer back to field
-                    self.profile.fields[self.profile.index] = self.profile.edit_buffer.clone();
-                    self.profile.editing = false;
-                }
-                KeyCode::Backspace => {
-                    self.profile.edit_buffer.pop();
-                }
-                KeyCode::Char(c) => {
-                    self.profile.edit_buffer.push(c);
-                }
-                _ => {}
-            }
-            return None;
-        }
-
-        // Navigation mode
-        let action = classify_list_key(code, false);
-        // The list is the editable fields plus the Save button (SAVE_INDEX).
-        if list_overlay::apply_nav(&action, &mut self.profile.index, SAVE_INDEX + 1) {
-            return None;
-        }
-        match code {
-            KeyCode::Enter => {
-                if self.profile.index < FIELD_COUNT {
-                    // Start editing the selected field
-                    self.profile.editing = true;
-                    self.profile.edit_buffer = self.profile.fields[self.profile.index].clone();
-                } else {
-                    // Save button
-                    let [given_name, family_name, about, about_emoji] = self.profile.fields.clone();
-                    if given_name.trim().is_empty() {
-                        self.status_message = "Given name is required".to_string();
-                        return None;
-                    }
-                    self.close_overlay();
-                    return Some(SendRequest::UpdateProfile {
-                        given_name,
-                        family_name,
-                        about,
-                        about_emoji,
-                    });
-                }
-            }
-            KeyCode::Esc => {
-                self.close_overlay();
-            }
-            _ => {}
-        }
-        None
+        crate::handlers::keys::handle_profile_key(self, code)
     }
 
     /// Handle a key press while the poll vote overlay is open.

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -293,3 +293,111 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
         _ => None,
     }
 }
+
+/// Handle a key press while the safety-number verify overlay is open.
+pub fn handle_verify_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    let action = classify_list_key(code, false);
+    // Any navigation cancels a pending confirmation, matching the original
+    // per-key reset.
+    if crate::list_overlay::apply_nav(&action, &mut app.verify.index, app.verify.identities.len()) {
+        app.verify.confirming = false;
+        return None;
+    }
+    if action == ListKeyAction::Close {
+        app.verify.confirming = false;
+        app.close_overlay();
+        return None;
+    }
+    // 'v' and Enter both trigger verification; every other key cancels a
+    // pending confirm.
+    if action == ListKeyAction::Select || code == KeyCode::Char('v') {
+        if let Some(id) = app.verify.identities.get(app.verify.index) {
+            if id.safety_number.is_empty() {
+                app.status_message = "Safety number not available — cannot verify".to_string();
+                return None;
+            }
+            if app.verify.confirming {
+                // Second press: actually trust with the specific safety number
+                if let Some(ref number) = id.number {
+                    let recipient = number.clone();
+                    let safety_number = id.safety_number.clone();
+                    app.verify.confirming = false;
+                    return Some(SendRequest::TrustIdentity {
+                        recipient,
+                        safety_number,
+                    });
+                }
+            } else {
+                // First press: ask for confirmation
+                app.verify.confirming = true;
+            }
+        }
+    } else {
+        app.verify.confirming = false;
+    }
+    None
+}
+
+/// Handle a key press while the profile editor overlay is open.
+pub fn handle_profile_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    const FIELD_COUNT: usize = 4;
+    const SAVE_INDEX: usize = FIELD_COUNT;
+
+    if app.profile.editing {
+        // Editing a field
+        match code {
+            KeyCode::Esc => {
+                // Cancel edit, discard buffer
+                app.profile.editing = false;
+            }
+            KeyCode::Enter => {
+                // Confirm edit, write buffer back to field
+                app.profile.fields[app.profile.index] = app.profile.edit_buffer.clone();
+                app.profile.editing = false;
+            }
+            KeyCode::Backspace => {
+                app.profile.edit_buffer.pop();
+            }
+            KeyCode::Char(c) => {
+                app.profile.edit_buffer.push(c);
+            }
+            _ => {}
+        }
+        return None;
+    }
+
+    // Navigation mode
+    let action = classify_list_key(code, false);
+    // The list is the editable fields plus the Save button (SAVE_INDEX).
+    if crate::list_overlay::apply_nav(&action, &mut app.profile.index, SAVE_INDEX + 1) {
+        return None;
+    }
+    match code {
+        KeyCode::Enter => {
+            if app.profile.index < FIELD_COUNT {
+                // Start editing the selected field
+                app.profile.editing = true;
+                app.profile.edit_buffer = app.profile.fields[app.profile.index].clone();
+            } else {
+                // Save button
+                let [given_name, family_name, about, about_emoji] = app.profile.fields.clone();
+                if given_name.trim().is_empty() {
+                    app.status_message = "Given name is required".to_string();
+                    return None;
+                }
+                app.close_overlay();
+                return Some(SendRequest::UpdateProfile {
+                    given_name,
+                    family_name,
+                    about,
+                    about_emoji,
+                });
+            }
+        }
+        KeyCode::Esc => {
+            app.close_overlay();
+        }
+        _ => {}
+    }
+    None
+}


### PR DESCRIPTION
## Summary

Continues the `handlers/` extraction one overlay at a time (the issue notes parallel work on this file conflicts, so this is a single-overlay-style slice). Follows the established poll/pin precedent already in `handlers/keys.rs`.

`handle_verify_key` and `handle_profile_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`. `app.rs` keeps one-line delegation shims, so every call site and the existing tests are unchanged.

## Why these two

Both are self-contained: they touch only `app.verify` / `app.profile`, `app.close_overlay()` (already `pub(crate)`), and `app.status_message` (a public field), with no private-helper dependencies that would need promotion. Both were also just covered by the #550 navigation tests, which still pass through the shims, so the move is verified behavior-preserving.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)