### PR TITLE
refactor: move delete-confirm key handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4140,85 +4140,12 @@ impl App {
     /// Handle a key press in the delete confirmation overlay.
     /// Returns Some(SendRequest::RemoteDelete) if remote delete is requested.
     pub fn handle_delete_confirm_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        match code {
-            KeyCode::Char('y') => {
-                self.close_overlay();
-                let conv_id = self.active_conversation.clone()?;
-                let conv = self.store.conversations.get(&conv_id)?;
-                let is_group = conv.is_group;
-                let index = self
-                    .scroll
-                    .focused_index
-                    .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
-                let msg = conv.messages.get(index)?;
-                let is_outgoing = msg.is_outgoing();
-                let target_timestamp = msg.timestamp_ms;
-
-                // Apply local delete
-                let conv = self.store.conversations.get_mut(&conv_id)?;
-                let msg = conv.messages.get_mut(index)?;
-                msg.is_deleted = true;
-                msg.body = "[deleted]".to_string();
-                msg.reactions.clear();
-                self.db_warn_visible(
-                    self.db.mark_message_deleted(&conv_id, target_timestamp),
-                    "mark_message_deleted",
-                );
-
-                // Send remote delete only for outgoing messages
-                if is_outgoing {
-                    return Some(SendRequest::RemoteDelete {
-                        recipient: conv_id,
-                        is_group,
-                        target_timestamp,
-                    });
-                }
-                None
-            }
-            KeyCode::Char('l') => {
-                // Local-only delete (for outgoing messages)
-                self.close_overlay();
-                let conv_id = self.active_conversation.clone()?;
-                let conv = self.store.conversations.get(&conv_id)?;
-                let index = self
-                    .scroll
-                    .focused_index
-                    .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
-                let msg = conv.messages.get(index)?;
-                let target_timestamp = msg.timestamp_ms;
-
-                let conv = self.store.conversations.get_mut(&conv_id)?;
-                let msg = conv.messages.get_mut(index)?;
-                msg.is_deleted = true;
-                msg.body = "[deleted]".to_string();
-                msg.reactions.clear();
-                self.db_warn_visible(
-                    self.db.mark_message_deleted(&conv_id, target_timestamp),
-                    "mark_message_deleted",
-                );
-                None
-            }
-            KeyCode::Char('n') | KeyCode::Esc => {
-                self.close_overlay();
-                None
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_delete_confirm_key(self, code)
     }
 
     /// Handle a key press in the delete-conversation confirmation overlay.
     pub fn handle_delete_conversation_confirm_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        match code {
-            KeyCode::Char('y') => {
-                self.close_overlay();
-                self.delete_active_conversation()
-            }
-            KeyCode::Char('n') | KeyCode::Esc => {
-                self.close_overlay();
-                None
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_delete_conversation_confirm_key(self, code)
     }
 
     /// Remove the active conversation from local state, the database, and any

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -294,6 +294,89 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
     }
 }
 
+/// Handle a key press in the message delete confirmation overlay.
+pub fn handle_delete_confirm_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    match code {
+        KeyCode::Char('y') => {
+            app.close_overlay();
+            let conv_id = app.active_conversation.clone()?;
+            let conv = app.store.conversations.get(&conv_id)?;
+            let is_group = conv.is_group;
+            let index = app
+                .scroll
+                .focused_index
+                .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
+            let msg = conv.messages.get(index)?;
+            let is_outgoing = msg.is_outgoing();
+            let target_timestamp = msg.timestamp_ms;
+
+            // Apply local delete
+            let conv = app.store.conversations.get_mut(&conv_id)?;
+            let msg = conv.messages.get_mut(index)?;
+            msg.is_deleted = true;
+            msg.body = "[deleted]".to_string();
+            msg.reactions.clear();
+            app.db_warn_visible(
+                app.db.mark_message_deleted(&conv_id, target_timestamp),
+                "mark_message_deleted",
+            );
+
+            // Send remote delete only for outgoing messages
+            if is_outgoing {
+                return Some(SendRequest::RemoteDelete {
+                    recipient: conv_id,
+                    is_group,
+                    target_timestamp,
+                });
+            }
+            None
+        }
+        KeyCode::Char('l') => {
+            // Local-only delete (for outgoing messages)
+            app.close_overlay();
+            let conv_id = app.active_conversation.clone()?;
+            let conv = app.store.conversations.get(&conv_id)?;
+            let index = app
+                .scroll
+                .focused_index
+                .unwrap_or_else(|| conv.messages.len().saturating_sub(1));
+            let msg = conv.messages.get(index)?;
+            let target_timestamp = msg.timestamp_ms;
+
+            let conv = app.store.conversations.get_mut(&conv_id)?;
+            let msg = conv.messages.get_mut(index)?;
+            msg.is_deleted = true;
+            msg.body = "[deleted]".to_string();
+            msg.reactions.clear();
+            app.db_warn_visible(
+                app.db.mark_message_deleted(&conv_id, target_timestamp),
+                "mark_message_deleted",
+            );
+            None
+        }
+        KeyCode::Char('n') | KeyCode::Esc => {
+            app.close_overlay();
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Handle a key press in the delete-conversation confirmation overlay.
+pub fn handle_delete_conversation_confirm_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    match code {
+        KeyCode::Char('y') => {
+            app.close_overlay();
+            app.delete_active_conversation()
+        }
+        KeyCode::Char('n') | KeyCode::Esc => {
+            app.close_overlay();
+            None
+        }
+        _ => None,
+    }
+}
+
 /// Handle a key press while the safety-number verify overlay is open.
 pub fn handle_verify_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
     let action = classify_list_key(code, false);


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing the one-overlay-at-a-time campaign after #553.

`handle_delete_confirm_key` and `handle_delete_conversation_confirm_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`, with one-line delegation shims left in `app.rs`.

They depend only on `pub(crate)` helpers (`close_overlay`, `db_warn_visible`, `delete_active_conversation`) and public fields, so the move is mechanical and behavior-preserving.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)