### PR TITLE
refactor: move contacts and forward picker handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2349,7 +2349,7 @@ impl App {
         self.update_forward_filter();
     }
 
-    fn update_forward_filter(&mut self) {
+    pub(crate) fn update_forward_filter(&mut self) {
         let filter = self.forward.filter.to_lowercase();
         self.forward.filtered = self
             .store
@@ -2376,97 +2376,11 @@ impl App {
     }
 
     pub fn handle_forward_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        let action = classify_list_key(code, true);
-        if list_overlay::apply_nav(
-            &action,
-            &mut self.forward.index,
-            self.forward.filtered.len(),
-        ) {
-            return None;
-        }
-        match action {
-            ListKeyAction::Select => {
-                if let Some((conv_id, name)) =
-                    self.forward.filtered.get(self.forward.index).cloned()
-                {
-                    let is_group = self
-                        .store
-                        .conversations
-                        .get(&conv_id)
-                        .map(|c| c.is_group)
-                        .unwrap_or(false);
-                    let body = format!("[Forwarded]\n{}", self.forward.body);
-                    let local_ts_ms = chrono::Utc::now().timestamp_millis();
-                    self.close_overlay();
-                    self.status_message = format!("Forwarded to {name}");
-                    self.store.move_conversation_to_top(&conv_id);
-                    return Some(SendRequest::Message {
-                        recipient: conv_id,
-                        body,
-                        is_group,
-                        local_ts_ms,
-                        mentions: Vec::new(),
-                        attachment: None,
-                        quote_timestamp: None,
-                        quote_author: None,
-                        quote_body: None,
-                    });
-                }
-            }
-            ListKeyAction::Close => {
-                self.close_overlay();
-            }
-            ListKeyAction::FilterPush(c) => {
-                if !c.is_control() {
-                    self.forward.filter.push(c);
-                    self.update_forward_filter();
-                }
-            }
-            ListKeyAction::FilterPop => {
-                self.forward.filter.pop();
-                self.update_forward_filter();
-            }
-            ListKeyAction::None | ListKeyAction::Up | ListKeyAction::Down => {}
-        }
-        None
+        crate::handlers::keys::handle_forward_key(self, code)
     }
 
     pub fn handle_contacts_key(&mut self, code: KeyCode) {
-        let action = classify_list_key(code, true);
-        if list_overlay::apply_nav(
-            &action,
-            &mut self.contacts_overlay.index,
-            self.contacts_overlay.filtered.len(),
-        ) {
-            return;
-        }
-        match action {
-            ListKeyAction::Select => {
-                if let Some((number, _)) = self
-                    .contacts_overlay
-                    .filtered
-                    .get(self.contacts_overlay.index)
-                {
-                    let number = number.clone();
-                    self.close_overlay();
-                    self.contacts_overlay.filter.clear();
-                    self.join_conversation(&number);
-                }
-            }
-            ListKeyAction::Close => {
-                self.close_overlay();
-                self.contacts_overlay.filter.clear();
-            }
-            ListKeyAction::FilterPush(c) => {
-                self.contacts_overlay.filter.push(c);
-                self.refresh_contacts_filter();
-            }
-            ListKeyAction::FilterPop => {
-                self.contacts_overlay.filter.pop();
-                self.refresh_contacts_filter();
-            }
-            ListKeyAction::None | ListKeyAction::Up | ListKeyAction::Down => {}
-        }
+        crate::handlers::keys::handle_contacts_key(self, code)
     }
 
     /// Handle a key press while the search overlay is open.

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -294,6 +294,96 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
     }
 }
 
+/// Handle a key press while the forward-message picker overlay is open.
+pub fn handle_forward_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    let action = classify_list_key(code, true);
+    if crate::list_overlay::apply_nav(&action, &mut app.forward.index, app.forward.filtered.len()) {
+        return None;
+    }
+    match action {
+        ListKeyAction::Select => {
+            if let Some((conv_id, name)) = app.forward.filtered.get(app.forward.index).cloned() {
+                let is_group = app
+                    .store
+                    .conversations
+                    .get(&conv_id)
+                    .map(|c| c.is_group)
+                    .unwrap_or(false);
+                let body = format!("[Forwarded]\n{}", app.forward.body);
+                let local_ts_ms = chrono::Utc::now().timestamp_millis();
+                app.close_overlay();
+                app.status_message = format!("Forwarded to {name}");
+                app.store.move_conversation_to_top(&conv_id);
+                return Some(SendRequest::Message {
+                    recipient: conv_id,
+                    body,
+                    is_group,
+                    local_ts_ms,
+                    mentions: Vec::new(),
+                    attachment: None,
+                    quote_timestamp: None,
+                    quote_author: None,
+                    quote_body: None,
+                });
+            }
+        }
+        ListKeyAction::Close => {
+            app.close_overlay();
+        }
+        ListKeyAction::FilterPush(c) => {
+            if !c.is_control() {
+                app.forward.filter.push(c);
+                app.update_forward_filter();
+            }
+        }
+        ListKeyAction::FilterPop => {
+            app.forward.filter.pop();
+            app.update_forward_filter();
+        }
+        ListKeyAction::None | ListKeyAction::Up | ListKeyAction::Down => {}
+    }
+    None
+}
+
+/// Handle a key press while the contacts picker overlay is open.
+pub fn handle_contacts_key(app: &mut App, code: KeyCode) {
+    let action = classify_list_key(code, true);
+    if crate::list_overlay::apply_nav(
+        &action,
+        &mut app.contacts_overlay.index,
+        app.contacts_overlay.filtered.len(),
+    ) {
+        return;
+    }
+    match action {
+        ListKeyAction::Select => {
+            if let Some((number, _)) = app
+                .contacts_overlay
+                .filtered
+                .get(app.contacts_overlay.index)
+            {
+                let number = number.clone();
+                app.close_overlay();
+                app.contacts_overlay.filter.clear();
+                app.join_conversation(&number);
+            }
+        }
+        ListKeyAction::Close => {
+            app.close_overlay();
+            app.contacts_overlay.filter.clear();
+        }
+        ListKeyAction::FilterPush(c) => {
+            app.contacts_overlay.filter.push(c);
+            app.refresh_contacts_filter();
+        }
+        ListKeyAction::FilterPop => {
+            app.contacts_overlay.filter.pop();
+            app.refresh_contacts_filter();
+        }
+        ListKeyAction::None | ListKeyAction::Up | ListKeyAction::Down => {}
+    }
+}
+
 /// Handle a key press in the message delete confirmation overlay.
 pub fn handle_delete_confirm_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
     match code {


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #554.

`handle_forward_key` and `handle_contacts_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`, with one-line delegation shims in `app.rs`.

`update_forward_filter` is promoted from private to `pub(crate)` so the moved forward handler can call it. The other dependencies were already accessible: `close_overlay`, `join_conversation`, `refresh_contacts_filter` (`pub(crate)`/`pub`), and `ConversationStore::move_conversation_to_top` (`pub`).

Behavior is unchanged (both are pure key-to-action dispatch over `forward` / `contacts_overlay` state).

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)