### PR TITLE
refactor: move message-request and reaction-picker handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1936,88 +1936,16 @@ impl App {
 
     /// Handle a key press while the message-request overlay is open.
     fn handle_message_request_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        let conv_id = match self.active_conversation.clone() {
-            Some(id) => id,
-            None => {
-                self.close_overlay();
-                return None;
-            }
-        };
-        match code {
-            KeyCode::Char('a') => {
-                let is_group = self
-                    .store
-                    .conversations
-                    .get(&conv_id)
-                    .map(|c| c.is_group)
-                    .unwrap_or(false);
-                if let Some(conv) = self.store.conversations.get_mut(&conv_id) {
-                    conv.accepted = true;
-                }
-                self.db_warn_visible(self.db.update_accepted(&conv_id, true), "update_accepted");
-                self.close_overlay();
-                Some(SendRequest::MessageRequestResponse {
-                    recipient: conv_id,
-                    is_group,
-                    response_type: "accept".to_string(),
-                })
-            }
-            KeyCode::Char('d') => {
-                self.close_overlay();
-                self.delete_active_conversation()
-            }
-            KeyCode::Esc => {
-                self.close_overlay();
-                self.active_conversation = None;
-                None
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_message_request_key(self, code)
     }
 
     fn handle_reaction_picker_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        match code {
-            KeyCode::Char('h') | KeyCode::Left => {
-                self.reactions.picker_index = self.reactions.picker_index.saturating_sub(1);
-                None
-            }
-            KeyCode::Char('l') | KeyCode::Right => {
-                if self.reactions.picker_index < QUICK_REACTIONS.len() - 1 {
-                    self.reactions.picker_index += 1;
-                }
-                None
-            }
-            KeyCode::Char(c @ '1'..='8') => {
-                let idx = (c as u8 - b'1') as usize;
-                if idx < QUICK_REACTIONS.len() {
-                    self.reactions.picker_index = idx;
-                    self.close_overlay();
-                    self.prepare_reaction_send()
-                } else {
-                    None
-                }
-            }
-            KeyCode::Enter | KeyCode::Char(' ') => {
-                self.close_overlay();
-                self.prepare_reaction_send()
-            }
-            KeyCode::Char('e') | KeyCode::Char('/') => {
-                // Open full emoji picker from reaction context
-                self.emoji_picker.open(EmojiPickerSource::Reaction, None);
-                self.open_overlay(OverlayKind::EmojiPicker);
-                None
-            }
-            KeyCode::Esc => {
-                self.close_overlay();
-                None
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_reaction_picker_key(self, code)
     }
 
     /// Build a SendRequest::Reaction from the current picker selection and focused message.
     /// If the user already reacted with the same emoji, removes it instead (toggle behavior).
-    fn prepare_reaction_send(&mut self) -> Option<SendRequest> {
+    pub(crate) fn prepare_reaction_send(&mut self) -> Option<SendRequest> {
         let emoji = QUICK_REACTIONS
             .get(self.reactions.picker_index)?
             .to_string();

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -11,7 +11,10 @@
 use chrono::Utc;
 use crossterm::event::KeyCode;
 
-use crate::app::{App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, SendRequest};
+use crate::app::{
+    App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, QUICK_REACTIONS, SendRequest,
+};
+use crate::domain::EmojiPickerSource;
 use crate::list_overlay::{ListKeyAction, classify_list_key};
 
 // ---------------------------------------------------------------------------
@@ -288,6 +291,88 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
         KeyCode::Esc => {
             app.close_overlay();
             app.poll_vote.pending = None;
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Handle a key press in the message-request (accept/delete) overlay.
+pub fn handle_message_request_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    let conv_id = match app.active_conversation.clone() {
+        Some(id) => id,
+        None => {
+            app.close_overlay();
+            return None;
+        }
+    };
+    match code {
+        KeyCode::Char('a') => {
+            let is_group = app
+                .store
+                .conversations
+                .get(&conv_id)
+                .map(|c| c.is_group)
+                .unwrap_or(false);
+            if let Some(conv) = app.store.conversations.get_mut(&conv_id) {
+                conv.accepted = true;
+            }
+            app.db_warn_visible(app.db.update_accepted(&conv_id, true), "update_accepted");
+            app.close_overlay();
+            Some(SendRequest::MessageRequestResponse {
+                recipient: conv_id,
+                is_group,
+                response_type: "accept".to_string(),
+            })
+        }
+        KeyCode::Char('d') => {
+            app.close_overlay();
+            app.delete_active_conversation()
+        }
+        KeyCode::Esc => {
+            app.close_overlay();
+            app.active_conversation = None;
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Handle a key press in the quick-reaction picker overlay.
+pub fn handle_reaction_picker_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    match code {
+        KeyCode::Char('h') | KeyCode::Left => {
+            app.reactions.picker_index = app.reactions.picker_index.saturating_sub(1);
+            None
+        }
+        KeyCode::Char('l') | KeyCode::Right => {
+            if app.reactions.picker_index < QUICK_REACTIONS.len() - 1 {
+                app.reactions.picker_index += 1;
+            }
+            None
+        }
+        KeyCode::Char(c @ '1'..='8') => {
+            let idx = (c as u8 - b'1') as usize;
+            if idx < QUICK_REACTIONS.len() {
+                app.reactions.picker_index = idx;
+                app.close_overlay();
+                app.prepare_reaction_send()
+            } else {
+                None
+            }
+        }
+        KeyCode::Enter | KeyCode::Char(' ') => {
+            app.close_overlay();
+            app.prepare_reaction_send()
+        }
+        KeyCode::Char('e') | KeyCode::Char('/') => {
+            // Open full emoji picker from reaction context
+            app.emoji_picker.open(EmojiPickerSource::Reaction, None);
+            app.open_overlay(OverlayKind::EmojiPicker);
+            None
+        }
+        KeyCode::Esc => {
+            app.close_overlay();
             None
         }
         _ => None,


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #555.

`handle_message_request_key` and `handle_reaction_picker_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`. Both were private and are called from the overlay dispatcher and a few tests, so `app.rs` keeps private method shims that delegate (the dispatcher and the tests are unchanged).

`prepare_reaction_send` is promoted from private to `pub(crate)` so the moved reaction handler can call it; `prepare_reaction_send_emoji` stays private (only used within `app.rs`).

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib, including the existing `handle_message_request_key` tests via the shim)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)