### PR TITLE
refactor: move theme and keybindings key handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -809,7 +809,7 @@ impl App {
     }
 
     /// Persist current settings to the config file.
-    fn save_settings(&self) {
+    pub(crate) fn save_settings(&self) {
         if self.is_demo {
             return;
         }
@@ -1283,163 +1283,12 @@ impl App {
 
     /// Handle a key press while the theme picker overlay is open.
     pub fn handle_theme_key(&mut self, code: KeyCode) {
-        // Theme-specific: space selects, q closes
-        let code = match code {
-            KeyCode::Char(' ') => KeyCode::Enter,
-            KeyCode::Char('q') => KeyCode::Esc,
-            other => other,
-        };
-        let action = classify_list_key(code, false);
-        if list_overlay::apply_nav(
-            &action,
-            &mut self.theme_picker.index,
-            self.theme_picker.available_themes.len(),
-        ) {
-            return;
-        }
-        match action {
-            ListKeyAction::Select => {
-                if let Some(selected) = self
-                    .theme_picker
-                    .available_themes
-                    .get(self.theme_picker.index)
-                {
-                    self.theme = selected.clone();
-                    self.save_settings();
-                }
-                self.close_overlay();
-            }
-            ListKeyAction::Close => {
-                self.close_overlay();
-            }
-            _ => {}
-        }
+        crate::handlers::keys::handle_theme_key(self, code)
     }
 
     /// Handle a key press while the keybindings overlay is open.
     pub fn handle_keybindings_key(&mut self, code: KeyCode) {
-        if self.keybindings_overlay.profile_picker {
-            match code {
-                KeyCode::Char('j') | KeyCode::Down
-                    if self.keybindings_overlay.profile_index
-                        < self
-                            .keybindings_overlay
-                            .available_profiles
-                            .len()
-                            .saturating_sub(1) =>
-                {
-                    self.keybindings_overlay.profile_index += 1;
-                }
-                KeyCode::Char('k') | KeyCode::Up => {
-                    self.keybindings_overlay.profile_index =
-                        self.keybindings_overlay.profile_index.saturating_sub(1);
-                }
-                KeyCode::Char(' ') | KeyCode::Enter => {
-                    if let Some(name) = self
-                        .keybindings_overlay
-                        .available_profiles
-                        .get(self.keybindings_overlay.profile_index)
-                    {
-                        let mut kb = keybindings::find_profile(name);
-                        let overrides = keybindings::load_overrides();
-                        kb.apply_overrides(&overrides);
-                        self.keybindings = kb;
-                        self.save_settings();
-                    }
-                    self.keybindings_overlay.profile_picker = false;
-                }
-                KeyCode::Esc => {
-                    self.keybindings_overlay.profile_picker = false;
-                }
-                _ => {}
-            }
-            return;
-        }
-
-        if let Some((displaced_action, _combo)) = self.keybindings_overlay.conflict.take() {
-            match code {
-                KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    // Accept: the displaced action loses its binding
-                    self.status_message = format!(
-                        "{} is now unbound",
-                        keybindings::action_label(displaced_action)
-                    );
-                }
-                _ => {
-                    // Undo the rebind — restore both
-                    let (mode, action) =
-                        self.keybindings_overlay_item(self.keybindings_overlay.index);
-                    if let Some(action) = action {
-                        self.keybindings.reset_action(mode, action);
-                        self.keybindings.reset_action(mode, displaced_action);
-                    }
-                    self.status_message.clear();
-                }
-            }
-            return;
-        }
-
-        let total = self.keybindings_overlay_total();
-        match code {
-            KeyCode::Char('j') | KeyCode::Down => {
-                if self.keybindings_overlay.index < total.saturating_sub(1) {
-                    self.keybindings_overlay.index += 1;
-                }
-                // Skip section headers
-                while self.keybindings_overlay.index < total
-                    && self
-                        .keybindings_overlay_item(self.keybindings_overlay.index)
-                        .1
-                        .is_none()
-                {
-                    self.keybindings_overlay.index += 1;
-                }
-            }
-            KeyCode::Char('k') | KeyCode::Up => {
-                self.keybindings_overlay.index = self.keybindings_overlay.index.saturating_sub(1);
-                // Skip section headers (index 0 is the profile row — always selectable)
-                while self.keybindings_overlay.index > 0
-                    && self
-                        .keybindings_overlay_item(self.keybindings_overlay.index)
-                        .1
-                        .is_none()
-                {
-                    self.keybindings_overlay.index =
-                        self.keybindings_overlay.index.saturating_sub(1);
-                }
-            }
-            KeyCode::Enter => {
-                if self.keybindings_overlay.index == 0 {
-                    // Profile row → open profile picker
-                    self.keybindings_overlay.profile_picker = true;
-                    self.keybindings_overlay.profile_index = self
-                        .keybindings_overlay
-                        .available_profiles
-                        .iter()
-                        .position(|n| *n == self.keybindings.profile_name)
-                        .unwrap_or(0);
-                } else {
-                    let (_, action) = self.keybindings_overlay_item(self.keybindings_overlay.index);
-                    if action.is_some() {
-                        self.keybindings_overlay.capturing = true;
-                        self.status_message = "Press a key combo...".to_string();
-                    }
-                }
-            }
-            KeyCode::Backspace => {
-                // Reset to profile default
-                let (mode, action) = self.keybindings_overlay_item(self.keybindings_overlay.index);
-                if let Some(action) = action {
-                    self.keybindings.reset_action(mode, action);
-                    self.status_message = format!("Reset {}", keybindings::action_label(action));
-                }
-            }
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.close_overlay();
-                self.save_settings();
-            }
-            _ => {}
-        }
+        crate::handlers::keys::handle_keybindings_key(self, code)
     }
 
     /// Handle keybinding capture: intercepts ALL keys when capturing a new binding.

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -15,6 +15,7 @@ use crate::app::{
     App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, QUICK_REACTIONS, SendRequest,
 };
 use crate::domain::EmojiPickerSource;
+use crate::keybindings;
 use crate::list_overlay::{ListKeyAction, classify_list_key};
 
 // ---------------------------------------------------------------------------
@@ -294,6 +295,165 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
             None
         }
         _ => None,
+    }
+}
+
+/// Handle a key press while the theme picker overlay is open.
+pub fn handle_theme_key(app: &mut App, code: KeyCode) {
+    // Theme-specific: space selects, q closes
+    let code = match code {
+        KeyCode::Char(' ') => KeyCode::Enter,
+        KeyCode::Char('q') => KeyCode::Esc,
+        other => other,
+    };
+    let action = classify_list_key(code, false);
+    if crate::list_overlay::apply_nav(
+        &action,
+        &mut app.theme_picker.index,
+        app.theme_picker.available_themes.len(),
+    ) {
+        return;
+    }
+    match action {
+        ListKeyAction::Select => {
+            if let Some(selected) = app
+                .theme_picker
+                .available_themes
+                .get(app.theme_picker.index)
+            {
+                app.theme = selected.clone();
+                app.save_settings();
+            }
+            app.close_overlay();
+        }
+        ListKeyAction::Close => {
+            app.close_overlay();
+        }
+        _ => {}
+    }
+}
+
+/// Handle a key press while the keybindings overlay is open.
+pub fn handle_keybindings_key(app: &mut App, code: KeyCode) {
+    if app.keybindings_overlay.profile_picker {
+        match code {
+            KeyCode::Char('j') | KeyCode::Down
+                if app.keybindings_overlay.profile_index
+                    < app
+                        .keybindings_overlay
+                        .available_profiles
+                        .len()
+                        .saturating_sub(1) =>
+            {
+                app.keybindings_overlay.profile_index += 1;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                app.keybindings_overlay.profile_index =
+                    app.keybindings_overlay.profile_index.saturating_sub(1);
+            }
+            KeyCode::Char(' ') | KeyCode::Enter => {
+                if let Some(name) = app
+                    .keybindings_overlay
+                    .available_profiles
+                    .get(app.keybindings_overlay.profile_index)
+                {
+                    let mut kb = keybindings::find_profile(name);
+                    let overrides = keybindings::load_overrides();
+                    kb.apply_overrides(&overrides);
+                    app.keybindings = kb;
+                    app.save_settings();
+                }
+                app.keybindings_overlay.profile_picker = false;
+            }
+            KeyCode::Esc => {
+                app.keybindings_overlay.profile_picker = false;
+            }
+            _ => {}
+        }
+        return;
+    }
+
+    if let Some((displaced_action, _combo)) = app.keybindings_overlay.conflict.take() {
+        match code {
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                // Accept: the displaced action loses its binding
+                app.status_message = format!(
+                    "{} is now unbound",
+                    keybindings::action_label(displaced_action)
+                );
+            }
+            _ => {
+                // Undo the rebind -- restore both
+                let (mode, action) = app.keybindings_overlay_item(app.keybindings_overlay.index);
+                if let Some(action) = action {
+                    app.keybindings.reset_action(mode, action);
+                    app.keybindings.reset_action(mode, displaced_action);
+                }
+                app.status_message.clear();
+            }
+        }
+        return;
+    }
+
+    let total = app.keybindings_overlay_total();
+    match code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            if app.keybindings_overlay.index < total.saturating_sub(1) {
+                app.keybindings_overlay.index += 1;
+            }
+            // Skip section headers
+            while app.keybindings_overlay.index < total
+                && app
+                    .keybindings_overlay_item(app.keybindings_overlay.index)
+                    .1
+                    .is_none()
+            {
+                app.keybindings_overlay.index += 1;
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            app.keybindings_overlay.index = app.keybindings_overlay.index.saturating_sub(1);
+            // Skip section headers (index 0 is the profile row -- always selectable)
+            while app.keybindings_overlay.index > 0
+                && app
+                    .keybindings_overlay_item(app.keybindings_overlay.index)
+                    .1
+                    .is_none()
+            {
+                app.keybindings_overlay.index = app.keybindings_overlay.index.saturating_sub(1);
+            }
+        }
+        KeyCode::Enter => {
+            if app.keybindings_overlay.index == 0 {
+                // Profile row -> open profile picker
+                app.keybindings_overlay.profile_picker = true;
+                app.keybindings_overlay.profile_index = app
+                    .keybindings_overlay
+                    .available_profiles
+                    .iter()
+                    .position(|n| *n == app.keybindings.profile_name)
+                    .unwrap_or(0);
+            } else {
+                let (_, action) = app.keybindings_overlay_item(app.keybindings_overlay.index);
+                if action.is_some() {
+                    app.keybindings_overlay.capturing = true;
+                    app.status_message = "Press a key combo...".to_string();
+                }
+            }
+        }
+        KeyCode::Backspace => {
+            // Reset to profile default
+            let (mode, action) = app.keybindings_overlay_item(app.keybindings_overlay.index);
+            if let Some(action) = action {
+                app.keybindings.reset_action(mode, action);
+                app.status_message = format!("Reset {}", keybindings::action_label(action));
+            }
+        }
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.close_overlay();
+            app.save_settings();
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #556.

`handle_theme_key` and `handle_keybindings_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`, with one-line delegation shims in `app.rs`.

`save_settings` is promoted from private to `pub(crate)` so the moved handlers can persist on selection. The keybindings overlay helpers they call (`keybindings_overlay_item`, `keybindings_overlay_total`) were already `pub`. `handle_keybinding_capture` (the capture-mode intercept) stays in `app.rs` for a later slice.

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)