### PR TITLE
refactor: move action-menu key handler into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -38,7 +38,7 @@ use crate::image_render::ImageProtocol;
 use crate::input::COMMANDS;
 use crate::input::{next_char_pos, prev_char_pos};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
-use crate::list_overlay::{self, ListKeyAction, classify_list_key};
+use crate::list_overlay::{self, classify_list_key};
 use crate::mute::MuteState;
 use crate::signal::types::{MessageStatus, Reaction, SignalEvent, TrustLevel};
 use crate::theme::{self, Theme};
@@ -1969,53 +1969,13 @@ impl App {
 
     /// Handle a key press while the action menu overlay is open.
     pub fn handle_action_menu_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        let item_count = self.action_menu_items().len();
-        if item_count == 0 {
-            self.close_overlay();
-            return None;
-        }
-        let action = classify_list_key(code, false);
-        if list_overlay::apply_nav(&action, &mut self.action_menu.index, item_count) {
-            return None;
-        }
-        match action {
-            ListKeyAction::Select => {
-                let items = self.action_menu_items();
-                if let Some(action) = items.get(self.action_menu.index) {
-                    let hint = action.key_hint;
-                    self.close_overlay();
-                    self.execute_action_by_hint(hint)
-                } else {
-                    self.close_overlay();
-                    None
-                }
-            }
-            ListKeyAction::Close => {
-                self.close_overlay();
-                None
-            }
-            ListKeyAction::None => {
-                // Action menu shortcut keys: parse the keypress into a hint,
-                // then check that the hint corresponds to an action currently
-                // present in the menu (the menu items vary by message state).
-                let KeyCode::Char(c) = code else { return None };
-                let hint = ActionMenuHint::from_char(c)?;
-                let items = self.action_menu_items();
-                if items.iter().any(|a| a.key_hint == hint) {
-                    self.close_overlay();
-                    self.execute_action_by_hint(hint)
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
+        crate::handlers::keys::handle_action_menu_key(self, code)
     }
 
     /// Execute an action by its hint. Reuses the same logic as the direct
     /// Normal-mode keybinds. Exhaustive match: adding a variant to
     /// [`ActionMenuHint`] is a compiler error here until handled.
-    fn execute_action_by_hint(&mut self, hint: ActionMenuHint) -> Option<SendRequest> {
+    pub(crate) fn execute_action_by_hint(&mut self, hint: ActionMenuHint) -> Option<SendRequest> {
         use crate::handlers::keys;
         match hint {
             ActionMenuHint::Reply => keys::execute_reply(self),

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -12,7 +12,8 @@ use chrono::Utc;
 use crossterm::event::KeyCode;
 
 use crate::app::{
-    App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, QUICK_REACTIONS, SendRequest,
+    ActionMenuHint, App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, QUICK_REACTIONS,
+    SendRequest,
 };
 use crate::domain::EmojiPickerSource;
 use crate::keybindings;
@@ -293,6 +294,51 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
             app.close_overlay();
             app.poll_vote.pending = None;
             None
+        }
+        _ => None,
+    }
+}
+
+/// Handle a key press while the per-message action menu overlay is open.
+pub fn handle_action_menu_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    let item_count = app.action_menu_items().len();
+    if item_count == 0 {
+        app.close_overlay();
+        return None;
+    }
+    let action = classify_list_key(code, false);
+    if crate::list_overlay::apply_nav(&action, &mut app.action_menu.index, item_count) {
+        return None;
+    }
+    match action {
+        ListKeyAction::Select => {
+            let items = app.action_menu_items();
+            if let Some(action) = items.get(app.action_menu.index) {
+                let hint = action.key_hint;
+                app.close_overlay();
+                app.execute_action_by_hint(hint)
+            } else {
+                app.close_overlay();
+                None
+            }
+        }
+        ListKeyAction::Close => {
+            app.close_overlay();
+            None
+        }
+        ListKeyAction::None => {
+            // Action menu shortcut keys: parse the keypress into a hint, then
+            // check that the hint corresponds to an action currently present in
+            // the menu (the menu items vary by message state).
+            let KeyCode::Char(c) = code else { return None };
+            let hint = ActionMenuHint::from_char(c)?;
+            let items = app.action_menu_items();
+            if items.iter().any(|a| a.key_hint == hint) {
+                app.close_overlay();
+                app.execute_action_by_hint(hint)
+            } else {
+                None
+            }
         }
         _ => None,
     }


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #557.

`handle_action_menu_key` moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`.

The dispatcher itself is small; the bulk (`execute_action_by_hint`) stays in `app.rs` and is promoted from private to `pub(crate)` so the moved handler can call it, alongside the already-`pub` `action_menu_items`. `ListKeyAction` is no longer pattern-matched in `app.rs`, so it is dropped from the `list_overlay` import there.

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)