### PR TITLE
refactor: move settings and customize key handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -38,7 +38,7 @@ use crate::image_render::ImageProtocol;
 use crate::input::COMMANDS;
 use crate::input::{next_char_pos, prev_char_pos};
 use crate::keybindings::{self, BindingMode, KeyAction, KeyBindings};
-use crate::list_overlay::{self, classify_list_key};
+use crate::list_overlay;
 use crate::mute::MuteState;
 use crate::signal::types::{MessageStatus, Reaction, SignalEvent, TrustLevel};
 use crate::theme::{self, Theme};
@@ -1006,81 +1006,12 @@ impl App {
     /// Navigation follows SETTINGS_VISUAL_ORDER so j/k matches the visual layout.
     /// After toggles: Preview at SETTINGS.len(), Image mode at +1, Customize at +2.
     pub fn handle_settings_key(&mut self, code: KeyCode) {
-        let preview_index = SETTINGS.len();
-        let image_mode_index = SETTINGS.len() + 1;
-        let customize_index = SETTINGS.len() + 2;
-
-        // Find current position in visual order
-        let visual_pos = SETTINGS_VISUAL_ORDER
-            .iter()
-            .position(|&i| i == self.settings_overlay.index)
-            .unwrap_or(0);
-
-        match code {
-            KeyCode::Char('j') | KeyCode::Down if visual_pos + 1 < SETTINGS_VISUAL_ORDER.len() => {
-                self.settings_overlay.index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
-            }
-            KeyCode::Char('k') | KeyCode::Up if visual_pos > 0 => {
-                self.settings_overlay.index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
-            }
-            KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
-                if self.settings_overlay.index == preview_index {
-                    self.notifications.notification_preview =
-                        self.notifications.notification_preview.cycle();
-                } else if self.settings_overlay.index == image_mode_index {
-                    self.image.image_mode = self.image.image_mode.cycle();
-                } else if self.settings_overlay.index == customize_index {
-                    self.open_overlay(OverlayKind::Customize);
-                    self.settings_overlay.customize_index = 0;
-                } else {
-                    self.toggle_setting(self.settings_overlay.index);
-                }
-            }
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.close_overlay();
-                self.save_settings();
-                self.fire_deferred_settings_hooks();
-            }
-            _ => {}
-        }
+        crate::handlers::keys::handle_settings_key(self, code)
     }
 
     /// Handle a key press in the Customize sub-menu (Theme, Keybindings, Profile).
     pub fn handle_customize_key(&mut self, code: KeyCode) {
-        const ITEMS: usize = 3; // Theme, Keybindings, Profile
-        let action = classify_list_key(code, false);
-        if list_overlay::apply_nav(&action, &mut self.settings_overlay.customize_index, ITEMS) {
-            return;
-        }
-        match code {
-            KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
-                self.close_overlay();
-                self.save_settings();
-                match self.settings_overlay.customize_index {
-                    0 => {
-                        self.open_overlay(OverlayKind::ThemePicker);
-                        self.theme_picker.index = self
-                            .theme_picker
-                            .available_themes
-                            .iter()
-                            .position(|t| t.name == self.theme.name)
-                            .unwrap_or(0);
-                    }
-                    1 => {
-                        self.open_overlay(OverlayKind::Keybindings);
-                        self.keybindings_overlay.index = 0;
-                    }
-                    2 => {
-                        self.open_settings_profile_manager();
-                    }
-                    _ => {}
-                }
-            }
-            KeyCode::Esc | KeyCode::Char('q') => {
-                self.close_overlay();
-            }
-            _ => {}
-        }
+        crate::handlers::keys::handle_customize_key(self, code)
     }
 
     /// Apply a profile without firing expensive hooks (image re-rendering).
@@ -1097,14 +1028,14 @@ impl App {
     /// Currently just the mouse-capture toggle: applying it immediately on each
     /// keystroke would clobber input mid-edit, so we queue the new state and
     /// `main.rs` flips the terminal mode on the next tick.
-    fn fire_deferred_settings_hooks(&mut self) {
+    pub(crate) fn fire_deferred_settings_hooks(&mut self) {
         if self.mouse.enabled != self.settings_overlay.mouse_snapshot {
             self.mouse.pending_toggle = Some(self.mouse.enabled);
         }
     }
 
     /// Open the settings profile manager overlay.
-    fn open_settings_profile_manager(&mut self) {
+    pub(crate) fn open_settings_profile_manager(&mut self) {
         self.settings_profiles.available = crate::settings_profile::all_settings_profiles();
         self.settings_profiles.index = self
             .settings_profiles

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -13,7 +13,7 @@ use crossterm::event::KeyCode;
 
 use crate::app::{
     ActionMenuHint, App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, QUICK_REACTIONS,
-    SendRequest,
+    SETTINGS, SETTINGS_VISUAL_ORDER, SendRequest,
 };
 use crate::domain::EmojiPickerSource;
 use crate::keybindings;
@@ -296,6 +296,85 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
             None
         }
         _ => None,
+    }
+}
+
+/// Handle a key press while the settings overlay is open.
+pub fn handle_settings_key(app: &mut App, code: KeyCode) {
+    let preview_index = SETTINGS.len();
+    let image_mode_index = SETTINGS.len() + 1;
+    let customize_index = SETTINGS.len() + 2;
+
+    // Find current position in visual order
+    let visual_pos = SETTINGS_VISUAL_ORDER
+        .iter()
+        .position(|&i| i == app.settings_overlay.index)
+        .unwrap_or(0);
+
+    match code {
+        KeyCode::Char('j') | KeyCode::Down if visual_pos + 1 < SETTINGS_VISUAL_ORDER.len() => {
+            app.settings_overlay.index = SETTINGS_VISUAL_ORDER[visual_pos + 1];
+        }
+        KeyCode::Char('k') | KeyCode::Up if visual_pos > 0 => {
+            app.settings_overlay.index = SETTINGS_VISUAL_ORDER[visual_pos - 1];
+        }
+        KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
+            if app.settings_overlay.index == preview_index {
+                app.notifications.notification_preview =
+                    app.notifications.notification_preview.cycle();
+            } else if app.settings_overlay.index == image_mode_index {
+                app.image.image_mode = app.image.image_mode.cycle();
+            } else if app.settings_overlay.index == customize_index {
+                app.open_overlay(OverlayKind::Customize);
+                app.settings_overlay.customize_index = 0;
+            } else {
+                app.toggle_setting(app.settings_overlay.index);
+            }
+        }
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.close_overlay();
+            app.save_settings();
+            app.fire_deferred_settings_hooks();
+        }
+        _ => {}
+    }
+}
+
+/// Handle a key press in the Customize sub-menu (Theme, Keybindings, Profile).
+pub fn handle_customize_key(app: &mut App, code: KeyCode) {
+    const ITEMS: usize = 3; // Theme, Keybindings, Profile
+    let action = classify_list_key(code, false);
+    if crate::list_overlay::apply_nav(&action, &mut app.settings_overlay.customize_index, ITEMS) {
+        return;
+    }
+    match code {
+        KeyCode::Char(' ') | KeyCode::Enter | KeyCode::Tab => {
+            app.close_overlay();
+            app.save_settings();
+            match app.settings_overlay.customize_index {
+                0 => {
+                    app.open_overlay(OverlayKind::ThemePicker);
+                    app.theme_picker.index = app
+                        .theme_picker
+                        .available_themes
+                        .iter()
+                        .position(|t| t.name == app.theme.name)
+                        .unwrap_or(0);
+                }
+                1 => {
+                    app.open_overlay(OverlayKind::Keybindings);
+                    app.keybindings_overlay.index = 0;
+                }
+                2 => {
+                    app.open_settings_profile_manager();
+                }
+                _ => {}
+            }
+        }
+        KeyCode::Esc | KeyCode::Char('q') => {
+            app.close_overlay();
+        }
+        _ => {}
     }
 }
 


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #558.

`handle_settings_key` and `handle_customize_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`, with one-line delegation shims in `app.rs`.

`fire_deferred_settings_hooks` and `open_settings_profile_manager` are promoted from private to `pub(crate)` so the moved handlers can call them. The settings consts (`SETTINGS`, `SETTINGS_VISUAL_ORDER`) and `toggle_setting` were already `pub`. With these handlers gone, `classify_list_key` has no remaining callers in `app.rs` and is dropped from the `list_overlay` import there.

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)