### PR TITLE
refactor: move search and file-browser key handlers into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2053,9 +2053,7 @@ impl App {
 
     /// Handle a key press while the search overlay is open.
     pub fn handle_search_key(&mut self, code: KeyCode) {
-        let active = self.active_conversation.as_deref().map(str::to_owned);
-        let action = self.search.handle_key(code, active.as_deref(), &self.db);
-        self.dispatch_search_action(action);
+        crate::handlers::keys::handle_search_key(self, code)
     }
 
     /// Jump to a message by its timestamp_ms in the active conversation.
@@ -2141,7 +2139,7 @@ impl App {
     }
 
     /// Dispatch a `SearchAction` returned by `SearchState` methods.
-    fn dispatch_search_action(&mut self, action: SearchAction) {
+    pub(crate) fn dispatch_search_action(&mut self, action: SearchAction) {
         match action {
             SearchAction::Select {
                 conv_id,
@@ -2177,16 +2175,7 @@ impl App {
 
     /// Handle a key press while the file browser overlay is open.
     pub fn handle_file_browser_key(&mut self, code: KeyCode) {
-        match self.file_picker.handle_key(code) {
-            crate::domain::FilePickerOutcome::Continue => {}
-            crate::domain::FilePickerOutcome::Selected(path) => {
-                self.pending_attachment = Some(path);
-                self.close_overlay();
-            }
-            crate::domain::FilePickerOutcome::Cancelled => {
-                self.close_overlay();
-            }
-        }
+        crate::handlers::keys::handle_file_browser_key(self, code)
     }
 
     /// Handle a key press while the autocomplete popup is visible.

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -299,6 +299,27 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
     }
 }
 
+/// Handle a key press while the message search overlay is open.
+pub fn handle_search_key(app: &mut App, code: KeyCode) {
+    let active = app.active_conversation.as_deref().map(str::to_owned);
+    let action = app.search.handle_key(code, active.as_deref(), &app.db);
+    app.dispatch_search_action(action);
+}
+
+/// Handle a key press while the file browser overlay is open.
+pub fn handle_file_browser_key(app: &mut App, code: KeyCode) {
+    match app.file_picker.handle_key(code) {
+        crate::domain::FilePickerOutcome::Continue => {}
+        crate::domain::FilePickerOutcome::Selected(path) => {
+            app.pending_attachment = Some(path);
+            app.close_overlay();
+        }
+        crate::domain::FilePickerOutcome::Cancelled => {
+            app.close_overlay();
+        }
+    }
+}
+
 /// Handle a key press while the settings overlay is open.
 pub fn handle_settings_key(app: &mut App, code: KeyCode) {
     let preview_index = SETTINGS.len();


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #559.

`handle_search_key` and `handle_file_browser_key` move from inline `impl App` methods into `handlers::keys` as free functions over `&mut App`, with one-line delegation shims in `app.rs`.

`dispatch_search_action` is promoted from private to `pub(crate)` so the moved search handler can call it (it stays in `app.rs`). The file-browser handler needed no promotions.

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)