### PR TITLE
refactor: move autocomplete key handler into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2024,47 +2024,7 @@ impl App {
     /// Returns `Some(SendRequest)` when the user submits a command
     /// that requires sending a message. Returns `None` otherwise.
     pub fn handle_autocomplete_key(&mut self, code: KeyCode) -> Option<SendRequest> {
-        let list_len = self.autocomplete.len();
-        match code {
-            KeyCode::Up => {
-                if list_len > 0 {
-                    self.autocomplete.index = if self.autocomplete.index == 0 {
-                        list_len - 1
-                    } else {
-                        self.autocomplete.index - 1
-                    };
-                }
-            }
-            KeyCode::Down => {
-                if list_len > 0 {
-                    self.autocomplete.index = (self.autocomplete.index + 1) % list_len;
-                }
-            }
-            KeyCode::Tab => {
-                self.apply_autocomplete();
-            }
-            KeyCode::Esc => {
-                self.autocomplete.clear();
-                if self.is_overlay(OverlayKind::Autocomplete) {
-                    self.close_overlay();
-                }
-            }
-            KeyCode::Enter => {
-                if self.autocomplete.mode == AutocompleteMode::Mention {
-                    self.apply_autocomplete();
-                    // Don't submit on Enter for mentions — just complete
-                } else {
-                    // Command and Join: apply + submit
-                    self.apply_autocomplete();
-                    return self.handle_input();
-                }
-            }
-            _ => {
-                self.apply_input_edit(code);
-                self.update_autocomplete();
-            }
-        }
-        None
+        crate::handlers::keys::handle_autocomplete_key(self, code)
     }
 
     pub fn new(account: String, db: Database, config_path: &std::path::Path) -> Self {

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -15,6 +15,7 @@ use crate::app::{
     ActionMenuHint, App, InputMode, OverlayKind, PIN_DURATIONS, PinPending, QUICK_REACTIONS,
     SETTINGS, SETTINGS_VISUAL_ORDER, SendRequest,
 };
+use crate::autocomplete::AutocompleteMode;
 use crate::domain::EmojiPickerSource;
 use crate::keybindings;
 use crate::list_overlay::{ListKeyAction, classify_list_key};
@@ -456,6 +457,53 @@ pub fn handle_settings_profile_manager_key(app: &mut App, code: KeyCode) {
         }
         _ => {}
     }
+}
+
+/// Handle a key press while the autocomplete popup is visible.
+/// Returns `Some(SendRequest)` when the user submits a command that requires
+/// sending a message. Returns `None` otherwise.
+pub fn handle_autocomplete_key(app: &mut App, code: KeyCode) -> Option<SendRequest> {
+    let list_len = app.autocomplete.len();
+    match code {
+        KeyCode::Up => {
+            if list_len > 0 {
+                app.autocomplete.index = if app.autocomplete.index == 0 {
+                    list_len - 1
+                } else {
+                    app.autocomplete.index - 1
+                };
+            }
+        }
+        KeyCode::Down => {
+            if list_len > 0 {
+                app.autocomplete.index = (app.autocomplete.index + 1) % list_len;
+            }
+        }
+        KeyCode::Tab => {
+            app.apply_autocomplete();
+        }
+        KeyCode::Esc => {
+            app.autocomplete.clear();
+            if app.is_overlay(OverlayKind::Autocomplete) {
+                app.close_overlay();
+            }
+        }
+        KeyCode::Enter => {
+            if app.autocomplete.mode == AutocompleteMode::Mention {
+                app.apply_autocomplete();
+                // Don't submit on Enter for mentions -- just complete
+            } else {
+                // Command and Join: apply + submit
+                app.apply_autocomplete();
+                return app.handle_input();
+            }
+        }
+        _ => {
+            app.apply_input_edit(code);
+            app.update_autocomplete();
+        }
+    }
+    None
 }
 
 /// Handle a key press while the message search overlay is open.


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #561.

`handle_autocomplete_key` moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`.

All of its dependencies (`apply_autocomplete`, `apply_input_edit`, `update_autocomplete`, `is_overlay`, `handle_input`) were already `pub`, so no promotions were needed; only `AutocompleteMode` needed importing into the handlers module.

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)