### PR TITLE
refactor: move keybinding-capture handler into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1066,44 +1066,7 @@ impl App {
 
     /// Handle keybinding capture: intercepts ALL keys when capturing a new binding.
     pub fn handle_keybinding_capture(&mut self, modifiers: KeyModifiers, code: KeyCode) {
-        if code == KeyCode::Esc && modifiers == KeyModifiers::NONE {
-            self.keybindings_overlay.capturing = false;
-            self.status_message.clear();
-            return;
-        }
-
-        let (mode, action) = self.keybindings_overlay_item(self.keybindings_overlay.index);
-        let Some(action) = action else {
-            self.keybindings_overlay.capturing = false;
-            return;
-        };
-
-        // Strip SHIFT for Char keys — case is encoded in the character itself
-        let modifiers = if matches!(code, KeyCode::Char(_)) {
-            modifiers - KeyModifiers::SHIFT
-        } else {
-            modifiers
-        };
-        let combo = keybindings::KeyCombo { modifiers, code };
-        let displaced = self.keybindings.rebind(mode, action, combo.clone());
-        self.keybindings_overlay.capturing = false;
-
-        if let Some(displaced_action) = displaced
-            && displaced_action != action
-        {
-            self.status_message = format!(
-                "'{}' was bound to {}. Accept? (y/n)",
-                keybindings::format_key_combo(&combo),
-                keybindings::action_label(displaced_action)
-            );
-            self.keybindings_overlay.conflict = Some((displaced_action, combo));
-            return;
-        }
-        self.status_message = format!(
-            "{} → {}",
-            keybindings::action_label(action),
-            keybindings::format_key_combo(&combo)
-        );
+        crate::handlers::keys::handle_keybinding_capture(self, modifiers, code)
     }
 
     /// Total number of rows in the keybindings overlay (profile + sections + actions).

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -9,7 +9,7 @@
 //! `app.rs` boundary.
 
 use chrono::Utc;
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyModifiers};
 
 use crate::app::{
     ActionMenuHint, App, GroupMenuHint, GroupMenuState, InputMode, OverlayKind, PIN_DURATIONS,
@@ -298,6 +298,48 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
         }
         _ => None,
     }
+}
+
+/// Handle keybinding capture: intercepts ALL keys when capturing a new binding.
+pub fn handle_keybinding_capture(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
+    if code == KeyCode::Esc && modifiers == KeyModifiers::NONE {
+        app.keybindings_overlay.capturing = false;
+        app.status_message.clear();
+        return;
+    }
+
+    let (mode, action) = app.keybindings_overlay_item(app.keybindings_overlay.index);
+    let Some(action) = action else {
+        app.keybindings_overlay.capturing = false;
+        return;
+    };
+
+    // Strip SHIFT for Char keys -- case is encoded in the character itself
+    let modifiers = if matches!(code, KeyCode::Char(_)) {
+        modifiers - KeyModifiers::SHIFT
+    } else {
+        modifiers
+    };
+    let combo = keybindings::KeyCombo { modifiers, code };
+    let displaced = app.keybindings.rebind(mode, action, combo.clone());
+    app.keybindings_overlay.capturing = false;
+
+    if let Some(displaced_action) = displaced
+        && displaced_action != action
+    {
+        app.status_message = format!(
+            "'{}' was bound to {}. Accept? (y/n)",
+            keybindings::format_key_combo(&combo),
+            keybindings::action_label(displaced_action)
+        );
+        app.keybindings_overlay.conflict = Some((displaced_action, combo));
+        return;
+    }
+    app.status_message = format!(
+        "{} \u{2192} {}",
+        keybindings::action_label(action),
+        keybindings::format_key_combo(&combo)
+    );
 }
 
 /// Handle a key press while the /group menu (and its sub-states) is open.


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #563.

`handle_keybinding_capture` moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`.

All of its dependencies (`keybindings_overlay_item`, the `keybindings` field and module functions, `status_message`) were already accessible, so no promotions were needed. The user-facing "action -> combo" status string keeps its `U+2192` arrow exactly (written as `\u{2192}`).

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)