### PR TITLE
refactor: move lock-screen key handler into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2361,32 +2361,7 @@ impl App {
     /// Backspace deletes, Esc clears the buffer (but does NOT unlock).
     /// Returns true if the key was consumed (always true when locked).
     pub fn handle_lock_key(&mut self, code: crossterm::event::KeyCode) -> bool {
-        use crossterm::event::KeyCode;
-        // Any char/Backspace clears the transient error so the user can retry.
-        // Leave error visible on Enter so a submit failure stays on screen.
-        if matches!(code, KeyCode::Char(_) | KeyCode::Backspace) {
-            self.lock.error = None;
-        }
-        match code {
-            KeyCode::Char(c) => {
-                self.lock.input_buffer.push(c);
-                true
-            }
-            KeyCode::Backspace => {
-                self.lock.input_buffer.pop();
-                true
-            }
-            KeyCode::Esc => {
-                // Esc clears the current input but does not unlock or change phase.
-                self.lock.input_buffer.clear();
-                true
-            }
-            KeyCode::Enter => {
-                self.submit_lock_input();
-                true
-            }
-            _ => true, // swallow all other keys; lock screen owns input fully
-        }
+        crate::handlers::keys::handle_lock_key(self, code)
     }
 
     /// Resolve an Enter press on the lock screen by advancing the phase
@@ -2400,7 +2375,7 @@ impl App {
     ///   stay and set the error.
     /// - ChangePassphraseNew: hash + save the new passphrase, transition
     ///   to Unlocked, clear old_passphrase_verified.
-    fn submit_lock_input(&mut self) {
+    pub(crate) fn submit_lock_input(&mut self) {
         use crate::domain::{LockPhase, hash_passphrase, load_hash, save_hash, verify_passphrase};
         let entered = std::mem::take(&mut self.lock.input_buffer);
         match self.lock.phase {

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -300,6 +300,36 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
     }
 }
 
+/// Handle a key press on the session lock screen. Returns true to signal the
+/// lock owns the key (it always does while the lock is up).
+pub fn handle_lock_key(app: &mut App, code: KeyCode) -> bool {
+    // Any char/Backspace clears the transient error so the user can retry.
+    // Leave error visible on Enter so a submit failure stays on screen.
+    if matches!(code, KeyCode::Char(_) | KeyCode::Backspace) {
+        app.lock.error = None;
+    }
+    match code {
+        KeyCode::Char(c) => {
+            app.lock.input_buffer.push(c);
+            true
+        }
+        KeyCode::Backspace => {
+            app.lock.input_buffer.pop();
+            true
+        }
+        KeyCode::Esc => {
+            // Esc clears the current input but does not unlock or change phase.
+            app.lock.input_buffer.clear();
+            true
+        }
+        KeyCode::Enter => {
+            app.submit_lock_input();
+            true
+        }
+        _ => true, // swallow all other keys; lock screen owns input fully
+    }
+}
+
 /// Handle keybinding capture: intercepts ALL keys when capturing a new binding.
 pub fn handle_keybinding_capture(app: &mut App, modifiers: KeyModifiers, code: KeyCode) {
     if code == KeyCode::Esc && modifiers == KeyModifiers::NONE {


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #564.

`handle_lock_key` moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`.

`submit_lock_input` (the passphrase state machine it calls on Enter) is promoted from private to `pub(crate)` and stays in `app.rs`.

The existing lock-screen tests call `handle_lock_key` through the shim and pass unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)