### PR TITLE
refactor: move overlay-key dispatcher into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -20,12 +20,12 @@ pub use crate::conversation_store::{Conversation, DisplayMessage, Quote};
 use crate::conversation_store::{ConversationStore, db_warn};
 use crate::db::Database;
 use crate::domain::{
-    ActionMenuState, ContactsOverlayState, EmojiPickerAction, EmojiPickerSource, EmojiPickerState,
-    FilePickerState, ForwardOverlayState, GroupMenuOverlayState, ImageState, InputState,
-    KeybindingsOverlayState, LockState, MouseState, NotificationState, PendingState,
-    PinDurationOverlayState, PollVoteOverlayState, ProfileOverlayState, ReactionState, ScrollState,
-    SearchAction, SearchState, SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState,
-    TypingState, VerifyOverlayState,
+    ActionMenuState, ContactsOverlayState, EmojiPickerState, FilePickerState, ForwardOverlayState,
+    GroupMenuOverlayState, ImageState, InputState, KeybindingsOverlayState, LockState, MouseState,
+    NotificationState, PendingState, PinDurationOverlayState, PollVoteOverlayState,
+    ProfileOverlayState, ReactionState, ScrollState, SearchAction, SearchState,
+    SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState, TypingState,
+    VerifyOverlayState,
 };
 // These value types were relocated into `domain` so the domain layer is a leaf
 // (#495). Re-export them here so existing `crate::app::*` references across the
@@ -1303,11 +1303,11 @@ impl App {
     }
 
     /// Handle a key press while the message-request overlay is open.
-    fn handle_message_request_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+    pub(crate) fn handle_message_request_key(&mut self, code: KeyCode) -> Option<SendRequest> {
         crate::handlers::keys::handle_message_request_key(self, code)
     }
 
-    fn handle_reaction_picker_key(&mut self, code: KeyCode) -> Option<SendRequest> {
+    pub(crate) fn handle_reaction_picker_key(&mut self, code: KeyCode) -> Option<SendRequest> {
         crate::handlers::keys::handle_reaction_picker_key(self, code)
     }
 
@@ -1322,7 +1322,7 @@ impl App {
 
     /// Build a SendRequest::Reaction for an arbitrary emoji string.
     /// If the user already reacted with the same emoji, removes it instead (toggle behavior).
-    fn prepare_reaction_send_emoji(&mut self, emoji: &str) -> Option<SendRequest> {
+    pub(crate) fn prepare_reaction_send_emoji(&mut self, emoji: &str) -> Option<SendRequest> {
         let conv_id = self.active_conversation.clone()?;
         let conv = self.store.conversations.get(&conv_id)?;
         let is_group = conv.is_group;
@@ -2112,7 +2112,7 @@ impl App {
     }
 
     /// Handle a key press while sidebar filter is active.
-    fn handle_sidebar_filter_key(&mut self, code: KeyCode) {
+    pub(crate) fn handle_sidebar_filter_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Esc => {
                 self.clear_sidebar_filter();
@@ -2557,129 +2557,7 @@ impl App {
     }
 
     pub fn handle_overlay_key(&mut self, code: KeyCode) -> (bool, Option<SendRequest>) {
-        let Some(kind) = self.active_overlay() else {
-            return (false, None);
-        };
-        match kind {
-            OverlayKind::SidebarFilter => {
-                self.handle_sidebar_filter_key(code);
-                (true, None)
-            }
-            OverlayKind::PollVote => {
-                let send = self.handle_poll_vote_key(code);
-                (true, send)
-            }
-            OverlayKind::PinDuration => {
-                let send = self.handle_pin_duration_key(code);
-                (true, send)
-            }
-            OverlayKind::ActionMenu => {
-                let send = self.handle_action_menu_key(code);
-                (true, send)
-            }
-            OverlayKind::DeleteConfirm => {
-                let send = self.handle_delete_confirm_key(code);
-                (true, send)
-            }
-            OverlayKind::DeleteConversationConfirm => {
-                let send = self.handle_delete_conversation_confirm_key(code);
-                (true, send)
-            }
-            OverlayKind::FilePicker => {
-                self.handle_file_browser_key(code);
-                (true, None)
-            }
-            OverlayKind::EmojiPicker => match self.emoji_picker.handle_key(code) {
-                EmojiPickerAction::Select(emoji) => {
-                    let source = self.emoji_picker.source;
-                    self.emoji_picker.close();
-                    match source {
-                        EmojiPickerSource::Input => {
-                            self.input.buffer.insert_str(self.input.cursor, &emoji);
-                            self.input.cursor += emoji.len();
-                            (true, None)
-                        }
-                        EmojiPickerSource::Reaction => {
-                            let send = self.prepare_reaction_send_emoji(&emoji);
-                            (true, send)
-                        }
-                    }
-                }
-                EmojiPickerAction::Close => {
-                    let was_reaction = self.emoji_picker.source == EmojiPickerSource::Reaction;
-                    self.emoji_picker.close();
-                    if was_reaction {
-                        self.open_overlay(OverlayKind::ReactionPicker);
-                    }
-                    (true, None)
-                }
-                EmojiPickerAction::None => (true, None),
-            },
-            OverlayKind::ReactionPicker => {
-                let send = self.handle_reaction_picker_key(code);
-                (true, send)
-            }
-            OverlayKind::MessageRequest => {
-                let send = self.handle_message_request_key(code);
-                (true, send)
-            }
-            OverlayKind::GroupMenu => {
-                let send = self.handle_group_menu_key(code);
-                (true, send)
-            }
-            OverlayKind::About => {
-                self.close_overlay();
-                (true, None)
-            }
-            OverlayKind::Profile => {
-                let send = self.handle_profile_key(code);
-                (true, send)
-            }
-            OverlayKind::Help => {
-                self.close_overlay();
-                (true, None)
-            }
-            OverlayKind::Verify => {
-                let send = self.handle_verify_key(code);
-                (true, send)
-            }
-            OverlayKind::Forward => {
-                let send = self.handle_forward_key(code);
-                (true, send)
-            }
-            OverlayKind::Contacts => {
-                self.handle_contacts_key(code);
-                (true, None)
-            }
-            OverlayKind::Search => {
-                self.handle_search_key(code);
-                (true, None)
-            }
-            OverlayKind::SettingsProfiles => {
-                self.handle_settings_profile_manager_key(code);
-                (true, None)
-            }
-            OverlayKind::ThemePicker => {
-                self.handle_theme_key(code);
-                (true, None)
-            }
-            OverlayKind::Keybindings => {
-                self.handle_keybindings_key(code);
-                (true, None)
-            }
-            OverlayKind::Customize => {
-                self.handle_customize_key(code);
-                (true, None)
-            }
-            OverlayKind::Settings => {
-                self.handle_settings_key(code);
-                (true, None)
-            }
-            OverlayKind::Autocomplete => {
-                let send = self.handle_autocomplete_key(code);
-                (true, send)
-            }
-        }
+        crate::handlers::keys::handle_overlay_key(self, code)
     }
 
     /// Handle Normal mode key. Dispatches to scroll, edit, or action sub-handlers.

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -16,7 +16,7 @@ use crate::app::{
     PinPending, QUICK_REACTIONS, SETTINGS, SETTINGS_VISUAL_ORDER, SendRequest,
 };
 use crate::autocomplete::AutocompleteMode;
-use crate::domain::EmojiPickerSource;
+use crate::domain::{EmojiPickerAction, EmojiPickerSource};
 use crate::keybindings;
 use crate::list_overlay::{ListKeyAction, classify_list_key};
 
@@ -297,6 +297,134 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
             None
         }
         _ => None,
+    }
+}
+
+/// Route a key press to the handler for the currently active overlay. Returns
+/// `(handled, maybe_send)` -- `handled` is false only when no overlay is open.
+pub fn handle_overlay_key(app: &mut App, code: KeyCode) -> (bool, Option<SendRequest>) {
+    let Some(kind) = app.active_overlay() else {
+        return (false, None);
+    };
+    match kind {
+        OverlayKind::SidebarFilter => {
+            app.handle_sidebar_filter_key(code);
+            (true, None)
+        }
+        OverlayKind::PollVote => {
+            let send = app.handle_poll_vote_key(code);
+            (true, send)
+        }
+        OverlayKind::PinDuration => {
+            let send = app.handle_pin_duration_key(code);
+            (true, send)
+        }
+        OverlayKind::ActionMenu => {
+            let send = app.handle_action_menu_key(code);
+            (true, send)
+        }
+        OverlayKind::DeleteConfirm => {
+            let send = app.handle_delete_confirm_key(code);
+            (true, send)
+        }
+        OverlayKind::DeleteConversationConfirm => {
+            let send = app.handle_delete_conversation_confirm_key(code);
+            (true, send)
+        }
+        OverlayKind::FilePicker => {
+            app.handle_file_browser_key(code);
+            (true, None)
+        }
+        OverlayKind::EmojiPicker => match app.emoji_picker.handle_key(code) {
+            EmojiPickerAction::Select(emoji) => {
+                let source = app.emoji_picker.source;
+                app.emoji_picker.close();
+                match source {
+                    EmojiPickerSource::Input => {
+                        app.input.buffer.insert_str(app.input.cursor, &emoji);
+                        app.input.cursor += emoji.len();
+                        (true, None)
+                    }
+                    EmojiPickerSource::Reaction => {
+                        let send = app.prepare_reaction_send_emoji(&emoji);
+                        (true, send)
+                    }
+                }
+            }
+            EmojiPickerAction::Close => {
+                let was_reaction = app.emoji_picker.source == EmojiPickerSource::Reaction;
+                app.emoji_picker.close();
+                if was_reaction {
+                    app.open_overlay(OverlayKind::ReactionPicker);
+                }
+                (true, None)
+            }
+            EmojiPickerAction::None => (true, None),
+        },
+        OverlayKind::ReactionPicker => {
+            let send = app.handle_reaction_picker_key(code);
+            (true, send)
+        }
+        OverlayKind::MessageRequest => {
+            let send = app.handle_message_request_key(code);
+            (true, send)
+        }
+        OverlayKind::GroupMenu => {
+            let send = app.handle_group_menu_key(code);
+            (true, send)
+        }
+        OverlayKind::About => {
+            app.close_overlay();
+            (true, None)
+        }
+        OverlayKind::Profile => {
+            let send = app.handle_profile_key(code);
+            (true, send)
+        }
+        OverlayKind::Help => {
+            app.close_overlay();
+            (true, None)
+        }
+        OverlayKind::Verify => {
+            let send = app.handle_verify_key(code);
+            (true, send)
+        }
+        OverlayKind::Forward => {
+            let send = app.handle_forward_key(code);
+            (true, send)
+        }
+        OverlayKind::Contacts => {
+            app.handle_contacts_key(code);
+            (true, None)
+        }
+        OverlayKind::Search => {
+            app.handle_search_key(code);
+            (true, None)
+        }
+        OverlayKind::SettingsProfiles => {
+            app.handle_settings_profile_manager_key(code);
+            (true, None)
+        }
+        OverlayKind::ThemePicker => {
+            app.handle_theme_key(code);
+            (true, None)
+        }
+        OverlayKind::Keybindings => {
+            app.handle_keybindings_key(code);
+            (true, None)
+        }
+        OverlayKind::Customize => {
+            app.handle_customize_key(code);
+            (true, None)
+        }
+        OverlayKind::Settings => {
+            app.handle_settings_key(code);
+            (true, None)
+        }
+        OverlayKind::Autocomplete => {
+            let send = app.handle_autocomplete_key(code);
+            (true, send)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Continuing the `handlers/` extraction (#494) after #565. This moves the central dispatcher.

`handle_overlay_key` (the 26-arm dispatcher that routes each open overlay to its key handler) moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`. It mostly delegates to the per-overlay handlers already extracted in earlier slices, plus the inline emoji-picker branch.

Promotions:
- `prepare_reaction_send_emoji` -> `pub(crate)` (for the emoji Reaction path)
- the three remaining private method shims it dispatches to (`handle_sidebar_filter_key`, `handle_message_request_key`, `handle_reaction_picker_key`) -> `pub(crate)`

With the emoji branch moved out, `EmojiPickerAction` / `EmojiPickerSource` are no longer used in `app.rs` and are dropped from its imports.

The existing `handle_overlay_key` tests call through the shim and pass unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)