### PR TITLE
refactor: move global-key handler into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2451,66 +2451,7 @@ impl App {
     /// Handle global keys that work in both Normal and Insert mode.
     /// Returns true if the key was consumed.
     pub fn handle_global_key(&mut self, modifiers: KeyModifiers, code: KeyCode) -> bool {
-        if self.lock.is_locked() {
-            return self.handle_lock_key(code);
-        }
-        let action = self
-            .keybindings
-            .resolve(modifiers, code, BindingMode::Global);
-        if self.quit_confirm && !matches!(action, Some(KeyAction::Quit)) {
-            self.quit_confirm = false;
-            self.update_status();
-        }
-        match action {
-            Some(KeyAction::Quit) => {
-                if self.input.buffer.is_empty() || self.quit_confirm {
-                    self.should_quit = true;
-                } else {
-                    self.quit_confirm = true;
-                }
-                true
-            }
-            Some(KeyAction::NextConversation) if !self.is_overlay(OverlayKind::Autocomplete) => {
-                self.next_conversation();
-                true
-            }
-            Some(KeyAction::PrevConversation) => {
-                self.prev_conversation();
-                true
-            }
-            Some(KeyAction::ResizeSidebarLeft) => {
-                self.resize_sidebar(-2);
-                true
-            }
-            Some(KeyAction::ResizeSidebarRight) => {
-                self.resize_sidebar(2);
-                true
-            }
-            Some(KeyAction::PageScrollUp) => {
-                self.sync.user_scrolled = true;
-                self.scroll.offset = self.scroll.offset.saturating_add(5);
-                self.scroll.focused_index = None;
-                true
-            }
-            Some(KeyAction::PageScrollDown) => {
-                self.sync.user_scrolled = true;
-                self.scroll.offset = self.scroll.offset.saturating_sub(5);
-                self.scroll.focused_index = None;
-                true
-            }
-            Some(KeyAction::SidebarSearch) => {
-                self.sidebar_visible = true;
-                self.open_overlay(OverlayKind::SidebarFilter);
-                self.sidebar_filter.clear();
-                self.sidebar_filtered.clear();
-                true
-            }
-            Some(KeyAction::Lock) => {
-                self.lock_now();
-                true
-            }
-            _ => false,
-        }
+        crate::handlers::keys::handle_global_key(self, modifiers, code)
     }
 
     /// Handle overlay keys (help, contacts, settings, autocomplete).

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -17,7 +17,7 @@ use crate::app::{
 };
 use crate::autocomplete::AutocompleteMode;
 use crate::domain::{EmojiPickerAction, EmojiPickerSource};
-use crate::keybindings;
+use crate::keybindings::{self, BindingMode, KeyAction};
 use crate::list_overlay::{ListKeyAction, classify_list_key};
 
 // ---------------------------------------------------------------------------
@@ -297,6 +297,71 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
             None
         }
         _ => None,
+    }
+}
+
+/// Handle a global keybinding (active in both Normal and Insert mode). Returns
+/// true if the key was consumed. When locked, all keys route to the lock screen.
+pub fn handle_global_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) -> bool {
+    if app.lock.is_locked() {
+        return app.handle_lock_key(code);
+    }
+    let action = app
+        .keybindings
+        .resolve(modifiers, code, BindingMode::Global);
+    if app.quit_confirm && !matches!(action, Some(KeyAction::Quit)) {
+        app.quit_confirm = false;
+        app.update_status();
+    }
+    match action {
+        Some(KeyAction::Quit) => {
+            if app.input.buffer.is_empty() || app.quit_confirm {
+                app.should_quit = true;
+            } else {
+                app.quit_confirm = true;
+            }
+            true
+        }
+        Some(KeyAction::NextConversation) if !app.is_overlay(OverlayKind::Autocomplete) => {
+            app.next_conversation();
+            true
+        }
+        Some(KeyAction::PrevConversation) => {
+            app.prev_conversation();
+            true
+        }
+        Some(KeyAction::ResizeSidebarLeft) => {
+            app.resize_sidebar(-2);
+            true
+        }
+        Some(KeyAction::ResizeSidebarRight) => {
+            app.resize_sidebar(2);
+            true
+        }
+        Some(KeyAction::PageScrollUp) => {
+            app.sync.user_scrolled = true;
+            app.scroll.offset = app.scroll.offset.saturating_add(5);
+            app.scroll.focused_index = None;
+            true
+        }
+        Some(KeyAction::PageScrollDown) => {
+            app.sync.user_scrolled = true;
+            app.scroll.offset = app.scroll.offset.saturating_sub(5);
+            app.scroll.focused_index = None;
+            true
+        }
+        Some(KeyAction::SidebarSearch) => {
+            app.sidebar_visible = true;
+            app.open_overlay(OverlayKind::SidebarFilter);
+            app.sidebar_filter.clear();
+            app.sidebar_filtered.clear();
+            true
+        }
+        Some(KeyAction::Lock) => {
+            app.lock_now();
+            true
+        }
+        _ => false,
     }
 }
 


### PR DESCRIPTION
## Summary

Next slice of the `handlers/` extraction (#494), continuing after #566.

`handle_global_key` (the mode-independent keybinding handler: quit, conversation switch, sidebar resize/search, page scroll, lock) moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`.

All of its helpers (`resize_sidebar`, `next/prev_conversation`, `update_status`, `lock_now`, `handle_lock_key`) were already `pub`/`pub(crate)`; only `BindingMode` and `KeyAction` needed importing into the handlers module.

Behavior is unchanged.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)