### PR TITLE
refactor: move Insert-mode key handler into handlers/keys (#494)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2281,7 +2281,7 @@ impl App {
     }
 
     /// Build a Typing SendRequest for the active conversation, or None if no conversation is active.
-    fn build_typing_request(&self, stop: bool) -> Option<SendRequest> {
+    pub(crate) fn build_typing_request(&self, stop: bool) -> Option<SendRequest> {
         let conv_id = self.active_conversation.as_ref()?;
         let is_group = self
             .store
@@ -2517,158 +2517,7 @@ impl App {
         modifiers: KeyModifiers,
         code: KeyCode,
     ) -> Option<SendRequest> {
-        match self
-            .keybindings
-            .resolve(modifiers, code, BindingMode::Insert)
-        {
-            Some(KeyAction::ExitInsert) => {
-                self.mode = InputMode::Normal;
-                self.pending_normal_key = None; // defensive reset
-                self.close_overlay();
-                self.reply_target = None;
-                self.editing_message = None;
-                if self.typing.reset() {
-                    return self.build_typing_request(true);
-                }
-                None
-            }
-            Some(KeyAction::InsertNewline) => {
-                self.input.buffer.insert(self.input.cursor, '\n');
-                self.input.cursor += 1;
-                self.close_overlay();
-                self.typing.last_keypress = Some(Instant::now());
-                if !self.typing.sent
-                    && !self.input.buffer.starts_with('/')
-                    && self
-                        .active_conversation
-                        .as_ref()
-                        .is_some_and(|id| !self.blocked_conversations.contains(id))
-                {
-                    self.typing.sent = true;
-                    return self.build_typing_request(false);
-                }
-                None
-            }
-            Some(KeyAction::SendMessage) => {
-                let was_typing = self.typing.reset();
-                let result = self.handle_input();
-                if result.is_some() {
-                    result
-                } else if was_typing {
-                    self.build_typing_request(true)
-                } else {
-                    None
-                }
-            }
-            Some(KeyAction::DeleteWordBack) => {
-                self.delete_word_back();
-                None
-            }
-            // Actions that alternative profiles (Emacs/Minimal) may bind in Insert mode
-            Some(KeyAction::ScrollDown) => {
-                self.sync.user_scrolled = true;
-                self.scroll.offset = self.scroll.offset.saturating_sub(1);
-                self.scroll.focused_index = None;
-                None
-            }
-            Some(KeyAction::ScrollUp) => {
-                self.sync.user_scrolled = true;
-                self.scroll.offset = self.scroll.offset.saturating_add(1);
-                self.scroll.focused_index = None;
-                None
-            }
-            Some(KeyAction::CursorLeft) => {
-                self.input.cursor = prev_char_pos(&self.input.buffer, self.input.cursor);
-                None
-            }
-            Some(KeyAction::CursorRight) => {
-                self.input.cursor = next_char_pos(&self.input.buffer, self.input.cursor);
-                None
-            }
-            Some(KeyAction::LineStart) => {
-                self.input.cursor = self.current_line_start();
-                None
-            }
-            Some(KeyAction::LineEnd) => {
-                self.input.cursor = self.current_line_end();
-                None
-            }
-            Some(KeyAction::DeleteChar) => {
-                if self.input.cursor < self.input.buffer.len() {
-                    self.input.buffer.remove(self.input.cursor);
-                }
-                None
-            }
-            Some(KeyAction::DeleteToEnd) => {
-                let line_end = self.current_line_end();
-                self.input.buffer.drain(self.input.cursor..line_end);
-                None
-            }
-            Some(KeyAction::CopyMessage) => {
-                self.copy_selected_message(false);
-                None
-            }
-            Some(KeyAction::CopyAllMessages) => {
-                self.copy_selected_message(true);
-                None
-            }
-            Some(KeyAction::React) => crate::handlers::keys::execute_react(self),
-            Some(KeyAction::Quote) => crate::handlers::keys::execute_reply(self),
-            Some(KeyAction::EditMessage) => crate::handlers::keys::execute_edit(self),
-            Some(KeyAction::ForwardMessage) => crate::handlers::keys::execute_forward(self),
-            Some(KeyAction::DeleteMessage) => crate::handlers::keys::execute_delete_confirm(self),
-            Some(KeyAction::NextSearchResult) => {
-                crate::handlers::keys::execute_search_jump(self, true)
-            }
-            Some(KeyAction::PrevSearchResult) => {
-                crate::handlers::keys::execute_search_jump(self, false)
-            }
-            Some(KeyAction::OpenActionMenu) => {
-                crate::handlers::keys::execute_open_action_menu(self)
-            }
-            Some(KeyAction::PinMessage) => crate::handlers::keys::execute_pin_toggle(self),
-            Some(KeyAction::JumpToQuote) => {
-                self.jump_to_quote();
-                None
-            }
-            Some(KeyAction::JumpBack) => {
-                self.jump_back();
-                None
-            }
-            _ => {
-                let needs_ac_update = matches!(
-                    code,
-                    KeyCode::Backspace | KeyCode::Delete | KeyCode::Char(_)
-                );
-                self.apply_input_edit(code);
-                if needs_ac_update {
-                    self.update_autocomplete();
-                }
-                if matches!(
-                    code,
-                    KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
-                ) {
-                    self.typing.last_keypress = Some(Instant::now());
-                    if self.input.buffer.is_empty() && self.typing.sent {
-                        self.typing.sent = false;
-                        self.typing.last_keypress = None;
-                        return self.build_typing_request(true);
-                    }
-                    if !self.typing.sent
-                        && !self.input.buffer.is_empty()
-                        && !self.input.buffer.starts_with('/')
-                        && self
-                            .active_conversation
-                            .as_ref()
-                            .is_some_and(|id| !self.blocked_conversations.contains(id))
-                    {
-                        self.typing.sent = true;
-                        return self.build_typing_request(false);
-                    }
-                }
-                None
-            }
-        }
+        crate::handlers::keys::handle_insert_key(self, modifiers, code)
     }
 
     /// Handle an event from signal-cli
@@ -3278,7 +3127,7 @@ impl App {
     }
 
     /// Delete the word before the cursor (Ctrl+W behavior).
-    fn delete_word_back(&mut self) {
+    pub(crate) fn delete_word_back(&mut self) {
         if self.input.cursor == 0 {
             return;
         }

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -8,6 +8,8 @@
 //! calls are now internal to `handlers::keys` rather than crossing the
 //! `app.rs` boundary.
 
+use std::time::Instant;
+
 use chrono::Utc;
 use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -298,6 +300,161 @@ pub fn handle_poll_vote_key(app: &mut App, code: KeyCode) -> Option<SendRequest>
             None
         }
         _ => None,
+    }
+}
+
+/// Handle an Insert-mode key. Edits the composer and drives typing-indicator
+/// dispatch; alternative keybinding profiles may also bind message actions here.
+pub fn handle_insert_key(
+    app: &mut App,
+    modifiers: KeyModifiers,
+    code: KeyCode,
+) -> Option<SendRequest> {
+    match app
+        .keybindings
+        .resolve(modifiers, code, BindingMode::Insert)
+    {
+        Some(KeyAction::ExitInsert) => {
+            app.mode = InputMode::Normal;
+            app.pending_normal_key = None; // defensive reset
+            app.close_overlay();
+            app.reply_target = None;
+            app.editing_message = None;
+            if app.typing.reset() {
+                return app.build_typing_request(true);
+            }
+            None
+        }
+        Some(KeyAction::InsertNewline) => {
+            app.input.buffer.insert(app.input.cursor, '\n');
+            app.input.cursor += 1;
+            app.close_overlay();
+            app.typing.last_keypress = Some(Instant::now());
+            if !app.typing.sent
+                && !app.input.buffer.starts_with('/')
+                && app
+                    .active_conversation
+                    .as_ref()
+                    .is_some_and(|id| !app.blocked_conversations.contains(id))
+            {
+                app.typing.sent = true;
+                return app.build_typing_request(false);
+            }
+            None
+        }
+        Some(KeyAction::SendMessage) => {
+            let was_typing = app.typing.reset();
+            let result = app.handle_input();
+            if result.is_some() {
+                result
+            } else if was_typing {
+                app.build_typing_request(true)
+            } else {
+                None
+            }
+        }
+        Some(KeyAction::DeleteWordBack) => {
+            app.delete_word_back();
+            None
+        }
+        // Actions that alternative profiles (Emacs/Minimal) may bind in Insert mode
+        Some(KeyAction::ScrollDown) => {
+            app.sync.user_scrolled = true;
+            app.scroll.offset = app.scroll.offset.saturating_sub(1);
+            app.scroll.focused_index = None;
+            None
+        }
+        Some(KeyAction::ScrollUp) => {
+            app.sync.user_scrolled = true;
+            app.scroll.offset = app.scroll.offset.saturating_add(1);
+            app.scroll.focused_index = None;
+            None
+        }
+        Some(KeyAction::CursorLeft) => {
+            app.input.cursor = prev_char_pos(&app.input.buffer, app.input.cursor);
+            None
+        }
+        Some(KeyAction::CursorRight) => {
+            app.input.cursor = next_char_pos(&app.input.buffer, app.input.cursor);
+            None
+        }
+        Some(KeyAction::LineStart) => {
+            app.input.cursor = app.current_line_start();
+            None
+        }
+        Some(KeyAction::LineEnd) => {
+            app.input.cursor = app.current_line_end();
+            None
+        }
+        Some(KeyAction::DeleteChar) => {
+            if app.input.cursor < app.input.buffer.len() {
+                app.input.buffer.remove(app.input.cursor);
+            }
+            None
+        }
+        Some(KeyAction::DeleteToEnd) => {
+            let line_end = app.current_line_end();
+            app.input.buffer.drain(app.input.cursor..line_end);
+            None
+        }
+        Some(KeyAction::CopyMessage) => {
+            app.copy_selected_message(false);
+            None
+        }
+        Some(KeyAction::CopyAllMessages) => {
+            app.copy_selected_message(true);
+            None
+        }
+        Some(KeyAction::React) => execute_react(app),
+        Some(KeyAction::Quote) => execute_reply(app),
+        Some(KeyAction::EditMessage) => execute_edit(app),
+        Some(KeyAction::ForwardMessage) => execute_forward(app),
+        Some(KeyAction::DeleteMessage) => execute_delete_confirm(app),
+        Some(KeyAction::NextSearchResult) => execute_search_jump(app, true),
+        Some(KeyAction::PrevSearchResult) => execute_search_jump(app, false),
+        Some(KeyAction::OpenActionMenu) => execute_open_action_menu(app),
+        Some(KeyAction::PinMessage) => execute_pin_toggle(app),
+        Some(KeyAction::JumpToQuote) => {
+            app.jump_to_quote();
+            None
+        }
+        Some(KeyAction::JumpBack) => {
+            app.jump_back();
+            None
+        }
+        _ => {
+            let needs_ac_update = matches!(
+                code,
+                KeyCode::Backspace | KeyCode::Delete | KeyCode::Char(_)
+            );
+            app.apply_input_edit(code);
+            if needs_ac_update {
+                app.update_autocomplete();
+            }
+            if matches!(
+                code,
+                KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
+            ) {
+                app.typing.last_keypress = Some(Instant::now());
+                if app.input.buffer.is_empty() && app.typing.sent {
+                    app.typing.sent = false;
+                    app.typing.last_keypress = None;
+                    return app.build_typing_request(true);
+                }
+                if !app.typing.sent
+                    && !app.input.buffer.is_empty()
+                    && !app.input.buffer.starts_with('/')
+                    && app
+                        .active_conversation
+                        .as_ref()
+                        .is_some_and(|id| !app.blocked_conversations.contains(id))
+                {
+                    app.typing.sent = true;
+                    return app.build_typing_request(false);
+                }
+            }
+            None
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Continuing the `handlers/` extraction (#494) after #568. This is the last of the mode key handlers.

`handle_insert_key` (the composer editing handler plus typing-indicator dispatch, and the message actions that alternative keybinding profiles bind in Insert mode) moves from an inline `impl App` method into `handlers::keys` as a free function over `&mut App`, with a one-line delegation shim in `app.rs`.

`build_typing_request` and `delete_word_back` are promoted from private to `pub(crate)`; the rest of its helpers were already accessible. `std::time::Instant` is imported into the handlers module.

Behavior is unchanged. With this, all mode and overlay key handling lives in `handlers/keys.rs` and `app.rs` keeps thin delegation shims.

Remaining for #494: `handle_mouse_event`, `populate_demo_data` -> `src/demo.rs`, and relocating the inline test module.

## Testing

- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (676 bin + 220 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)