### PR TITLE
feat: emit explicit Disconnected and fail in-flight sends on signal-cli exit (#497)

### DIFF
--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -294,6 +294,13 @@ pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
                 }
             }
         }
+        SignalEvent::Disconnected => {
+            // The signal-cli child exited. Any in-flight sends were already
+            // failed via SendFailed events emitted just before this one. Mark
+            // disconnected immediately; the main loop's channel-closed path
+            // fills in the detailed exit reason (#497).
+            app.connected = false;
+        }
     }
 }
 

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -86,9 +86,19 @@ impl SignalClient {
                 }
 
                 if event_tx.send(event).await.is_err() {
-                    break;
+                    return;
                 }
             }
+
+            // stdout hit EOF: signal-cli exited. Fail any in-flight sends so their
+            // local messages leave the Sending state, then emit an explicit
+            // Disconnected before the channel closes (#497).
+            for event in drain_pending_as_failures(&pending_clone) {
+                if event_tx.send(event).await.is_err() {
+                    return;
+                }
+            }
+            let _ = event_tx.send(SignalEvent::Disconnected).await;
         });
 
         // Stdin writer task — send JSON-RPC requests to signal-cli
@@ -690,6 +700,20 @@ fn build_block_params(account: &str, recipient: &str, is_group: bool) -> serde_j
     }
 }
 
+/// Drain `pending` and turn every tracked send method (`send` / `sendPollCreate`,
+/// the ones dispatch_send registers) into a `SendFailed` event. Called when the
+/// stdout reader exits so in-flight sends do not hang in the Sending state
+/// forever after the child dies (#497). Recovers from a poisoned lock (REL-002).
+fn drain_pending_as_failures(
+    pending: &Mutex<HashMap<String, (String, Instant)>>,
+) -> Vec<SignalEvent> {
+    let mut map = pending.lock().unwrap_or_else(|e| e.into_inner());
+    map.drain()
+        .filter(|(_, (method, _))| method == "send" || method == "sendPollCreate")
+        .map(|(id, _)| SignalEvent::SendFailed { rpc_id: id })
+        .collect()
+}
+
 /// Parse one JSON-RPC line from signal-cli's stdout into an optional event.
 ///
 /// Pure given the shared `pending` correlation map and `download_dir`, so it can
@@ -987,6 +1011,39 @@ mod tests {
         let map = pending.lock().unwrap();
         assert!(!map.contains_key("stale"), "stale entry must be swept");
         assert!(!map.contains_key("fresh"), "correlated id consumed");
+    }
+
+    #[test]
+    fn drain_pending_as_failures_fails_tracked_sends_only() {
+        let pending = pending_map();
+        {
+            let mut map = pending.lock().unwrap();
+            map.insert("s1".to_string(), ("send".to_string(), Instant::now()));
+            map.insert(
+                "p1".to_string(),
+                ("sendPollCreate".to_string(), Instant::now()),
+            );
+            map.insert(
+                "lc".to_string(),
+                ("listContacts".to_string(), Instant::now()),
+            );
+        }
+
+        let events = drain_pending_as_failures(&pending);
+
+        // Only the two tracked send methods become SendFailed.
+        let mut failed: Vec<String> = events
+            .into_iter()
+            .map(|e| match e {
+                SignalEvent::SendFailed { rpc_id } => rpc_id,
+                other => panic!("expected SendFailed, got {other:?}"),
+            })
+            .collect();
+        failed.sort();
+        assert_eq!(failed, vec!["p1".to_string(), "s1".to_string()]);
+
+        // The map is fully drained (the untracked entry is dropped too).
+        assert!(pending.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -257,6 +257,10 @@ pub enum SignalEvent {
     GroupList(Vec<Group>),
     IdentityList(Vec<IdentityInfo>),
     Error(String),
+    /// The signal-cli stdout reader reached EOF (the child exited). Emitted
+    /// explicitly so the app can mark itself disconnected and fail any in-flight
+    /// sends, instead of relying solely on the mpsc channel closing (#497).
+    Disconnected,
 }
 
 impl SignalEvent {
@@ -375,6 +379,7 @@ impl SignalEvent {
             Self::GroupList(groups) => format!("GroupList(count={})", groups.len()),
             Self::IdentityList(ids) => format!("IdentityList(count={})", ids.len()),
             Self::Error(e) => format!("Error({e})"),
+            Self::Disconnected => "Disconnected".to_string(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Addresses the failure-path half of #497. When the signal-cli stdout reader reaches EOF (the child exited), it now does two things before its task ends:

1. **Fails in-flight sends.** Drains `pending_requests` and emits a `SendFailed` for every tracked send method (`send` / `sendPollCreate`), so optimistic local messages leave the Sending state instead of hanging forever. Previously the stale-entry sweep only ran when a response arrived, so a dead process stranded them until restart.
2. **Emits an explicit `SignalEvent::Disconnected`** before the channel closes. `handle_signal_event` uses it to mark the app disconnected immediately; the main loop's existing channel-closed path still fills in the detailed exit reason (stderr tail / exit code).

The drain recovers from a poisoned lock, matching the REL-002 fix that #549 already applied to the reader's correlation path (that was issue item 3, already done).

## Scope

Item 2 from the issue (supervised respawn with backoff in `main.rs`) is the remaining, larger piece and is left for a follow-up. This PR is the contained reader-side failure-path work.

## Testing

- New unit test `drain_pending_as_failures_fails_tracked_sends_only` (tracked sends become `SendFailed`, untracked entries are dropped, map fully drained).
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (677 bin + 221 lib)
- `cargo fmt` applied
- field-count ratchet: 66/66 (no App fields changed)