### PR TITLE
test: snapshot the focus-derivation render path (#496)

### DIFF
--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -541,6 +541,18 @@ mod snapshot_tests {
     }
 
     #[test]
+    fn chat_focused_message_scrolls_into_view() {
+        let mut app = demo_app();
+        app.mode = InputMode::Normal;
+        // Focus an early message: the render pass must derive focus, scroll it
+        // into view, and highlight it -- the focus-derivation-during-render path
+        // #496 flags as frame-order-dependent and previously untested.
+        app.scroll.focused_index = Some(2);
+        let output = render_to_string(&mut app, 100, 30);
+        insta::assert_snapshot!(output);
+    }
+
+    #[test]
     fn body_newlines_render_as_separate_lines() {
         use crate::conversation_store::DisplayMessage;
         let mut app = demo_app();

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__chat_focused_message_scrolls_into_view.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__chat_focused_message_scrolls_into_view.snap
@@ -1,0 +1,34 @@
+---
+source: src/ui/mod.rs
+expression: output
+---
+ Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
+  ? +15550007777 (1) ││[08:00] <Alice> Good morning! How's your day going?                         │
+  • ##Family (2)     ││    👍  1                                                                    │
+  • Carol (1)        ││● [08:05] <you> Just getting started, coffee in hand                        │
+    ##Rust Devs      ││    ❤️  1                                                                    │
+    Bob              ││[08:10] <Alice> Nice! I've been up since 6, went for a run                  │
+▸   Alice            ││● [08:15] <you> Impressive. I can barely get out of bed before 7            │
+    Dave             ││[08:20] <Alice> Ha! It gets easier once you build the habit                 │
+                     ││● [08:25] <you> That's what everyone says...                                │
+                     ││[08:30] <Alice> Trust me, after a week it becomes automatic                 │
+                     ││  ╭ <you> Just getting started, coffee in hand                              │
+                     ││[08:35] <Alice> Honestly same, I need my coffee first too                   │
+                     ││✓ [08:40] <you> Are you free this weekend?                                  │
+                     ││[08:42] <Alice> Yeah! What did you have in mind?                            │
+                     ││[08:45] <Alice> There's this farmers market: https://localmarket.example.com│
+                     ││  ├ Downtown Farmers Market                                                 │
+                     ││  ├ Fresh produce, artisan goods, and live music every Saturday…            │
+                     ││  ╰ https://localmarket.example.com                                         │
+                     ││○ [08:47] <you> Oh nice, what time should we go?                            │
+                     ││✓ [08:48] <Alice> Opens at 8, but 9 is fine. Less crowded.                  │
+                     ││○ [08:50] <you> Perfect, let's do 9                                         │
+                     ││○ [08:52] <Alice> I'll pick you up at 8:45                                  │
+                     ││○ [08:55] <you> (edited) Actually make it 8:30, I want to browse early      │
+                     ││[08:57] <Alice> Even better! See you Saturday                               │
+                     ││    🎉  1                                                                    │
+                     │╰────────────────────────────────────────────────────────────────────────────╯
+                     │╭────────────────────────────────────────────────────────────────────────────╮
+                     ││  Press i to type, / for commands                                           │
+                     │╰────────────────────────────────────────────────────────────────────────────╯
+ [NORMAL] │  ● connected │ Alice │ 7 chats


### PR DESCRIPTION
## Summary

Adds a Normal-mode snapshot with an early message focused, so the render pass must derive focus, scroll it into view (`ensure_focus_visible`), and highlight it. This is the focus-derivation-during-render behavior #496 calls out as frame-order-dependent and previously untestable without a fake terminal; it now has buffer-level coverage alongside the scroll-offset snapshots from #578.

Continues building the safety net the eventual ViewState / pre-render split needs before it can safely move focus derivation out of the render pass.

## Testing

- New snapshot `chat_focused_message_scrolls_into_view` generated and committed.
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (694 bin + 221 lib)
- `cargo fmt` applied