### PR TITLE
feat: auto-lock after keyboard inactivity (lock_timeout) (#438)

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -28,6 +28,7 @@ notify_group = true
 desktop_notifications = false
 notification_preview = "full"
 clipboard_clear_seconds = 30
+lock_timeout = 0
 image_mode = "halfblock"
 show_link_previews = true
 date_separators = true
@@ -58,6 +59,7 @@ proxy = ""
 | `desktop_notifications` | bool | `false` | OS-level desktop notifications for incoming messages |
 | `notification_preview` | string | `"full"` | Notification content level: `full`, `sender`, or `minimal` |
 | `clipboard_clear_seconds` | int | `30` | Seconds before clipboard auto-clears after copying (0 = disabled) |
+| `lock_timeout` | int | `0` | Minutes of keyboard inactivity before the session auto-locks (0 = disabled) |
 | `image_mode` | string | `"halfblock"` | Image rendering mode: `native` (Kitty / iTerm2 / Sixel), `halfblock` (universal Unicode fallback), or `none` |
 | `show_link_previews` | bool | `true` | Show link preview cards for URLs in messages |
 | `date_separators` | bool | `true` | Show date separator lines between messages from different days |

--- a/docs/src/user-guide/security.md
+++ b/docs/src/user-guide/security.md
@@ -126,8 +126,11 @@ Copied message content is automatically cleared from the system clipboard after
 ### Session lock
 
 `Ctrl-L` (or `/lock`) blanks the chat behind a passphrase prompt for the
-"someone walked up to my terminal" case. The passphrase is stored as an argon2
-PHC hash at `{config_dir}/lock_hash`, never as plaintext. While locked:
+"someone walked up to my terminal" case. Set `lock_timeout = N` (minutes) in the
+config to also auto-lock after N minutes without a keypress (0, the default,
+disables it; mouse movement does not count as activity). The passphrase is
+stored as an argon2 PHC hash at `{config_dir}/lock_hash`, never as plaintext.
+While locked:
 
 - Keyboard input is intercepted; nothing reaches the composer
 - Terminal bell and OS desktop notifications are suppressed

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,10 @@ pub struct Config {
     #[serde(default = "default_clipboard_clear_seconds")]
     pub clipboard_clear_seconds: u64,
 
+    /// Minutes of keyboard inactivity before the session auto-locks (0 = disabled)
+    #[serde(default)]
+    pub lock_timeout: u64,
+
     /// Image display mode (native / halfblock / none). `None` here means the
     /// field was absent from the on-disk TOML and migration should fill it in
     /// from the legacy `inline_images` / `native_images` flags.
@@ -244,6 +248,7 @@ impl Default for Config {
             desktop_notifications: false,
             notification_preview: NotificationPreview::Full,
             clipboard_clear_seconds: default_clipboard_clear_seconds(),
+            lock_timeout: 0,
             image_mode: Some(ImageMode::Halfblock),
             cell_pixel_width: 0,
             cell_pixel_height: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,14 @@ fn reconnect_backoff(attempt: u32) -> Duration {
     Duration::from_secs((1u64 << attempt.min(6)).min(30))
 }
 
+/// Whether the session should auto-lock now (#438). `timeout_mins == 0` disables
+/// it; otherwise lock once keyboard `idle` reaches that many minutes and we are
+/// not already locked. Only keypresses reset idle (the caller excludes mouse
+/// motion), so a wireless mouse on a desk can't hold the lock open forever.
+fn should_auto_lock(timeout_mins: u64, idle: Duration, already_locked: bool) -> bool {
+    timeout_mins > 0 && !already_locked && idle >= Duration::from_secs(timeout_mins * 60)
+}
+
 /// Set restrictive permissions (0600) on a sensitive file (Unix only).
 #[cfg(unix)]
 fn set_file_permissions(path: &std::path::Path) {
@@ -1363,6 +1371,8 @@ async fn run_app(
     // earliest time the next spawn attempt may run; None means "try now".
     let mut reconnect_attempts: u32 = 0;
     let mut next_reconnect_at: Option<Instant> = None;
+    // Auto-lock idle tracking (#438): reset on every keypress (not mouse).
+    let mut last_activity = Instant::now();
     // Loop-rate diagnostics: only counted/logged when --debug is on. Helps
     // locate non-converging redraw triggers (see issue #408). Cheap when off.
     let mut diag_last = Instant::now();
@@ -1496,6 +1506,7 @@ async fn run_app(
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
                     needs_redraw = true;
+                    last_activity = Instant::now();
                     if app.keybindings_overlay.capturing {
                         app.handle_keybinding_capture(key.modifiers, key.code);
                     } else if !app.handle_global_key(key.modifiers, key.code) {
@@ -1536,6 +1547,16 @@ async fn run_app(
                 _ => {}
             }
             had_terminal_event = event::poll(Duration::ZERO)?;
+        }
+
+        // Auto-lock after configured keyboard inactivity (#438).
+        if should_auto_lock(
+            config.lock_timeout,
+            last_activity.elapsed(),
+            app.lock.is_locked(),
+        ) {
+            app.lock_now();
+            needs_redraw = true;
         }
 
         // Drain signal events (non-blocking), detect disconnect
@@ -1710,6 +1731,24 @@ async fn run_app(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_auto_lock_respects_timeout_and_state() {
+        let min = Duration::from_secs(60);
+        // Disabled: never locks, however idle.
+        assert!(!should_auto_lock(0, Duration::from_secs(99999), false));
+        // Enabled, idle past the threshold, not yet locked -> lock.
+        assert!(should_auto_lock(1, min, false));
+        assert!(should_auto_lock(5, 5 * min, false));
+        // Idle below the threshold -> don't lock.
+        assert!(!should_auto_lock(
+            5,
+            5 * min - Duration::from_secs(1),
+            false
+        ));
+        // Already locked -> no-op (don't re-lock).
+        assert!(!should_auto_lock(1, 10 * min, true));
+    }
 
     #[test]
     fn reconnect_backoff_is_exponential_and_capped() {


### PR DESCRIPTION
## Summary

Adds the auto-lock timer that was scoped out of the session-lock MVP (#261). A new config field `lock_timeout` (minutes; `0` = disabled, the default) locks the session after that long without a keypress.

- **config.rs:** `lock_timeout: u64`, serde default `0`.
- **main.rs:** track `last_activity`, reset on every keypress (`Event::Key` Press only -- mouse motion and signal events do not count, so a wireless mouse can'"'"'t hold the lock open). Each loop iteration calls a pure `should_auto_lock()` and fires `app.lock_now()` (which already picks `LockEntry` vs `SetPassphrase` based on whether a passphrase hash exists) when idle past the threshold and not already locked.
- Pure `should_auto_lock(timeout_mins, idle, already_locked)` with unit tests (disabled, below/at threshold, already-locked).
- Documented in the configuration table, the example config, and the security guide'"'"'s session-lock section.

Matches the issue'"'"'s spec and implementation sketch (~config field + ~20 LOC in main.rs + a test).

## Testing

- New unit test `should_auto_lock_respects_timeout_and_state`
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (698 bin + 221 lib)
- `cargo fmt` applied; field-count ratchet 66/66