### PR TITLE
feat: ship a custom theme template (#476)

### DIFF
--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -312,6 +312,18 @@ Open the theme picker with `/theme` (alias `/t`) or from `/settings` > Theme.
 Choose from built-in themes with customizable sidebar, chat, status bar, and
 accent colors.
 
+### Custom themes
+
+Drop a `*.toml` theme file in your themes directory and it appears in the picker:
+
+- **Linux / macOS:** `~/.config/siggy/themes/`
+- **Windows:** `%APPDATA%\siggy\themes\`
+
+The repo ships a fully-commented starting point at
+[`themes/custom-theme-template.toml`](https://github.com/johnsideserf/siggy/blob/master/themes/custom-theme-template.toml):
+copy it in, edit the colors (named 16-color values, `#rrggbb` hex, or
+`indexed(N)` 256-color), set a unique `name`, and pick it via `/theme`.
+
 ## Pinned messages
 
 Pin important messages to the top of a conversation. Press `p` in Normal mode

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -706,4 +706,19 @@ bg = "#€abc"
         assert_eq!(parsed.sender_palette, theme.sender_palette);
         assert_eq!(parsed.receipt_viewed, theme.receipt_viewed);
     }
+
+    /// The shipped custom-theme template (#476) must stay a valid, complete
+    /// Theme so users who copy it get a working theme; this also fails if a new
+    /// Theme field is added without updating the template.
+    #[test]
+    fn custom_theme_template_parses() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/themes/custom-theme-template.toml"
+        );
+        let contents = std::fs::read_to_string(path).expect("template file present");
+        let theme: Theme = toml::from_str(&contents).expect("template parses as a Theme");
+        assert_eq!(theme.name, "My Theme");
+        assert_eq!(theme.sender_palette.len(), 8);
+    }
 }

--- a/themes/custom-theme-template.toml
+++ b/themes/custom-theme-template.toml
@@ -1,0 +1,73 @@
+# siggy custom theme template (#476)
+#
+# Copy this file to your themes directory and edit the colors, then pick it in
+# the app via /theme (or set `theme = "My Theme"` in config.toml).
+#
+#   Linux / macOS:  ~/.config/siggy/themes/my-theme.toml
+#   Windows:        %APPDATA%\siggy\themes\my-theme.toml
+#
+# The file name does not matter (any *.toml in that folder is loaded); the theme
+# is identified by its `name` field below. Every field is required.
+#
+# Color formats (any field accepts any of these):
+#   - Named 16-color:  "black" "red" "green" "yellow" "blue" "magenta" "cyan"
+#                      "gray" "dark_gray" "light_red" "light_green"
+#                      "light_yellow" "light_blue" "light_magenta" "light_cyan"
+#                      "white" "reset"
+#                      (named colors follow the terminal palette, so they adapt
+#                      to the user's terminal theme)
+#   - Hex truecolor:   "#rrggbb"  e.g. "#cba6f7"
+#   - 256-color index: "indexed(N)"  where N is 0-255  e.g. "indexed(236)"
+
+name = "My Theme"
+
+# --- Base ---
+bg = "black"             # main background
+bg_selected = "dark_gray" # selected sidebar row / highlighted background
+fg = "white"             # primary text
+fg_secondary = "gray"    # secondary text (timestamps, etc.)
+fg_muted = "dark_gray"   # muted text (hints, separators)
+
+# --- Accent ---
+accent = "cyan"            # titles, active conversation name
+accent_secondary = "yellow" # secondary accents
+
+# --- Status indicators ---
+success = "green"
+error = "red"
+warning = "yellow"
+
+# --- Messages ---
+sender_self = "green"      # your own name/messages
+# Eight colors hashed across other senders (group chats). Must be exactly 8.
+sender_palette = [
+    "cyan",
+    "magenta",
+    "yellow",
+    "blue",
+    "light_red",
+    "light_green",
+    "light_cyan",
+    "light_magenta",
+]
+link = "blue"              # hyperlinks
+mention = "cyan"           # @mentions
+quote = "dark_gray"        # quoted-reply text
+system_msg = "dark_gray"   # system / status messages in the chat
+msg_selected_bg = "indexed(236)" # background of the focused message in Normal mode
+
+# --- Input box ---
+input_insert = "cyan"      # border/cursor accent in Insert mode
+input_normal = "yellow"    # border/cursor accent in Normal mode
+
+# --- Status bar ---
+statusbar_bg = "dark_gray"
+statusbar_fg = "white"
+
+# --- Delivery receipt colors ---
+receipt_failed = "red"
+receipt_sending = "dark_gray"
+receipt_sent = "dark_gray"
+receipt_delivered = "white"
+receipt_read = "green"
+receipt_viewed = "cyan"


### PR DESCRIPTION
## Summary

Adds `themes/custom-theme-template.toml`, a fully-commented, valid starting point for user themes, as requested by @QuidRides.

It includes every `Theme` field with explanatory comments and documents the three accepted color formats (named 16-color values, `#rrggbb` hex truecolor, and `indexed(N)` 256-color). Users copy it into `~/.config/siggy/themes/` (or `%APPDATA%\siggy\themes\` on Windows), edit the colors, set a unique `name`, and pick it via `/theme`.

A test parses the shipped template as a `Theme`, so it stays valid and complete -- it will fail if a `Theme` field is ever added without updating the template. Documented under Features > Color themes > Custom themes, with a link to the file.

## Testing

- New test `custom_theme_template_parses`
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (699 bin + 222 lib)
- `cargo fmt` applied