### PR TITLE
feat: make overlay/toggle commands bindable as key actions (#202)

### DIFF
--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -5548,3 +5548,35 @@ fn lock_flow_set_then_unlock(mut app: App) {
     assert_eq!(app.lock.phase, crate::domain::LockPhase::Unlocked);
     assert!(app.lock.error.is_none());
 }
+
+#[rstest]
+fn bound_key_dispatches_command_action(mut app: App) {
+    // #202: command actions (open overlays / toggle sidebar) are bindable. A key
+    // bound to OpenSettings in Global mode must open the settings overlay.
+    use crate::keybindings::{BindingMode, KeyAction, KeyCombo};
+    let combo = KeyCombo {
+        modifiers: KeyModifiers::CONTROL,
+        code: KeyCode::Char('y'),
+    };
+    app.keybindings
+        .rebind(BindingMode::Global, KeyAction::OpenSettings, combo);
+
+    assert!(!app.is_overlay(OverlayKind::Settings));
+    let consumed = app.handle_global_key(KeyModifiers::CONTROL, KeyCode::Char('y'));
+    assert!(consumed, "bound command action must consume the key");
+    assert!(app.is_overlay(OverlayKind::Settings));
+}
+
+#[rstest]
+fn toggle_sidebar_action_flips_visibility(mut app: App) {
+    use crate::keybindings::{BindingMode, KeyAction, KeyCombo};
+    let combo = KeyCombo {
+        modifiers: KeyModifiers::CONTROL,
+        code: KeyCode::Char('b'),
+    };
+    app.keybindings
+        .rebind(BindingMode::Global, KeyAction::ToggleSidebar, combo);
+    let before = app.sidebar_visible;
+    app.handle_global_key(KeyModifiers::CONTROL, KeyCode::Char('b'));
+    assert_eq!(app.sidebar_visible, !before);
+}

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -853,6 +853,33 @@ pub fn handle_global_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) 
             app.lock_now();
             true
         }
+        // Overlay-open / toggle actions, mirroring the matching slash commands
+        // so they can be driven from a keybinding (#202).
+        Some(KeyAction::OpenContacts) => {
+            app.open_overlay(OverlayKind::Contacts);
+            app.contacts_overlay.index = 0;
+            app.contacts_overlay.filter.clear();
+            app.refresh_contacts_filter();
+            true
+        }
+        Some(KeyAction::OpenSettings) => {
+            app.open_overlay(OverlayKind::Settings);
+            app.settings_overlay.index = 0;
+            app.settings_overlay.mouse_snapshot = app.mouse.enabled;
+            true
+        }
+        Some(KeyAction::OpenHelp) => {
+            app.open_overlay(OverlayKind::Help);
+            true
+        }
+        Some(KeyAction::ToggleSidebar) => {
+            app.sidebar_visible = !app.sidebar_visible;
+            true
+        }
+        Some(KeyAction::Attach) => {
+            app.open_file_browser();
+            true
+        }
         _ => false,
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -26,6 +26,12 @@ pub enum KeyAction {
     ResizeSidebarRight,
     PageScrollUp,
     PageScrollDown,
+    // Global: open overlays / toggles (unbound by default; bind in a profile).
+    OpenContacts,
+    OpenSettings,
+    OpenHelp,
+    ToggleSidebar,
+    Attach,
     // Normal: scroll
     ScrollUp,
     ScrollDown,
@@ -420,6 +426,11 @@ pub const GLOBAL_ACTIONS: &[KeyAction] = &[
     KeyAction::ResizeSidebarRight,
     KeyAction::PageScrollUp,
     KeyAction::PageScrollDown,
+    KeyAction::OpenContacts,
+    KeyAction::OpenSettings,
+    KeyAction::OpenHelp,
+    KeyAction::ToggleSidebar,
+    KeyAction::Attach,
 ];
 
 pub const NORMAL_ACTIONS: &[KeyAction] = &[
@@ -480,6 +491,11 @@ pub fn action_label(action: KeyAction) -> &'static str {
         KeyAction::ResizeSidebarRight => "Grow sidebar",
         KeyAction::PageScrollUp => "Page scroll up",
         KeyAction::PageScrollDown => "Page scroll down",
+        KeyAction::OpenContacts => "Open contacts",
+        KeyAction::OpenSettings => "Open settings",
+        KeyAction::OpenHelp => "Open help",
+        KeyAction::ToggleSidebar => "Toggle sidebar",
+        KeyAction::Attach => "Attach file",
         KeyAction::ScrollUp => "Scroll up",
         KeyAction::ScrollDown => "Scroll down",
         KeyAction::FocusNextMessage => "Focus next message",


### PR DESCRIPTION
## Summary

Bridges the keybinding and command systems so the most-used overlay opens can be driven from a custom keybinding, as requested by @Dowsley (Tech debt milestone).

Adds five `KeyAction` variants -- `OpenContacts`, `OpenSettings`, `OpenHelp`, `ToggleSidebar`, `Attach` -- listed in `GLOBAL_ACTIONS` (so they show up in the in-app rebind overlay), with human-readable labels, and dispatched in `handle_global_key` with the same effect as their slash commands (`/contacts`, `/settings`, `/help`, `/sidebar`, `/attach`).

## Default bindings

They are **unbound by default**. That delivers the bindability the issue asks for without introducing default-binding conflicts against the ~40 existing defaults. Users bind them in `~/.config/siggy/keybindings/*.toml` (serde snake_case: `open_contacts`, `open_settings`, `open_help`, `toggle_sidebar`, `attach`) or via the in-app rebinder. Choosing sensible default combos (the issue floated `Ctrl-p` for contacts) can be a focused follow-up once conflict-free combos are picked.

## Testing

- New behavioral tests: a key bound to `OpenSettings` opens the settings overlay; a key bound to `ToggleSidebar` flips sidebar visibility.
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (701 bin + 222 lib)
- `cargo fmt` applied (incl. direct rustfmt of the `#[path]` test module)