### PR TITLE
feat: add --version flag (#257)

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -91,6 +91,7 @@ CLI flags override config file values for the current session:
 | `--debug` | Write debug log to `~/.cache/siggy/debug.log` (PII redacted) |
 | `--debug-full` | Same as `--debug` but without redaction |
 | `--reset-lock` | Delete the session-lock passphrase hash and exit |
+| `-V`, `--version` | Print `siggy <version>` to stdout and exit |
 
 ## Environment variables
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,7 +7,7 @@
 //! the persistent map and ordered sidebar list.
 
 use chrono::{DateTime, Utc};
-use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use crossterm::event::{KeyCode, KeyModifiers, MouseEvent};
 use ratatui::layout::Rect;
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -4,7 +4,7 @@ use crate::signal::types::{
     Attachment, Contact, Group, IdentityInfo, Mention, PollData, PollOption, ReceiptKind,
     SignalEvent, SignalMessage, StyleType, TextStyle, TrustLevel,
 };
-use crossterm::event::{KeyCode, KeyModifiers};
+use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use rstest::{fixture, rstest};
 
 #[fixture]

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,7 +194,13 @@ async fn main() -> Result<()> {
                 eprintln!("      --debug             Write debug log (PII redacted)");
                 eprintln!("      --debug-full        Write debug log (full, unredacted)");
                 eprintln!("      --reset-lock        Delete the session-lock passphrase and exit");
+                eprintln!("  -V, --version           Print version and exit");
                 eprintln!("      --help              Show this help");
+                std::process::exit(0);
+            }
+            "-V" | "--version" => {
+                // Plain "siggy x.y.z" on stdout for scripts/CI (#257).
+                println!("siggy {}", env!("CARGO_PKG_VERSION"));
                 std::process::exit(0);
             }
             _ => {


### PR DESCRIPTION
## Summary

First non-interactive primitive toward #257 (CLI for scripting/automation): `-V` / `--version` prints `siggy <version>` to stdout and exits 0, so CI and install scripts can check the installed version without launching the TUI. Added to `--help` and the CLI flags table in the docs.

## Drive-by cleanup

Also fixes a pre-existing non-test-build warning: `app.rs` imported `MouseButton` / `MouseEventKind` that, since the test module moved to `app_tests.rs` (#573), are only referenced by the tests (via `use super::*`). They are now imported directly in `app_tests.rs` and dropped from `app.rs` (which keeps `MouseEvent` for the `handle_mouse_event` shim). `clippy --tests` was already clean; this also silences the plain `cargo build` warning.

## Notes

This is a small, dependency-free, design-unambiguous slice; the larger non-interactive send/receive surface of #257 still warrants a scoping decision.

## Testing

- `cargo build` warning-free; `cargo run -- --version` prints `siggy 1.9.1`
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (701 bin + 222 lib)
- `cargo fmt` applied