### PR TITLE
feat: add --check setup health report (#257)

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -91,6 +91,7 @@ CLI flags override config file values for the current session:
 | `--debug` | Write debug log to `~/.cache/siggy/debug.log` (PII redacted) |
 | `--debug-full` | Same as `--debug` but without redaction |
 | `--reset-lock` | Delete the session-lock passphrase hash and exit |
+| `--check` | Print a setup health report (config, account, signal-cli, download dir) and exit; exit code 0 when ready, 1 otherwise |
 | `-V`, `--version` | Print `siggy <version>` to stdout and exit |
 
 ## Environment variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,7 @@ async fn main() -> Result<()> {
     let mut debug = false;
     let mut debug_full = false;
     let mut reset_lock = false;
+    let mut check = false;
 
     let mut i = 1;
     while i < args.len() {
@@ -178,6 +179,10 @@ async fn main() -> Result<()> {
                 reset_lock = true;
                 i += 1;
             }
+            "--check" => {
+                check = true;
+                i += 1;
+            }
             "--help" => {
                 eprintln!("siggy - Terminal Signal client");
                 eprintln!();
@@ -194,6 +199,9 @@ async fn main() -> Result<()> {
                 eprintln!("      --debug             Write debug log (PII redacted)");
                 eprintln!("      --debug-full        Write debug log (full, unredacted)");
                 eprintln!("      --reset-lock        Delete the session-lock passphrase and exit");
+                eprintln!(
+                    "      --check             Print a setup health report and exit (0 = ready)"
+                );
                 eprintln!("  -V, --version           Print version and exit");
                 eprintln!("      --help              Show this help");
                 std::process::exit(0);
@@ -241,6 +249,38 @@ async fn main() -> Result<()> {
     let mut config = Config::load(config_path)?;
     if let Some(acct) = account {
         config.account = acct;
+    }
+
+    // Non-interactive setup health report for scripts/CI (#257). Plain stdout,
+    // no TUI; exit 0 only when signal-cli is detected and an account is set.
+    if check {
+        let (found, location, _resolved) = setup::check_signal_cli(&config.signal_cli_path).await;
+        let account_ok = !config.account.is_empty();
+        println!("siggy {}", env!("CARGO_PKG_VERSION"));
+        println!("config:       {}", resolved_config_path.display());
+        println!(
+            "account:      {}",
+            if account_ok {
+                config.account.as_str()
+            } else {
+                "(not set)"
+            }
+        );
+        println!(
+            "signal-cli:   {}",
+            if found {
+                location
+            } else {
+                format!("NOT FOUND (configured: {})", config.signal_cli_path)
+            }
+        );
+        println!("download dir: {}", config.download_dir.display());
+        let ready = found && account_ok;
+        println!(
+            "status:       {}",
+            if ready { "ready" } else { "not ready" }
+        );
+        std::process::exit(if ready { 0 } else { 1 });
     }
 
     // Set up terminal BEFORE anything else so all errors render in the TUI

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -287,7 +287,7 @@ pub async fn run_setup(
 /// let the wizard report success via the `where` fallback and then fail at the
 /// linking step when it re-tried the unspawnable bare name. We now verify that
 /// whatever path we return can actually be spawned.
-async fn check_signal_cli(path: &str) -> (bool, String, String) {
+pub(crate) async fn check_signal_cli(path: &str) -> (bool, String, String) {
     // Try the path as given.
     if let Some(display) = try_spawn_version(path).await {
         return (true, display, path.to_string());


### PR DESCRIPTION
## Summary

Second non-interactive primitive toward #257. `siggy --check` prints a plain-stdout setup report and exits with a status code, so CI and install scripts can verify a working setup without launching the TUI:

```
siggy 1.9.1
config:       /home/user/.config/siggy/config.toml
account:      +15551234567
signal-cli:   /usr/bin/signal-cli (signal-cli 0.14.0)
download dir: /home/user/signal-downloads
status:       ready
```

Exit code is **0** only when signal-cli is detected (actually spawned to read its version) and an account is configured, **1** otherwise.

Reuses the existing `setup::check_signal_cli` detection (promoted to `pub(crate)`); no new dependencies. Listed in `--help` and the CLI flags doc.

## Testing

- `cargo build` warning-free; `cargo run -- --check` verified against a real setup (reports `ready`, exit 0)
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (701 bin + 222 lib)
- `cargo fmt` applied