### PR TITLE
feat: non-interactive --list conversations (#257)

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -93,6 +93,7 @@ CLI flags override config file values for the current session:
 | `--reset-lock` | Delete the session-lock passphrase hash and exit |
 | `--check` | Print a setup health report (config, account, signal-cli, download dir) and exit; exit code 0 when ready, 1 otherwise |
 | `--send <TO> <MSG>` | Send one message non-interactively and exit (`TO` = `+E164` for a 1:1 or a group id); exit 0 on confirmed send, 1 on failure/timeout |
+| `--list` | Print cached conversations as tab-separated rows (`unread`, `type`, `name`, `id`) and exit; reads the local DB, no signal-cli needed |
 | `-V`, `--version` | Print `siggy <version>` to stdout and exit |
 
 ## Environment variables

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,6 +172,7 @@ async fn main() -> Result<()> {
     let mut debug_full = false;
     let mut reset_lock = false;
     let mut check = false;
+    let mut list = false;
     let mut send_args: Option<(String, String)> = None;
 
     let mut i = 1;
@@ -223,6 +224,10 @@ async fn main() -> Result<()> {
                 check = true;
                 i += 1;
             }
+            "--list" => {
+                list = true;
+                i += 1;
+            }
             "--send" => {
                 if i + 2 < args.len() {
                     send_args = Some((args[i + 1].clone(), args[i + 2].clone()));
@@ -252,6 +257,9 @@ async fn main() -> Result<()> {
                     "      --check             Print a setup health report and exit (0 = ready)"
                 );
                 eprintln!("      --send <TO> <MSG>   Send one message non-interactively and exit");
+                eprintln!(
+                    "      --list              List cached conversations (tab-separated) and exit"
+                );
                 eprintln!("  -V, --version           Print version and exit");
                 eprintln!("      --help              Show this help");
                 std::process::exit(0);
@@ -331,6 +339,29 @@ async fn main() -> Result<()> {
             if ready { "ready" } else { "not ready" }
         );
         std::process::exit(if ready { 0 } else { 1 });
+    }
+
+    // Non-interactive conversation list for scripts (#257). Reads the cached DB
+    // (no signal-cli spawn) and prints tab-separated rows: unread, type, name, id
+    // -- no header, so it pipes cleanly into grep/cut/awk.
+    if list {
+        let db_path = dirs::data_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join("siggy")
+            .join("siggy.db");
+        if !db_path.exists() {
+            eprintln!(
+                "no database at {} (run siggy once to create it)",
+                db_path.display()
+            );
+            std::process::exit(1);
+        }
+        let db = db::Database::open(&db_path)?;
+        for c in db.load_conversations(1)? {
+            let kind = if c.is_group { "group" } else { "dm" };
+            println!("{}\t{}\t{}\t{}", c.unread, kind, c.name, c.id);
+        }
+        std::process::exit(0);
     }
 
     // Non-interactive one-shot send for scripts/cron (#257). No TUI; exit 0 on


### PR DESCRIPTION
## Summary

Read-only scripting primitive for #257: `siggy --list` reads the cached SQLite DB (no signal-cli spawn, no TUI) and prints one tab-separated row per conversation -- `unread`, `type` (`dm`|`group`), `name`, `id` -- with no header, so it pipes cleanly into `grep`/`cut`/`awk`:

```
0	group	Family	<group-id>
2	dm	Alice	+15551234567
```

Exits `0`, or `1` if the DB does not exist yet. Reuses `Database::load_conversations`; no new dependencies.

Rounds out the non-interactive CLI foundation alongside `--version`, `--check`, and `--send` (#586 / #587 / #588). Listed in `--help` and the CLI flags doc.

## Testing

- `cargo build` warning-free; `cargo run -- --list` verified against the real local DB (prints rows, exit 0)
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (701 bin + 222 lib)
- `cargo fmt` applied