### PR TITLE
perf: bound the image encode caches (#492)

### DIFF
--- a/src/domain/image.rs
+++ b/src/domain/image.rs
@@ -136,4 +136,60 @@ impl ImageState {
             scan_signature: None,
         }
     }
+
+    /// Bound the encode caches so they can't grow without limit (#492). Called
+    /// once per frame. At these caps anything evicted is off-screen and
+    /// regenerates lazily via the background render path, so a crude cap (rather
+    /// than true LRU) is enough and avoids per-insert bookkeeping. Sixel strings
+    /// are large (0.5-3MB each) so that cache gets a smaller entry budget.
+    pub fn enforce_cache_caps(&mut self) {
+        const NATIVE_CACHE_CAP: usize = 256;
+        const ITERM2_CACHE_CAP: usize = 256;
+        const SIXEL_CACHE_CAP: usize = 64;
+        cap_map(&mut self.native_image_cache, NATIVE_CACHE_CAP);
+        cap_map(&mut self.iterm2_crop_cache, ITERM2_CACHE_CAP);
+        cap_map(&mut self.sixel_cache, SIXEL_CACHE_CAP);
+    }
+}
+
+/// Drop arbitrary entries from `map` until it holds at most `cap`. A no-op when
+/// already within budget. Eviction order is unspecified (HashMap iteration); at
+/// the call sites' caps the working set is far smaller than `cap`, so only stale
+/// off-screen entries are ever removed.
+fn cap_map<K: Eq + std::hash::Hash + Clone, V>(map: &mut HashMap<K, V>, cap: usize) {
+    if map.len() <= cap {
+        return;
+    }
+    let excess = map.len() - cap;
+    let victims: Vec<K> = map.keys().take(excess).cloned().collect();
+    for k in victims {
+        map.remove(&k);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::cap_map;
+    use std::collections::HashMap;
+
+    #[test]
+    fn cap_map_is_noop_within_budget() {
+        let mut m: HashMap<u32, u32> = (0..5).map(|i| (i, i)).collect();
+        cap_map(&mut m, 10);
+        assert_eq!(m.len(), 5);
+    }
+
+    #[test]
+    fn cap_map_trims_to_cap() {
+        let mut m: HashMap<u32, u32> = (0..100).map(|i| (i, i)).collect();
+        cap_map(&mut m, 16);
+        assert_eq!(m.len(), 16);
+    }
+
+    #[test]
+    fn cap_map_exact_cap_unchanged() {
+        let mut m: HashMap<u32, u32> = (0..8).map(|i| (i, i)).collect();
+        cap_map(&mut m, 8);
+        assert_eq!(m.len(), 8);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1603,6 +1603,8 @@ async fn run_app(
         if app.ensure_active_images() {
             needs_redraw = true;
         }
+        // Keep the encode caches bounded (#492). Cheap O(1) length check per tick.
+        app.image.enforce_cache_caps();
 
         // Debounced message search: keystrokes mark the query dirty; the DB
         // scan runs here once typing pauses (#491).


### PR DESCRIPTION
## Summary

Addresses the unbounded-memory-growth half of #492 for the image encode caches. `native_image_cache`, `iterm2_crop_cache`, and `sixel_cache` previously grew without limit -- the iterm2 crop cache especially, since it stores one re-encoded PNG per `(path, crop, height)`, so scrolling a single image through the viewport deposits dozens of entries.

Adds `ImageState::enforce_cache_caps()`, called once per frame from the main loop, which trims each cache to an entry budget: 256 native / 256 iterm2 / 64 sixel (smaller for sixel since its strings are 0.5-3 MB each).

## Why a crude cap, not true LRU

At these budgets the on-screen working set is far smaller than the cap, so only stale off-screen entries are ever dropped, and they regenerate lazily via the existing background render path. A crude cap avoids per-insert bookkeeping and a new dependency. It is centralized in one method, so it touches **no** cache insert site or the sixel emit path -- keeping conflict surface with the external sixel PR #520 minimal.

Per-tick cost is an O(1) length check per cache.

## Scope

This covers the three encode caches; combined with the input-history cap (#546) and the idle-scan gate (#547), the core unbounded-growth items in #492 are addressed. Remaining #492 bits (`DisplayMessage.image_lines` eviction; the `collect_link_regions` has-links flag) are noted in the issue.

## Testing

- 3 unit tests for the `cap_map` helper (no-op within budget, trims to cap, exact-cap unchanged)
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (704 bin + 222 lib)
- `cargo fmt` applied; ratchet unaffected (ImageState is a domain sub-struct)