### PR TITLE
perf: evict image_lines for messages before the render window (#492)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -940,6 +940,25 @@ impl App {
             }
         }
 
+        // Evict cached image_lines for messages before the render window so they
+        // don't accumulate across a long scrolling session (#492). Those messages
+        // are never drawn this frame (chat_pane records render_window_start), and
+        // they regenerate via the work path above if scrolled back into view.
+        let evict_before = self.scroll.render_window_start.min(start);
+        if evict_before > 0
+            && let Some(conv) = self.store.conversations.get_mut(&id)
+        {
+            let upto = evict_before.min(conv.messages.len());
+            for msg in &mut conv.messages[..upto] {
+                if msg.image_lines.is_some() {
+                    msg.image_lines = None;
+                }
+                if msg.preview_image_lines.is_some() {
+                    msg.preview_image_lines = None;
+                }
+            }
+        }
+
         // Spawn background render tasks
         let is_native = self.image.image_mode == crate::domain::ImageMode::Native;
         let is_sixel = self.image.image_protocol == image_render::ImageProtocol::Sixel;
@@ -3364,6 +3383,9 @@ impl App {
 
     pub(crate) fn join_conversation(&mut self, target: &str) {
         self.leave_active_conversation();
+        // Stale from the previous conversation; the next render sets it. Prevents
+        // evicting the new conversation's image_lines before it has drawn (#492).
+        self.scroll.render_window_start = 0;
 
         // Try exact match first
         if self.store.conversations.contains_key(target) {

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -1083,6 +1083,38 @@ fn ensure_active_images_scan_is_gated_by_signature(mut app: App) {
     );
 }
 
+#[rstest]
+fn ensure_active_images_evicts_pre_window_image_lines(mut app: App) {
+    // #492: image_lines for messages before the render window are evicted to
+    // bound memory; messages within it are retained.
+    let conv_id = "+1";
+    app.store
+        .get_or_create_conversation(conv_id, "Alice", false, &app.db);
+    if let Some(conv) = app.store.conversations.get_mut(conv_id) {
+        for i in 0..80 {
+            let mut m = outgoing_sending_msg(1000 + i as i64, "hi");
+            m.image_lines = Some(Vec::new());
+            conv.messages.push(m);
+        }
+    }
+    app.active_conversation = Some(conv_id.to_string());
+    app.image.image_mode = crate::domain::ImageMode::Halfblock;
+    app.scroll.offset = 0; // ensure_active_images window starts at 80 - 60 = 20
+    app.scroll.render_window_start = 10; // render window [10, 80)
+
+    app.ensure_active_images();
+
+    let conv = &app.store.conversations[conv_id];
+    // Evicted before min(render_window_start = 10, ensure_start = 20) = 10.
+    assert!(conv.messages[0].image_lines.is_none());
+    assert!(conv.messages[9].image_lines.is_none());
+    assert!(
+        conv.messages[10].image_lines.is_some(),
+        "messages in the render window keep their lines"
+    );
+    assert!(conv.messages[79].image_lines.is_some());
+}
+
 // --- list_overlay nav adoption (#499) ---
 
 fn ident(number: &str, safety: &str) -> crate::signal::types::IdentityInfo {

--- a/src/domain/scroll.rs
+++ b/src/domain/scroll.rs
@@ -47,4 +47,9 @@ pub struct ScrollState {
     /// or composer keystrokes, so a matching key lets the renderer reuse them.
     pub height_cache_key: Option<u64>,
     pub height_cache: Vec<usize>,
+    /// Set by the renderer: index of the first message in the current render
+    /// window. Messages before this are never drawn, so their cached
+    /// `image_lines` can be evicted to bound memory (#492); they regenerate via
+    /// the background path if scrolled back into view.
+    pub render_window_start: usize,
 }

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -330,6 +330,9 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
     }
     let start = window_start(total, available_height, app.scroll.window_extra);
     let visible = &messages[start..total];
+    // Record the render-window start so off-window image_lines can be evicted to
+    // bound memory (#492); messages before `start` are never drawn this frame.
+    app.scroll.render_window_start = start;
 
     // Get last_read_index for unread marker
     let conv_id = app.active_conversation.as_ref().unwrap();


### PR DESCRIPTION
## Summary

`DisplayMessage.image_lines` (rendered halfblock/preview lines) were retained for every message ever scrolled through, growing unbounded over a long session. This evicts them for messages **before the render window** -- exactly what the issue calls for ("evict outside the render window; they regenerate via the existing background path").

## Done safely (no flicker regression)

A naive eviction outside `ensure_active_images`' 60-message window would revert *visible* images to placeholders, because `chat_pane` draws a wider `available_height * MSG_WINDOW_MULTIPLIER` window. So instead:

1. `chat_pane` records the render-window start it already computes, on a new `ScrollState` field `render_window_start`.
2. `ensure_active_images` clears `image_lines` / `preview_image_lines` for active-conversation messages before `min(render_window_start, its own window start)` -- messages never drawn this frame, so nothing visible flickers. They regenerate via the background path if scrolled back.
3. `render_window_start` is reset on conversation switch so a stale value can't evict the new conversation's lines before it draws.

With the encode-cache bound (#590), input-history cap (#546), and idle-scan gate (#547), this completes the unbounded-growth items in #492.

## Testing

- New unit test `ensure_active_images_evicts_pre_window_image_lines`
- `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (705 bin + 222 lib)
- `cargo fmt` applied; field-count ratchet 66/66 (`ScrollState` is a domain sub-struct)