### PR TITLE
feat: opt-in db_path config for side-by-side accounts (closes #260)

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -60,6 +60,7 @@ proxy = ""
 | `notification_preview` | string | `"full"` | Notification content level: `full`, `sender`, or `minimal` |
 | `clipboard_clear_seconds` | int | `30` | Seconds before clipboard auto-clears after copying (0 = disabled) |
 | `lock_timeout` | int | `0` | Minutes of keyboard inactivity before the session auto-locks (0 = disabled) |
+| `db_path` | string | *(unset)* | Override the message database path. Absolute paths are used as-is; relative paths resolve under the data dir. Leave unset for the default `siggy.db`. Used to run multiple accounts side by side (see below) |
 | `image_mode` | string | `"halfblock"` | Image rendering mode: `native` (Kitty / iTerm2 / Sixel), `halfblock` (universal Unicode fallback), or `none` |
 | `show_link_previews` | bool | `true` | Show link preview cards for URLs in messages |
 | `date_separators` | bool | `true` | Show date separator lines between messages from different days |
@@ -158,3 +159,31 @@ siggy --incognito
 Incognito mode replaces the on-disk SQLite database with an in-memory database.
 No messages, conversations, or read markers are saved. When you exit, all data is
 gone. The status bar shows a bold magenta **incognito** indicator.
+
+## Multiple accounts
+
+siggy runs one account per process, but you can use several accounts side by side
+by giving each its own config file (with its own `account`) and its own database
+via `db_path`, then selecting the config with `-c`:
+
+```toml
+# ~/.config/siggy/personal.toml
+account = "+15551110000"
+db_path = "personal.db"        # resolves to <data dir>/siggy/personal.db
+```
+
+```toml
+# ~/.config/siggy/work.toml
+account = "+15552220000"
+db_path = "work.db"
+```
+
+```sh
+siggy -c ~/.config/siggy/personal.toml
+siggy -c ~/.config/siggy/work.toml
+```
+
+Each account keeps a separate message history. `db_path` accepts an absolute
+path too. Without `db_path` the default `siggy.db` is used, so existing
+single-account setups are unaffected. The non-interactive `--list` honors the
+selected config's `db_path` as well.

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,13 @@ pub struct Config {
     #[serde(default)]
     pub lock_timeout: u64,
 
+    /// Override the message database path (for running multiple accounts side by
+    /// side, each with its own config + db). Absolute paths are used as-is;
+    /// relative paths resolve under the data dir. `None` keeps the default
+    /// `siggy.db`, so existing single-account setups are unaffected (#260).
+    #[serde(default)]
+    pub db_path: Option<String>,
+
     /// Image display mode (native / halfblock / none). `None` here means the
     /// field was absent from the on-disk TOML and migration should fill it in
     /// from the legacy `inline_images` / `native_images` flags.
@@ -249,6 +256,7 @@ impl Default for Config {
             notification_preview: NotificationPreview::Full,
             clipboard_clear_seconds: default_clipboard_clear_seconds(),
             lock_timeout: 0,
+            db_path: None,
             image_mode: Some(ImageMode::Halfblock),
             cell_pixel_width: 0,
             cell_pixel_height: 0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,26 @@ async fn run_send_oneshot(config: &Config, recipient: &str, body: &str) -> Resul
     }
 }
 
+/// Resolve the message database path for `config` (#260): the custom `db_path`
+/// (absolute as-is, relative under the data dir) or the default `siggy.db`. Does
+/// not perform the legacy signal-tui.db rename (that is a startup-only concern).
+fn resolve_db_path(config: &Config) -> std::path::PathBuf {
+    let db_dir = dirs::data_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("siggy");
+    match config.db_path.as_deref().filter(|p| !p.is_empty()) {
+        Some(custom) => {
+            let p = std::path::Path::new(custom);
+            if p.is_absolute() {
+                p.to_path_buf()
+            } else {
+                db_dir.join(p)
+            }
+        }
+        None => db_dir.join("siggy.db"),
+    }
+}
+
 /// Stream incoming messages to stdout, one tab-separated line each
 /// (`timestamp_ms`, sender, group-id-or-empty, body), until signal-cli
 /// disconnects or the user interrupts (Ctrl-C) (#257). Outgoing/sync and
@@ -378,10 +398,7 @@ async fn main() -> Result<()> {
     // (no signal-cli spawn) and prints tab-separated rows: unread, type, name, id
     // -- no header, so it pipes cleanly into grep/cut/awk.
     if list {
-        let db_path = dirs::data_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("."))
-            .join("siggy")
-            .join("siggy.db");
+        let db_path = resolve_db_path(&config);
         if !db_path.exists() {
             eprintln!(
                 "no database at {} (run siggy once to create it)",
@@ -542,8 +559,21 @@ async fn run_main_flow(
 
         std::fs::create_dir_all(&db_dir)?;
         set_dir_permissions(&db_dir);
-        let db_path = db_dir.join("siggy.db");
-        fs_migrate::migrate_path(&db_dir.join("signal-tui.db"), &db_path);
+        let db_path = resolve_db_path(config);
+        if config
+            .db_path
+            .as_deref()
+            .filter(|p| !p.is_empty())
+            .is_some()
+        {
+            // Custom per-account db (#260) may live outside db_dir; ensure its
+            // parent exists. No legacy rename - that only applies to the default.
+            if let Some(parent) = db_path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+        } else {
+            fs_migrate::migrate_path(&db_dir.join("signal-tui.db"), &db_path);
+        }
         set_file_permissions(&db_path);
         db::Database::open(&db_path)?
     };


### PR DESCRIPTION
## Summary

Adds an opt-in `db_path` config field so several Signal accounts can run side by side, each with its own config file and its own message database, selected with `-c`. This is the safe, no-migration enabler for multi-account use (issue #260): without `db_path` the default `siggy.db` is used, so existing single-account setups are completely unaffected.

## What changed

- **config.rs**: new `db_path: Option<String>` (serde default `None`).
- **main.rs**: `resolve_db_path()` resolves the db path (absolute as-is, relative under the data dir, default `siggy.db`). Used by both `--list` and the main startup DB open. Custom paths create their parent directory; the legacy `signal-tui.db` rename still applies only to the default path.
- **docs**: `configuration.md` gains a field-reference row and a "Multiple accounts" section with a worked example.

## Usage

```toml
# ~/.config/siggy/work.toml
account = "+15552220000"
db_path = "work.db"
```

```sh
siggy -c ~/.config/siggy/personal.toml
siggy -c ~/.config/siggy/work.toml
```

## Scope

This covers running multiple accounts as separate processes. An in-app account switcher remains a larger follow-up and is intentionally out of scope here.

## Checks

- `cargo build`, `cargo clippy --tests -- -D warnings`, `cargo test` (705 passed), `cargo fmt`, app field-count ratchet (66/66) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)