### PR TITLE
chore(release): bump version to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2516,7 +2516,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.9.1"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.9.1"
+version = "1.10.0"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -1,5 +1,5 @@
 ---
-source: src/ui.rs
+source: src/ui/mod.rs
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.9.1                                  │t too                   │
+                     ││[0│  siggy v1.10.0                                 │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

Bumps the version to **1.10.0** for the next release. master has carried a full release worth of work since v1.9.1 while `Cargo.toml` still read `1.9.1`, which collides with the already-published v1.9.1; this corrects that.

Minor (not patch) because the changes since v1.9.1 add new backward-compatible user-facing capability:

- Non-interactive CLI: `--version`, `--check`, `--send`, `--list`, `--receive` (#257)
- Multi-account `db_path` config for side-by-side accounts (#260)
- Auto-lock timer via `lock_timeout` (#438)
- Bindable overlay/toggle commands as key actions (#202)
- Custom theme template (#476)
- Supervised signal-cli reconnect with backoff (#497)

Plus security hardening (#504), perf work (#490/#491/#492), the black-square render diagnostics (#443), and a large internal refactor/test sweep.

## Changes

- `Cargo.toml` / `Cargo.lock`: `1.9.1` -> `1.10.0`
- Regenerated the about-overlay snapshot to show `siggy v1.10.0`

## After merge

Tag `v1.10.0` to trigger the release build, then `cargo publish`.

## Checks

- `cargo build`, `cargo clippy --tests -- -D warnings`, `cargo test` (708 passed), snapshot updated, all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)