### PR TITLE
feat: add --reset-account flag to clear local account data non-interactively

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -92,6 +92,7 @@ CLI flags override config file values for the current session:
 | `--debug` | Write debug log to `~/.cache/siggy/debug.log` (PII redacted) |
 | `--debug-full` | Same as `--debug` but without redaction |
 | `--reset-lock` | Delete the session-lock passphrase hash and exit |
+| `--reset-account` | Clear local signal-cli account data for the configured account and exit, for a clean relink (`siggy --reset-account` then `siggy --setup`). Only removes local data; a server-side conflict also needs old devices removed on your phone |
 | `--check` | Print a setup health report (config, account, signal-cli, download dir) and exit; exit code 0 when ready, 1 otherwise |
 | `--send <TO> <MSG>` | Send one message non-interactively and exit (`TO` = `+E164` for a 1:1 or a group id); exit 0 on confirmed send, 1 on failure/timeout |
 | `--list` | Print cached conversations as tab-separated rows (`unread`, `type`, `name`, `id`) and exit; reads the local DB, no signal-cli needed |

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,7 @@ async fn main() -> Result<()> {
     let mut debug = false;
     let mut debug_full = false;
     let mut reset_lock = false;
+    let mut reset_account = false;
     let mut check = false;
     let mut list = false;
     let mut receive = false;
@@ -308,6 +309,10 @@ async fn main() -> Result<()> {
                 reset_lock = true;
                 i += 1;
             }
+            "--reset-account" => {
+                reset_account = true;
+                i += 1;
+            }
             "--check" => {
                 check = true;
                 i += 1;
@@ -345,6 +350,9 @@ async fn main() -> Result<()> {
                 eprintln!("      --debug             Write debug log (PII redacted)");
                 eprintln!("      --debug-full        Write debug log (full, unredacted)");
                 eprintln!("      --reset-lock        Delete the session-lock passphrase and exit");
+                eprintln!(
+                    "      --reset-account     Clear local signal-cli account data (for a clean relink) and exit"
+                );
                 eprintln!(
                     "      --check             Print a setup health report and exit (0 = ready)"
                 );
@@ -402,6 +410,35 @@ async fn main() -> Result<()> {
     let mut config = Config::load(config_path)?;
     if let Some(acct) = account {
         config.account = acct;
+    }
+
+    // Non-interactive counterpart to the relink guard (#603/#607): clear stale
+    // local signal-cli account data so a subsequent `--setup` can relink from a
+    // clean slate. Exits without launching the TUI. Note: this only removes
+    // local data; a server-side conflict also needs old devices removed on the
+    // phone.
+    if reset_account {
+        if config.account.is_empty() {
+            eprintln!("no account configured; nothing to reset");
+            std::process::exit(1);
+        }
+        if !setup::account_exists_locally(&config.account) {
+            println!("No local account data found for {}.", config.account);
+            std::process::exit(0);
+        }
+        match setup::delete_local_account_data(&config).await {
+            Ok(()) => {
+                println!(
+                    "Cleared local signal-cli account data for {}. Run `siggy --setup` to relink.",
+                    config.account
+                );
+                std::process::exit(0);
+            }
+            Err(e) => {
+                eprintln!("failed to clear account data: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 
     // Non-interactive setup health report for scripts/CI (#257). Plain stdout,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -811,7 +811,7 @@ fn accounts_json_contains(json: &str, account: &str) -> bool {
 /// Whether `account` already has local signal-cli account data. Fails open: any
 /// error (no home dir, missing/unreadable/malformed file) returns false so the
 /// relink guard can only ever add a prompt, never block setup (#603).
-fn account_exists_locally(account: &str) -> bool {
+pub(crate) fn account_exists_locally(account: &str) -> bool {
     signal_cli_accounts_path()
         .and_then(|p| std::fs::read_to_string(p).ok())
         .is_some_and(|contents| accounts_json_contains(&contents, account))
@@ -821,7 +821,7 @@ fn account_exists_locally(account: &str) -> bool {
 /// number before relinking. `--ignore-registered` lets it proceed even when
 /// signal-cli still considers the (now unlinked) account registered. Does not
 /// touch the Signal servers, so it is safe for the local-conflict case (#603).
-async fn delete_local_account_data(config: &Config) -> Result<()> {
+pub(crate) async fn delete_local_account_data(config: &Config) -> Result<()> {
     let status = Command::new(&config.signal_cli_path)
         .arg("-a")
         .arg(&config.account)


### PR DESCRIPTION
Closes #607.

## What

Non-interactive counterpart to the relink guard (#603/#606). `siggy --reset-account` clears local signal-cli account data for the configured account and exits, for scripted/headless relinks:

```sh
siggy --reset-account   # clears stale local data
siggy --setup           # relink from a clean slate
```

Mirrors the existing `--reset-lock` flag.

## Behaviour

- No account configured -> error, exit 1
- No local data for the account -> `No local account data found`, exit 0 (nothing to do; avoids a confusing signal-cli error)
- Otherwise -> `signal-cli -a <acct> deleteLocalAccountData --ignore-registered`, then exit 0 with a note to run `--setup`; exit 1 on failure

Reuses the helpers from #606 (`account_exists_locally`, `delete_local_account_data`, now `pub(crate)`). The help text and docs note that a server-side conflict also needs old devices removed on the phone (local reset alone is not enough).

## Testing
- `cargo fmt`, `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (716 + 222)
- App field count unchanged (66/66)
- Verified live (safely): `--help` lists the flag, and `--reset-account -a +19999999999` (a number with no local data) correctly read/parsed the real `accounts.json`, found no match, printed "No local account data found", and exited 0 without touching any real account