### PR TITLE
feat: inline voice message playback

### DIFF
--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -17,6 +17,10 @@ linked devices) sync into the TUI automatically.
   Requires tmux 3.3+ with `set -g allow-passthrough on` plus the
   `SIGGY_IMAGE_PROTOCOL` env var to name the outer terminal (auto-detection
   cannot see through tmux). See the Troubleshooting page.
+- **Voice messages** -- audio attachments show as `[voice ▶ name]`. Press `o`
+  (open) on the focused message to play it inline through a detected command-line
+  player (`mpv`, `ffplay`, `afplay`, `cvlc`, `paplay`, or `aplay`, in that order).
+  If none is installed it falls back to opening the file in your OS default app.
 - **Other files** -- shown as `[attachment: filename]` with the download path
 - **Send files** -- use `/attach` to open a file browser and attach a file to
   your next message

--- a/src/app.rs
+++ b/src/app.rs
@@ -3746,9 +3746,21 @@ impl App {
                     .and_then(|n| n.to_str())
                     .map(str::to_string)
                     .unwrap_or_else(|| path.clone());
-                match open::that(&canon) {
-                    Ok(()) => self.status_message = format!("Opened {filename}"),
-                    Err(e) => self.status_message = format!("Failed to open: {e}"),
+                // Voice/audio: play inline via a detected CLI player (#199)
+                // instead of handing off to the OS default app. Falls back to
+                // open::that when no player is installed.
+                if crate::audio::is_audio_path(&canon)
+                    && let Some(player) = crate::audio::detect_player(None)
+                {
+                    match crate::audio::play(&canon, &player) {
+                        Ok(_) => self.status_message = format!("Playing {filename}"),
+                        Err(e) => self.status_message = format!("Failed to play {filename}: {e}"),
+                    }
+                } else {
+                    match open::that(&canon) {
+                        Ok(()) => self.status_message = format!("Opened {filename}"),
+                        Err(e) => self.status_message = format!("Failed to open: {e}"),
+                    }
                 }
             }
         }

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -4144,6 +4144,26 @@ fn attachment_without_filename_uses_content_type(mut app: App) {
     let mut msg = make_msg("+1", None, None, false);
     msg.attachments = vec![Attachment {
         id: "a1".to_string(),
+        content_type: "application/x-thing".to_string(),
+        filename: None,
+        local_path: None,
+    }];
+    app.handle_signal_event(SignalEvent::MessageReceived(msg));
+    let conv = &app.store.conversations["+1"];
+    assert!(
+        conv.messages
+            .iter()
+            .any(|m| m.body.contains("[attachment: application/x-thing]"))
+    );
+}
+
+#[rstest]
+fn audio_attachment_renders_as_voice(mut app: App) {
+    // Voice notes / audio attachments get a play affordance, not the generic
+    // attachment label (#199).
+    let mut msg = make_msg("+1", None, None, false);
+    msg.attachments = vec![Attachment {
+        id: "a1".to_string(),
         content_type: "audio/ogg".to_string(),
         filename: None,
         local_path: None,
@@ -4153,7 +4173,8 @@ fn attachment_without_filename_uses_content_type(mut app: App) {
     assert!(
         conv.messages
             .iter()
-            .any(|m| m.body.contains("[attachment: audio/ogg]"))
+            .any(|m| m.body.contains("[voice \u{25b6} audio/ogg]")),
+        "audio attachment should render as a voice play affordance"
     );
 }
 

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,148 @@
+//! Inline voice-message playback (#199).
+//!
+//! Signal voice notes arrive as audio attachments (usually `audio/ogg`/opus).
+//! Rather than take on a Rust audio-decoding dependency, siggy shells out to
+//! whatever command-line player is already installed, detected the same way it
+//! detects signal-cli. Playback is fire-and-forget: the player runs detached
+//! and siggy does not track progress (a live progress indicator is a follow-up).
+//! When no player is found, callers fall back to opening the file in the OS
+//! default app.
+
+use std::path::Path;
+use std::process::{Child, Command, Stdio};
+
+/// Known headless CLI players, in preference order, with the args that make
+/// them play one file and exit without opening a window. `mpv`/`ffplay` (and
+/// `cvlc`) decode Signal's opus/ogg notes; `afplay` is macOS-native; `paplay`/
+/// `aplay` are last because they only reliably handle PCM/WAV.
+const PLAYERS: &[(&str, &[&str])] = &[
+    ("mpv", &["--no-video", "--really-quiet"]),
+    ("ffplay", &["-nodisp", "-autoexit", "-loglevel", "quiet"]),
+    ("afplay", &[]),
+    ("cvlc", &["--play-and-exit", "--intf", "dummy"]),
+    ("paplay", &[]),
+    ("aplay", &["-q"]),
+];
+
+/// The fixed arguments for a known player name, or `None` if unknown. Pure, so
+/// the player table can be unit-tested without touching the filesystem.
+fn player_args(name: &str) -> Option<&'static [&'static str]> {
+    PLAYERS
+        .iter()
+        .find(|(n, _)| *n == name)
+        .map(|(_, args)| *args)
+}
+
+/// Whether `exe` is found on `PATH` (honouring Windows executable extensions).
+fn on_path(exe: &str) -> bool {
+    let exts: &[&str] = if cfg!(windows) {
+        &["", ".exe", ".bat", ".cmd", ".com"]
+    } else {
+        &[""]
+    };
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&paths).any(|dir| {
+        exts.iter()
+            .any(|ext| dir.join(format!("{exe}{ext}")).is_file())
+    })
+}
+
+/// Resolve the player command to use as `[executable, args...]`.
+///
+/// A non-empty `override_cmd` (the `audio_player` config option) wins and is
+/// used as-is, so a user can point at any binary. Otherwise the first
+/// [`PLAYERS`] entry found on `PATH` is chosen. Returns `None` when nothing is
+/// available, so the caller can fall back to opening the file externally.
+pub fn detect_player(override_cmd: Option<&str>) -> Option<Vec<String>> {
+    if let Some(cmd) = override_cmd.map(str::trim).filter(|c| !c.is_empty()) {
+        let mut parts = cmd.split_whitespace().map(str::to_string);
+        let exe = parts.next()?;
+        let mut command = vec![exe];
+        command.extend(parts);
+        return Some(command);
+    }
+    for (name, args) in PLAYERS {
+        if on_path(name) {
+            let mut command = vec![(*name).to_string()];
+            command.extend(args.iter().map(|s| (*s).to_string()));
+            return Some(command);
+        }
+    }
+    None
+}
+
+/// Spawn `player` (from [`detect_player`]) on `path`, detached, with stdio
+/// silenced so it never disturbs the TUI. Returns the child handle; the caller
+/// may drop it (fire-and-forget) or keep it to stop playback later.
+pub fn play(path: &Path, player: &[String]) -> std::io::Result<Child> {
+    let (exe, args) = player.split_first().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "empty player command")
+    })?;
+    Command::new(exe)
+        .args(args)
+        .arg(path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+}
+
+/// Whether a content type is an audio attachment (a voice note or audio file).
+pub fn is_audio(content_type: &str) -> bool {
+    content_type.starts_with("audio/")
+}
+
+/// Whether a file path looks like a playable audio file by extension. Used to
+/// decide, at open time, whether to play inline rather than hand off to the OS.
+pub fn is_audio_path(path: &Path) -> bool {
+    matches!(
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .as_deref(),
+        Some("mp3" | "ogg" | "oga" | "m4a" | "wav" | "flac" | "opus" | "aac")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_audio_matches_audio_types_only() {
+        assert!(is_audio("audio/ogg"));
+        assert!(is_audio("audio/aac"));
+        assert!(!is_audio("image/png"));
+        assert!(!is_audio("application/octet-stream"));
+        assert!(!is_audio(""));
+    }
+
+    #[test]
+    fn player_args_known_and_unknown() {
+        assert_eq!(
+            player_args("ffplay"),
+            Some(["-nodisp", "-autoexit", "-loglevel", "quiet"].as_slice())
+        );
+        assert_eq!(player_args("afplay"), Some([].as_slice()));
+        assert_eq!(player_args("not-a-player"), None);
+    }
+
+    #[test]
+    fn detect_player_honours_override_verbatim() {
+        // Single binary.
+        assert_eq!(
+            detect_player(Some("/usr/bin/myplayer")),
+            Some(vec!["/usr/bin/myplayer".to_string()])
+        );
+        // Override with args is split on whitespace.
+        assert_eq!(
+            detect_player(Some("mpv --no-config")),
+            Some(vec!["mpv".to_string(), "--no-config".to_string()])
+        );
+        // Blank / whitespace override is ignored: behaves identically to no
+        // override (both fall through to PATH autodetect).
+        assert_eq!(detect_player(Some("   ")), detect_player(None));
+    }
+}

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -525,6 +525,19 @@ fn resolve_incoming(app: &App, msg: &SignalMessage) -> Option<ResolvedMessage> {
                 body_raw: None,
                 mentions: Vec::new(),
             });
+        } else if crate::audio::is_audio(&att.content_type) {
+            // Voice notes / audio: a play affordance instead of a generic
+            // attachment label. `o` (open) plays it inline (#199).
+            entries.push(ResolvedEntry {
+                body: format!("[voice \u{25b6} {label}]{path_info}"),
+                image_lines: None,
+                image_path: None,
+                mention_ranges: Vec::new(),
+                style_ranges: Vec::new(),
+                quote: None,
+                body_raw: None,
+                mentions: Vec::new(),
+            });
         } else {
             entries.push(ResolvedEntry {
                 body: format!("[attachment: {label}]{path_info}"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@
 //! startup.
 
 mod app;
+mod audio;
 mod autocomplete;
 mod config;
 mod conversation_store;

--- a/src/ui/links.rs
+++ b/src/ui/links.rs
@@ -182,9 +182,12 @@ pub(in crate::ui) fn styled_uri_spans(
         .fg(theme.mention)
         .add_modifier(Modifier::BOLD);
 
-    // Attachment/image patterns: extract bracket text as display, URI as hidden metadata
-    if body.starts_with("[image:") || body.starts_with("[attachment:") {
-        // Extract the bracket portion: [image: label] or [attachment: label]
+    // Attachment/image/voice patterns: extract bracket text as display, URI as hidden metadata
+    if body.starts_with("[image:")
+        || body.starts_with("[attachment:")
+        || body.starts_with("[voice ")
+    {
+        // Extract the bracket portion: [image: label], [attachment: label], or [voice ▶ label]
         if let Some(bracket_end) = body.find(']') {
             let display_text = &body[..=bracket_end]; // e.g. "[image: photo.jpg]"
 


### PR DESCRIPTION
Implements the core of #199 (inline playback). Live progress indicator + duration and an `audio_player` config override are deferred follow-ups (noted below).

## Problem

Voice messages (Signal voice notes arrive as `audio/ogg`/opus attachments) showed as `[attachment: audio/ogg]` with no way to listen without opening the file in an external app.

## Change

- **`src/audio.rs`** (new): detects an installed command-line player (`mpv`, `ffplay`, `afplay`, `cvlc`, `paplay`, `aplay`, in preference order) and spawns it detached with stdio silenced. No Rust audio dependency, mirroring how siggy detects signal-cli. Includes an override hook for a future config option.
- **Inline affordance**: audio attachments now render as `[voice ▶ name]` instead of the generic attachment label.
- **Playback**: the existing `o` (open) key plays a focused voice/audio attachment inline via the detected player, falling back to the OS default app (`open::that`) when no player is installed.

## Design notes

- **Fire-and-forget** this pass: no `App` state, so **no field-count impact** (66/66).
- **Deferred follow-ups** (in #199): live progress `[voice 0:05/0:12]` + duration (needs playback tracking / `ffprobe`), and the `audio_player` config override (detection already supports it; plumbing it needs a domain extraction to stay under the field ratchet).

## Testing
- `cargo fmt`, `cargo clippy --tests -- -D warnings` clean
- `cargo test` green (720 + 222), incl. new unit tests for the player table / override parsing / audio detection, and an integration test for the `[voice ▶ …]` render label
- App field count unchanged (66/66)
- Note: inline playback against a real voice note + a real player is best verified live (`o` on a received voice message)