### PR TITLE
feat: export conversations to markdown, JSON, or plain text

### DIFF
--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -12,7 +12,7 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 | `/search` | `/s` | `<query>` | Search messages across all conversations |
 | `/attach` | `/a` | | Open file browser to attach a file |
 | `/paste` | `/pa` | | Paste from clipboard (text or image) |
-| `/export` | | `[n]` | Export chat history to plain text file |
+| `/export` | | `[txt\|md\|json] [n]` | Export chat history to a file |
 | `/sidebar` | `/sb` | | Toggle sidebar visibility |
 | `/bell` | `/notify` | `[type]` | Toggle notifications (`direct`, `group`, or both) |
 | `/mute` | | | Mute/unmute current conversation |
@@ -171,12 +171,19 @@ to confirm (or Esc to cancel). Move to Save and press Enter to push changes.
 /export
 ```
 
-Exports all messages in the current conversation to a text file in your Downloads
-directory (e.g. `siggy-export-Alice-2026-03-14.txt`).
+Exports all messages in the current conversation to a file in your Downloads
+directory (e.g. `siggy-export-Alice-2026-03-14.txt`). Pass a format for
+Markdown or JSON output:
 
-**Export last 50 messages:**
+```
+/export md
+/export json
+```
+
+**Export last 50 messages (any format):**
 ```
 /export 50
+/export md 50
 ```
 
 ## Messaging a new contact

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -435,13 +435,20 @@ conversation. A filterable picker overlay lets you choose the destination.
 
 ## Export chat history
 
-Use `/export` to save the active conversation's messages as a plain text file.
-The file is saved to your Downloads directory as `siggy-export-<name>-<date>.txt`.
+Use `/export` to save the active conversation's messages to a file in your
+Downloads directory as `siggy-export-<name>-<date>.<ext>`. Three formats are
+available:
 
-Use `/export <n>` to export only the last N messages (e.g. `/export 100`).
+- `/export` or `/export txt` - plain text in a simple IRC-style format
+- `/export md` - Markdown, nicer for reading and sharing
+- `/export json` - structured output for scripting (pipe through `jq`)
 
-The output includes timestamps, sender names, message bodies, "(edited)" labels,
-quoted replies, and system messages in a simple IRC-style format.
+Add a number to export only the last N messages, in either order:
+`/export md 100` or `/export 100 md`.
+
+All formats include timestamps, sender names, message bodies, "(edited)"
+labels, quoted replies, and reactions. JSON additionally carries sender IDs,
+millisecond timestamps, and deleted/system flags.
 
 ## Demo mode
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3766,8 +3766,14 @@ impl App {
         }
     }
 
-    /// Export the active conversation's messages to a plain text file.
-    pub(crate) fn export_chat_history(&mut self, limit: Option<usize>) {
+    /// Export the active conversation's messages to a file in the given
+    /// format (plain text, Markdown, or JSON). Rendering lives in
+    /// `crate::export`; this owns file naming, sanitizing, and the write.
+    pub(crate) fn export_chat_history(
+        &mut self,
+        format: crate::export::ExportFormat,
+        limit: Option<usize>,
+    ) {
         let conv_id = match self.active_conversation.as_ref() {
             Some(id) => id.clone(),
             None => {
@@ -3791,8 +3797,6 @@ impl App {
             return;
         }
 
-        // Build plain text output
-        let mut output = String::new();
         let safe_name: String = conv
             .name
             .chars()
@@ -3804,39 +3808,25 @@ impl App {
                 }
             })
             .collect();
-        let date = chrono::Local::now().format("%Y-%m-%d");
-        let filename = format!("siggy-export-{safe_name}-{date}.txt");
+        let now = chrono::Local::now();
+        let filename = format!(
+            "siggy-export-{safe_name}-{}.{}",
+            now.format("%Y-%m-%d"),
+            format.extension()
+        );
 
-        output.push_str(&format!("Chat export: {}\n", conv.name));
-        output.push_str(&format!(
-            "Exported: {}\n",
-            chrono::Local::now().format("%Y-%m-%d %H:%M")
-        ));
-        output.push_str(&format!("Messages: {}\n", export_msgs.len()));
-        output.push_str(&"-".repeat(60));
-        output.push('\n');
+        let output = crate::export::render(format, &conv.name, export_msgs, now);
 
-        for msg in export_msgs {
-            let time = msg
-                .timestamp
-                .with_timezone(&chrono::Local)
-                .format("%Y-%m-%d %H:%M");
-            if msg.is_system {
-                output.push_str(&format!("[{time}] * {}\n", msg.body));
-            } else {
-                let prefix = if msg.is_edited { "(edited) " } else { "" };
-                output.push_str(&format!("[{time}] <{}> {prefix}{}\n", msg.sender, msg.body));
-                if let Some(ref q) = msg.quote {
-                    output.push_str(&format!("  > <{}> {}\n", q.author, q.body));
-                }
-            }
-        }
-
-        // Strip control characters from the assembled export (message bodies
+        // Strip control characters from text/Markdown exports (message bodies
         // and names are remote-controlled) so the saved file cannot inject
         // terminal escapes when viewed with cat/less (#504). Structural
-        // newlines and tabs are preserved.
-        let output = crate::debug_log::strip_control_chars(&output, true);
+        // newlines and tabs are preserved. JSON needs no stripping: serde
+        // escapes control characters inside strings.
+        let output = if format == crate::export::ExportFormat::Json {
+            output
+        } else {
+            crate::debug_log::strip_control_chars(&output, true)
+        };
 
         // Write to download dir or home
         let dir = dirs::download_dir()

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,0 +1,289 @@
+//! Conversation export rendering (#613).
+//!
+//! Pure formatting for `/export`: given a conversation name and its display
+//! messages, produce the file contents in plain text, Markdown, or JSON.
+//! `App::export_chat_history` owns file naming, control-char stripping, and
+//! the actual write; everything here is side-effect free so each format can
+//! be unit-tested on constructed messages.
+
+use chrono::{DateTime, Local};
+
+use crate::conversation_store::DisplayMessage;
+// ExportFormat lives in `input` (with the `/export` parser) because `input`
+// is part of the fuzz lib target and this module is not.
+pub use crate::input::ExportFormat;
+
+/// Render `messages` in the given format. `exported_at` is stamped into the
+/// header (passed in rather than read from the clock so output is testable).
+pub fn render(
+    format: ExportFormat,
+    conv_name: &str,
+    messages: &[DisplayMessage],
+    exported_at: DateTime<Local>,
+) -> String {
+    match format {
+        ExportFormat::Text => render_text(conv_name, messages, exported_at),
+        ExportFormat::Markdown => render_markdown(conv_name, messages, exported_at),
+        ExportFormat::Json => render_json(conv_name, messages, exported_at),
+    }
+}
+
+fn local_minute(ts: &DateTime<chrono::Utc>) -> String {
+    ts.with_timezone(&Local)
+        .format("%Y-%m-%d %H:%M")
+        .to_string()
+}
+
+fn reactions_summary(msg: &DisplayMessage) -> Option<String> {
+    if msg.reactions.is_empty() {
+        return None;
+    }
+    Some(
+        msg.reactions
+            .iter()
+            .map(|r| format!("{} ({})", r.emoji, r.sender))
+            .collect::<Vec<_>>()
+            .join(", "),
+    )
+}
+
+fn render_text(
+    conv_name: &str,
+    messages: &[DisplayMessage],
+    exported_at: DateTime<Local>,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("Chat export: {conv_name}\n"));
+    out.push_str(&format!(
+        "Exported: {}\n",
+        exported_at.format("%Y-%m-%d %H:%M")
+    ));
+    out.push_str(&format!("Messages: {}\n", messages.len()));
+    out.push_str(&"-".repeat(60));
+    out.push('\n');
+
+    for msg in messages {
+        let time = local_minute(&msg.timestamp);
+        if msg.is_system {
+            out.push_str(&format!("[{time}] * {}\n", msg.body));
+        } else {
+            let prefix = if msg.is_edited { "(edited) " } else { "" };
+            out.push_str(&format!("[{time}] <{}> {prefix}{}\n", msg.sender, msg.body));
+            if let Some(ref q) = msg.quote {
+                out.push_str(&format!("  > <{}> {}\n", q.author, q.body));
+            }
+            if let Some(reactions) = reactions_summary(msg) {
+                out.push_str(&format!("  reactions: {reactions}\n"));
+            }
+        }
+    }
+    out
+}
+
+fn render_markdown(
+    conv_name: &str,
+    messages: &[DisplayMessage],
+    exported_at: DateTime<Local>,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# Chat export: {conv_name}\n\n"));
+    out.push_str(&format!(
+        "Exported {} - {} messages\n\n---\n",
+        exported_at.format("%Y-%m-%d %H:%M"),
+        messages.len()
+    ));
+
+    for msg in messages {
+        let time = local_minute(&msg.timestamp);
+        out.push('\n');
+        if msg.is_system {
+            out.push_str(&format!("*[{time}] {}*\n", msg.body));
+            continue;
+        }
+        let edited = if msg.is_edited { " (edited)" } else { "" };
+        out.push_str(&format!(
+            "**[{time}] {}:**{edited} {}\n",
+            msg.sender, msg.body
+        ));
+        if let Some(ref q) = msg.quote {
+            out.push_str(&format!("> {}: {}\n", q.author, q.body));
+        }
+        if let Some(reactions) = reactions_summary(msg) {
+            out.push_str(&format!("- reactions: {reactions}\n"));
+        }
+    }
+    out
+}
+
+fn render_json(
+    conv_name: &str,
+    messages: &[DisplayMessage],
+    exported_at: DateTime<Local>,
+) -> String {
+    let msgs: Vec<serde_json::Value> = messages
+        .iter()
+        .map(|msg| {
+            serde_json::json!({
+                "timestamp": msg.timestamp.to_rfc3339(),
+                "timestamp_ms": msg.timestamp_ms,
+                "sender": msg.sender,
+                "sender_id": msg.sender_id,
+                "body": msg.body,
+                "system": msg.is_system,
+                "edited": msg.is_edited,
+                "deleted": msg.is_deleted,
+                "quote": msg.quote.as_ref().map(|q| {
+                    serde_json::json!({ "author": q.author, "body": q.body })
+                }),
+                "reactions": msg.reactions.iter().map(|r| {
+                    serde_json::json!({ "emoji": r.emoji, "sender": r.sender })
+                }).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+
+    let doc = serde_json::json!({
+        "conversation": conv_name,
+        "exported_at": exported_at.to_rfc3339(),
+        "message_count": messages.len(),
+        "messages": msgs,
+    });
+    // Pretty output for humans; still valid input for jq and scripts.
+    serde_json::to_string_pretty(&doc).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation_store::Quote;
+    use crate::signal::types::{MessageStatus, Reaction};
+    use chrono::TimeZone;
+
+    fn msg(sender: &str, body: &str, ts_ms: i64) -> DisplayMessage {
+        DisplayMessage {
+            sender: sender.to_string(),
+            timestamp: chrono::Utc.timestamp_millis_opt(ts_ms).unwrap(),
+            body: body.to_string(),
+            is_system: false,
+            image_lines: None,
+            image_path: None,
+            status: Some(MessageStatus::Sent),
+            timestamp_ms: ts_ms,
+            reactions: Vec::new(),
+            mention_ranges: Vec::new(),
+            style_ranges: Vec::new(),
+            body_raw: None,
+            mentions: Vec::new(),
+            quote: None,
+            is_edited: false,
+            is_deleted: false,
+            is_pinned: false,
+            sender_id: sender.to_string(),
+            expires_in_seconds: 0,
+            expiration_start_ms: 0,
+            poll_data: None,
+            poll_votes: Vec::new(),
+            preview: None,
+            preview_image_lines: None,
+            preview_image_path: None,
+        }
+    }
+
+    fn now() -> DateTime<Local> {
+        Local.timestamp_millis_opt(1_700_000_000_000).unwrap()
+    }
+
+    #[test]
+    fn from_arg_parses_formats_case_insensitively() {
+        assert_eq!(ExportFormat::from_arg("txt"), Some(ExportFormat::Text));
+        assert_eq!(ExportFormat::from_arg("TEXT"), Some(ExportFormat::Text));
+        assert_eq!(ExportFormat::from_arg("md"), Some(ExportFormat::Markdown));
+        assert_eq!(
+            ExportFormat::from_arg("Markdown"),
+            Some(ExportFormat::Markdown)
+        );
+        assert_eq!(ExportFormat::from_arg("json"), Some(ExportFormat::Json));
+        assert_eq!(ExportFormat::from_arg("csv"), None);
+        assert_eq!(ExportFormat::from_arg("100"), None);
+    }
+
+    #[test]
+    fn text_includes_header_quote_and_reactions() {
+        let mut m = msg("alice", "hello", 1_700_000_000_000);
+        m.quote = Some(Quote {
+            author: "bob".to_string(),
+            body: "earlier".to_string(),
+            timestamp_ms: 1,
+            author_id: "+2".to_string(),
+        });
+        m.reactions = vec![Reaction {
+            emoji: "\u{1F44D}".to_string(),
+            sender: "bob".to_string(),
+        }];
+        let out = render(ExportFormat::Text, "Alice", &[m], now());
+        assert!(out.starts_with("Chat export: Alice\n"));
+        assert!(out.contains("Messages: 1\n"));
+        assert!(out.contains("<alice> hello\n"));
+        assert!(out.contains("  > <bob> earlier\n"));
+        assert!(out.contains("  reactions: \u{1F44D} (bob)\n"));
+    }
+
+    #[test]
+    fn text_marks_system_and_edited_messages() {
+        let mut edited = msg("alice", "fixed", 1);
+        edited.is_edited = true;
+        let mut system = msg("", "group renamed", 2);
+        system.is_system = true;
+        let out = render(ExportFormat::Text, "c", &[edited, system], now());
+        assert!(out.contains("<alice> (edited) fixed\n"));
+        assert!(out.contains("] * group renamed\n"));
+    }
+
+    #[test]
+    fn markdown_formats_messages_and_quotes() {
+        let mut m = msg("alice", "hello", 1_700_000_000_000);
+        m.quote = Some(Quote {
+            author: "bob".to_string(),
+            body: "earlier".to_string(),
+            timestamp_ms: 1,
+            author_id: "+2".to_string(),
+        });
+        let out = render(ExportFormat::Markdown, "Alice", &[m], now());
+        assert!(out.starts_with("# Chat export: Alice\n"));
+        assert!(out.contains("alice:** hello\n"));
+        assert!(out.contains("> bob: earlier\n"));
+    }
+
+    #[test]
+    fn json_round_trips_and_carries_fields() {
+        let mut m = msg("alice", "hi \"there\"", 1_700_000_000_000);
+        m.reactions = vec![Reaction {
+            emoji: "\u{2764}".to_string(),
+            sender: "you".to_string(),
+        }];
+        let out = render(ExportFormat::Json, "Alice", &[m], now());
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["conversation"], "Alice");
+        assert_eq!(v["message_count"], 1);
+        assert_eq!(v["messages"][0]["sender"], "alice");
+        assert_eq!(v["messages"][0]["body"], "hi \"there\"");
+        assert_eq!(v["messages"][0]["quote"], serde_json::Value::Null);
+        assert_eq!(v["messages"][0]["reactions"][0]["emoji"], "\u{2764}");
+    }
+
+    #[test]
+    fn json_escapes_control_characters() {
+        let m = msg("alice", "evil\u{1b}[31mtext", 1);
+        let out = render(ExportFormat::Json, "c", &[m], now());
+        // Raw ESC must not appear; serde escapes it as a \u sequence.
+        assert!(!out.contains('\u{1b}'));
+        assert!(out.contains("\\u001b"));
+    }
+
+    #[test]
+    fn extensions_match_formats() {
+        assert_eq!(ExportFormat::Text.extension(), "txt");
+        assert_eq!(ExportFormat::Markdown.extension(), "md");
+        assert_eq!(ExportFormat::Json.extension(), "json");
+    }
+}

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -172,8 +172,8 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
             allow_multiple,
         } => create_poll(app, question, options, allow_multiple),
         InputAction::Paste => app.handle_paste_command(),
-        InputAction::Export(limit) => {
-            app.export_chat_history(limit);
+        InputAction::Export { format, limit } => {
+            app.export_chat_history(format, limit);
             None
         }
         InputAction::Unknown(msg) => {

--- a/src/input.rs
+++ b/src/input.rs
@@ -167,8 +167,8 @@ pub const COMMANDS: &[CommandInfo] = &[
     CommandInfo {
         name: "/export",
         alias: "",
-        args: "[n]",
-        description: "Export chat history to text file",
+        args: "[txt|md|json] [n]",
+        description: "Export chat history to a file",
     },
     CommandInfo {
         name: "/help",
@@ -257,8 +257,11 @@ pub enum InputAction {
     Keybindings,
     /// Open the emoji picker overlay (optional initial search filter)
     Emoji(String),
-    /// Export chat history to a text file (optional: last N messages)
-    Export(Option<usize>),
+    /// Export chat history to a file (optional format and last-N limit)
+    Export {
+        format: ExportFormat,
+        limit: Option<usize>,
+    },
     /// Unknown command
     Unknown(String),
 }
@@ -349,21 +352,60 @@ pub fn parse_input(input: &str) -> InputAction {
         "/profile" => InputAction::Profile,
         "/about" => InputAction::About,
         "/keybindings" | "/kb" => InputAction::Keybindings,
-        "/export" => {
-            if arg.is_empty() {
-                InputAction::Export(None)
-            } else {
-                match arg.parse::<usize>() {
-                    Ok(n) => InputAction::Export(Some(n)),
-                    Err(_) => InputAction::Unknown(
-                        "/export takes an optional number (e.g. /export 100)".to_string(),
-                    ),
-                }
-            }
-        }
+        "/export" => parse_export_args(&arg),
         "/help" | "/h" => InputAction::Help,
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }
+}
+
+/// Output format for a conversation export. Rendering lives in
+/// `crate::export`; the enum lives here so the `/export` parser stays inside
+/// the fuzzable lib target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportFormat {
+    Text,
+    Markdown,
+    Json,
+}
+
+impl ExportFormat {
+    /// Parse a `/export` argument token; `None` if it is not a format name.
+    pub fn from_arg(arg: &str) -> Option<Self> {
+        match arg.to_ascii_lowercase().as_str() {
+            "txt" | "text" => Some(ExportFormat::Text),
+            "md" | "markdown" => Some(ExportFormat::Markdown),
+            "json" => Some(ExportFormat::Json),
+            _ => None,
+        }
+    }
+
+    /// File extension for the export file.
+    pub fn extension(self) -> &'static str {
+        match self {
+            ExportFormat::Text => "txt",
+            ExportFormat::Markdown => "md",
+            ExportFormat::Json => "json",
+        }
+    }
+}
+
+/// Parse `/export` arguments: an optional format name (txt/md/json) and an
+/// optional last-N message count, in either order. Defaults to plain text.
+fn parse_export_args(arg: &str) -> InputAction {
+    let mut format = ExportFormat::Text;
+    let mut limit = None;
+    for token in arg.split_whitespace() {
+        if let Ok(n) = token.parse::<usize>() {
+            limit = Some(n);
+        } else if let Some(f) = ExportFormat::from_arg(token) {
+            format = f;
+        } else {
+            return InputAction::Unknown(
+                "Usage: /export [txt|md|json] [n] (e.g. /export md 100)".to_string(),
+            );
+        }
+    }
+    InputAction::Export { format, limit }
 }
 
 /// Parse `/poll` arguments: extract quoted strings and `--single` flag.
@@ -540,6 +582,35 @@ mod tests {
         assert_eq!(prev_char_pos(s, 5), 1); // before the emoji
         assert_eq!(prev_char_pos(s, 1), 0); // before 'a'
         assert_eq!(prev_char_pos(s, 0), 0); // clamps at start
+    }
+
+    // --- /export argument parsing ---
+
+    #[rstest]
+    #[case("/export", ExportFormat::Text, None)]
+    #[case("/export 100", ExportFormat::Text, Some(100))]
+    #[case("/export md", ExportFormat::Markdown, None)]
+    #[case("/export json 50", ExportFormat::Json, Some(50))]
+    #[case("/export 50 markdown", ExportFormat::Markdown, Some(50))]
+    #[case("/export TXT", ExportFormat::Text, None)]
+    fn parse_export_variants(
+        #[case] input: &str,
+        #[case] format: ExportFormat,
+        #[case] limit: Option<usize>,
+    ) {
+        assert_eq!(parse_input(input), InputAction::Export { format, limit });
+    }
+
+    #[test]
+    fn parse_export_rejects_unknown_tokens() {
+        assert!(matches!(
+            parse_input("/export csv"),
+            InputAction::Unknown(_)
+        ));
+        assert!(matches!(
+            parse_input("/export md extra nonsense"),
+            InputAction::Unknown(_)
+        ));
     }
 
     // --- No-arg commands: 19 cases → 1 parameterized test ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod db;
 mod debug_log;
 mod demo;
 mod domain;
+mod export;
 mod fs_migrate;
 mod handlers;
 mod image_render;


### PR DESCRIPTION
Closes #613.

## What

Extends `/export` with a format argument: `/export [txt|md|json] [n]`, format and last-N limit accepted in either order (`/export md 100` or `/export 100 md`). Plain text remains the default and keeps its exact IRC-style layout.

- **txt** - unchanged format, plus reactions (previously omitted)
- **md** - Markdown with bold sender headers, blockquoted replies, italic system messages
- **json** - pretty-printed structured output for scripting: timestamps (RFC 3339 + ms), sender + sender_id, body, system/edited/deleted flags, quote, reactions

## How

- New `src/export.rs`: pure per-format render functions taking `(conv_name, messages, exported_at)`. The timestamp is passed in rather than read from the clock, so every format is unit-tested on constructed messages.
- `App::export_chat_history` keeps file naming, sanitization, and the write; the filename extension now follows the format.
- `ExportFormat` lives in `input.rs` (with the `/export` parser) because `input` is part of the fuzz lib target and the render module is not; `export.rs` re-exports it.
- JSON output skips the #504 control-char stripping since serde escapes control characters inside strings (covered by a test asserting raw ESC never appears); text and Markdown keep the existing sanitization.

## Docs

- `features.md`: rewritten "Export chat history" section with the three formats.
- `commands.md`: table row and examples updated.

## Testing

- 7 unit tests in `export.rs`: header/quote/reactions in text, system + edited markers, Markdown structure, JSON round-trip via serde parse, control-char escaping, format parsing, extensions.
- Parser tests in `input.rs`: 6 argument permutations plus rejection of unknown tokens.
- `cargo clippy --tests -D warnings` clean, all 989 tests pass, App field count unchanged (66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
