### PR TITLE
feat: audio_player config option to override the voice playback command

### DIFF
--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -62,6 +62,7 @@ proxy = ""
 | `lock_timeout` | int | `0` | Minutes of keyboard inactivity before the session auto-locks (0 = disabled) |
 | `db_path` | string | *(unset)* | Override the message database path. Absolute paths are used as-is; relative paths resolve under the data dir. Leave unset for the default `siggy.db`. Used to run multiple accounts side by side (see below) |
 | `image_mode` | string | `"halfblock"` | Image rendering mode: `native` (Kitty / iTerm2 / Sixel), `halfblock` (universal Unicode fallback), or `none` |
+| `audio_player` | string | *(unset)* | Command for inline voice message playback, e.g. `"mpv --no-config"`. Leave unset to autodetect a player on PATH (mpv, ffplay, afplay, cvlc, paplay, aplay) |
 | `show_link_previews` | bool | `true` | Show link preview cards for URLs in messages |
 | `date_separators` | bool | `true` | Show date separator lines between messages from different days |
 | `show_receipts` | bool | `true` | Show delivery/read receipt status symbols |

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -20,7 +20,9 @@ linked devices) sync into the TUI automatically.
 - **Voice messages** -- audio attachments show as `[voice ▶ name]`. Press `o`
   (open) on the focused message to play it inline through a detected command-line
   player (`mpv`, `ffplay`, `afplay`, `cvlc`, `paplay`, or `aplay`, in that order).
-  If none is installed it falls back to opening the file in your OS default app.
+  Set `audio_player` in the config to use a specific command instead (see
+  [Configuration](configuration.md)). If no player is available it falls back
+  to opening the file in your OS default app.
 - **Other files** -- shown as `[attachment: filename]` with the download path
 - **Send files** -- use `/attach` to open a file browser and attach a file to
   your next message

--- a/src/app.rs
+++ b/src/app.rs
@@ -21,8 +21,8 @@ use crate::conversation_store::{ConversationStore, db_warn};
 use crate::db::Database;
 use crate::domain::{
     ActionMenuState, ContactsOverlayState, EmojiPickerState, FilePickerState, ForwardOverlayState,
-    GroupMenuOverlayState, ImageState, InputState, KeybindingsOverlayState, LockState, MouseState,
-    NotificationState, PendingState, PinDurationOverlayState, PollVoteOverlayState,
+    GroupMenuOverlayState, ImageState, InputState, KeybindingsOverlayState, LockState, MediaState,
+    MouseState, NotificationState, PendingState, PinDurationOverlayState, PollVoteOverlayState,
     ProfileOverlayState, ReactionState, ScrollState, SearchAction, SearchState,
     SettingsOverlayState, SettingsProfileOverlayState, ThemePickerState, TypingState,
     VerifyOverlayState,
@@ -521,9 +521,8 @@ pub struct App {
     pub prev_active_conversation: Option<String>,
     /// Incognito mode — in-memory DB, no local persistence
     pub incognito: bool,
-    /// Directory attachments are downloaded to. "Open attachment" refuses any
-    /// path outside this directory (message bodies are remote-controlled text).
-    pub download_dir: PathBuf,
+    /// Media handling: attachment download dir and voice playback override.
+    pub media: MediaState,
     /// Show date separator lines between messages from different days
     pub date_separators: bool,
     /// Show delivery/read receipt status symbols on outgoing messages
@@ -1830,7 +1829,7 @@ impl App {
             image: ImageState::new(image_render_tx, image_render_rx),
             prev_active_conversation: None,
             incognito: false,
-            download_dir: PathBuf::new(),
+            media: MediaState::default(),
             date_separators: true,
             show_receipts: true,
             color_receipts: true,
@@ -3728,7 +3727,7 @@ impl App {
 
     fn open_file(&mut self, uri: &str) {
         let path = file_uri_to_path(uri);
-        match classify_file_open(&path, &self.download_dir) {
+        match classify_file_open(&path, &self.media.download_dir) {
             OpenFileDecision::NotFound => {
                 self.status_message = format!("File not found: {path}");
             }
@@ -3750,7 +3749,8 @@ impl App {
                 // instead of handing off to the OS default app. Falls back to
                 // open::that when no player is installed.
                 if crate::audio::is_audio_path(&canon)
-                    && let Some(player) = crate::audio::detect_player(None)
+                    && let Some(player) =
+                        crate::audio::detect_player(self.media.audio_player.as_deref())
                 {
                     match crate::audio::play(&canon, &player) {
                         Ok(_) => self.status_message = format!("Playing {filename}"),

--- a/src/config.rs
+++ b/src/config.rs
@@ -137,6 +137,12 @@ pub struct Config {
     #[serde(default)]
     pub cell_pixel_height: u16,
 
+    /// Command used to play voice messages inline, e.g. "mpv --no-config".
+    /// Absent or empty autodetects a CLI player on PATH (mpv, ffplay,
+    /// afplay, cvlc, paplay, aplay, in that order).
+    #[serde(default)]
+    pub audio_player: Option<String>,
+
     /// Legacy: show inline halfblock image previews (migrated to image_mode)
     #[serde(default = "default_true", skip_serializing)]
     pub inline_images: bool,
@@ -260,6 +266,7 @@ impl Default for Config {
             image_mode: Some(ImageMode::Halfblock),
             cell_pixel_width: 0,
             cell_pixel_height: 0,
+            audio_player: None,
             inline_images: true,
             show_link_previews: true,
             native_images: false,

--- a/src/domain/media.rs
+++ b/src/domain/media.rs
@@ -1,0 +1,18 @@
+//! Media-handling sub-state extracted from `App` (#352 pattern).
+//!
+//! Holds the media-related values copied from `Config` at startup: where
+//! attachments are downloaded and how voice messages are played.
+
+use std::path::PathBuf;
+
+/// Media-handling configuration snapshot.
+#[derive(Default)]
+pub struct MediaState {
+    /// Directory attachments are downloaded to. "Open attachment" refuses any
+    /// path outside this directory (message bodies are remote-controlled text).
+    pub download_dir: PathBuf,
+    /// User override for the voice playback command (`audio_player` in
+    /// config.toml, e.g. "mpv --no-config"). `None` or empty falls back to
+    /// autodetecting a player on PATH (see `crate::audio::detect_player`).
+    pub audio_player: Option<String>,
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -11,6 +11,7 @@ mod file_picker;
 mod image;
 mod input;
 mod lock;
+mod media;
 mod mouse;
 mod notification;
 mod overlays;
@@ -27,6 +28,7 @@ pub use image::{ImageMode, ImageRenderResult, ImageState, LinkRegion, VisibleIma
 pub use input::InputState;
 pub use lock::{LockPhase, LockState};
 pub use lock::{hash_passphrase, load_hash, lock_hash_path, save_hash, verify_passphrase};
+pub use media::MediaState;
 pub use mouse::MouseState;
 pub use notification::{NotificationPreview, NotificationState};
 pub use overlays::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -1630,7 +1630,8 @@ async fn run_app(
     app.notifications.clipboard_clear_seconds = config.clipboard_clear_seconds;
     app.image.image_mode = config.image_mode.unwrap_or_default();
     app.incognito = incognito;
-    app.download_dir = config.download_dir.clone();
+    app.media.download_dir = config.download_dir.clone();
+    app.media.audio_player = config.audio_player.clone();
     app.sidebar_width = config.sidebar_width.clamp(14, 40);
     if config.cell_pixel_width > 0 && config.cell_pixel_height > 0 {
         app.image.cell_px = (config.cell_pixel_width, config.cell_pixel_height);


### PR DESCRIPTION
Closes #619.

## What

Adds an `audio_player` config option that overrides PATH autodetection for inline voice message playback (#617):

```toml
audio_player = "mpv --no-config"
```

Absent or empty keeps the existing behavior: autodetect mpv, ffplay, afplay, cvlc, paplay, or aplay on PATH.

## How

- The override plumbing already existed: `audio::detect_player(Some(cmd))` splits the command on whitespace and uses it verbatim (with unit tests from #617). This PR wires it to config.
- New `Config::audio_player: Option<String>` field (serde default, so existing config files are untouched; `None` is omitted on save).
- Field-count ratchet: to keep `App` at its 66-field baseline, `download_dir` is extracted into a new `domain::MediaState` sub-struct that also carries the new `audio_player` override (the #352 pattern). Net direct-field count is flat.

## Docs

- `configuration.md`: new table row.
- `features.md`: voice messages bullet mentions the override.

## Testing

- Existing `detect_player` override tests cover the behavior (verbatim command, whitespace split, blank falls back to autodetect).
- `cargo clippy --tests -D warnings` clean, all 989 tests pass, App field count 66 (baseline 66).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
