### PR TITLE
feat: reveal spoiler text while the message is focused

### DIFF
--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -215,7 +215,8 @@ Signal formatting is rendered in the chat area:
 - **Italic** -- displayed with terminal italic
 - **Strikethrough** -- displayed with terminal strikethrough
 - **Monospace** -- displayed in gray
-- **Spoiler** -- hidden behind block characters (`████`)
+- **Spoiler** -- hidden behind block characters (`████`); focus the message
+  with `J`/`K` in Normal mode to reveal the text while focused
 
 Styles compose correctly with @mentions and link highlighting.
 

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -493,9 +493,17 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
                 lines.push(Line::from(spans));
                 line_msg_idx.push(Some(msg_index));
             } else {
-                // Style URIs and @mentions
-                let (body_spans, hidden_url) =
-                    styled_uri_spans(&msg.body, &msg.mention_ranges, &msg.style_ranges, theme);
+                // Style URIs and @mentions. Spoilers unmask while the message
+                // is explicitly focused via J/K in Normal mode (#616).
+                let reveal_spoilers =
+                    app.mode == InputMode::Normal && app.scroll.focused_index == Some(msg_index);
+                let (body_spans, hidden_url) = styled_uri_spans(
+                    &msg.body,
+                    &msg.mention_ranges,
+                    &msg.style_ranges,
+                    theme,
+                    reveal_spoilers,
+                );
                 if let Some(url) = hidden_url {
                     // Collect display text for link_url_map lookup
                     let display_text: String =

--- a/src/ui/links.rs
+++ b/src/ui/links.rs
@@ -166,6 +166,10 @@ pub(in crate::ui) fn split_spans_by_newline(spans: Vec<Span<'static>>) -> Vec<Ve
 /// Split a message body into spans, styling any URI (https://, http://, file:///) as
 /// underlined blue text. Non-URI text is rendered as plain spans.
 ///
+/// `reveal_spoilers` controls SPOILER ranges: masked behind block characters
+/// normally, shown as real text (in the muted spoiler color) when the message
+/// is focused (#616).
+///
 /// Returns `(spans, Option<hidden_url>)`. For attachment bodies like
 /// `[image: label](file:///path)`, the bracket text is the visible link and
 /// the URI inside parens is returned separately (not displayed).
@@ -174,6 +178,7 @@ pub(in crate::ui) fn styled_uri_spans(
     mention_ranges: &[(usize, usize)],
     style_ranges: &[(usize, usize, StyleType)],
     theme: &Theme,
+    reveal_spoilers: bool,
 ) -> (Vec<Span<'static>>, Option<String>) {
     let link_style = Style::default()
         .fg(theme.link)
@@ -322,11 +327,18 @@ pub(in crate::ui) fn styled_uri_spans(
         }
 
         let segment_text = &body[seg_start..seg_end];
-        if is_spoiler {
+        if is_spoiler && !reveal_spoilers {
             // Replace each character with a block character
             let block_text: String = segment_text.chars().map(|_| '\u{2588}').collect();
             let spoiler_style = style.fg(theme.fg_muted);
             spans.push(Span::styled(block_text, spoiler_style));
+        } else if is_spoiler {
+            // Revealed spoiler: real text in the same muted color as the mask,
+            // so it reads as "this was hidden" while the message is focused.
+            spans.push(Span::styled(
+                segment_text.to_string(),
+                style.fg(theme.fg_muted),
+            ));
         } else {
             // Apply text style modifiers
             for &(ss, se, st) in style_ranges {
@@ -367,5 +379,24 @@ mod tests {
     #[case("no-scheme.com", "no-scheme.com")]
     fn extract_url_cases(#[case] input: &str, #[case] expected: &str) {
         assert_eq!(extract_url(input), expected);
+    }
+
+    #[test]
+    fn spoiler_masked_by_default_and_revealed_on_focus() {
+        let theme = crate::theme::default_theme();
+        let ranges = vec![(6, 12, StyleType::Spoiler)];
+
+        let (spans, _) = styled_uri_spans("it is secret", &[], &ranges, &theme, false);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(
+            text,
+            "it is \u{2588}\u{2588}\u{2588}\u{2588}\u{2588}\u{2588}"
+        );
+
+        let (spans, _) = styled_uri_spans("it is secret", &[], &ranges, &theme, true);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(text, "it is secret");
+        // Revealed text keeps the muted spoiler color as a "was hidden" hint.
+        assert_eq!(spans.last().unwrap().style.fg, Some(theme.fg_muted));
     }
 }


### PR DESCRIPTION
Closes #616.

## What

Spoiler ranges render masked (`████`) as before. Focusing the message with `J`/`K` in Normal mode now reveals the real text for as long as the message is focused; moving focus away re-masks it. A terminal-native take on Signal's tap-to-reveal.

Revealed text keeps the muted spoiler color (same as the mask) so it still reads as previously-hidden content.

## How

- `styled_uri_spans` gains a `reveal_spoilers` flag: masked branch unchanged, revealed branch emits the real text with `fg_muted`.
- The single call site in `chat_pane` passes `app.mode == Normal && app.scroll.focused_index == Some(msg_index)`, so reveal follows explicit J/K focus exactly (the same condition as the focus highlight).
- Docs: features.md spoiler bullet updated.

## Testing

- New unit test: masked by default (block chars), revealed on focus with the muted color hint.
- `cargo clippy --tests -D warnings` clean, all 990 tests pass, App fields unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)