### PR TITLE
docs: bring the docsite to parity with v1.10.0

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,122 @@
 # Changelog
 
+## v1.10.0
+
+The automation-and-hardening release: a non-interactive CLI for scripting,
+supervised signal-cli reconnect, auto-lock, custom theme files, and the
+completion of the deep-review sweep (#492-#504) that finished moving every
+key handler out of `app.rs`.
+
+### New features
+
+- **Non-interactive CLI** -- `--version`, `--check` (setup health report),
+  `--send` (one-shot send), `--list` (conversations), and `--receive`
+  (streaming JSON) run without the TUI for scripts and automation (closes
+  #257). Companion docs cover scheduling messages via the OS scheduler
+  (closes #259), and the repo ships a Claude Code skill for the CLI
+  (closes #258).
+- **Supervised signal-cli reconnect** -- if the signal-cli child exits,
+  siggy now emits an explicit Disconnected state, fails in-flight sends
+  instead of leaving them stuck in Sending, and respawns the process with
+  backoff (closes #497).
+- **Auto-lock idle timer** -- new `lock_timeout` config locks the session
+  after N minutes of keyboard inactivity, rounding out the v1.8.0 session
+  lock (closes #438).
+- **Custom theme template** -- drop a `*.toml` in the themes directory and
+  it appears in `/theme`; the repo ships a fully-commented
+  `themes/custom-theme-template.toml` starting point (closes #476).
+- **Bindable command actions** -- `open_contacts`, `open_settings`,
+  `open_help`, `toggle_sidebar`, and `attach` are exposed as keybinding
+  actions (unbound by default) so overlay opens can be driven from custom
+  keys (closes #202).
+- **Side-by-side accounts** -- new `db_path` config override lets a second
+  config file point at its own message database (closes #260).
+- **Clearer signal-cli failure hints** -- outdated or failing signal-cli
+  now produces actionable errors, device-link failures surface signal-cli's
+  stderr, and a 409 "device limit / relink conflict" gets step-by-step
+  recovery guidance.
+
+### Bug fixes
+
+- **Control-character sanitization** -- exports, the debug log, and desktop
+  notifications strip terminal escape sequences from remote-controlled text
+  (message bodies, names) so a malicious message cannot inject escapes.
+- **Startup spinner hang** -- the "Loading identities..." phase can no
+  longer spin forever; a 20s watchdog surfaces the app with a warning
+  instead. The splash-screen composer hint no longer suggests messaging
+  before a conversation is open.
+- **CLI lock contention** -- `--send`/`--receive` report "another instance
+  is using this account" instead of timing out when the TUI is running.
+- **Black-square image diagnosis** -- transparency mapping in the halfblock
+  renderer is pinned by tests and `--debug` logs each image's transparency
+  ratio to make the favicon black-square report (#443) diagnosable.
+
+### Performance
+
+- Message-pane line heights cached across frames, per-tick image viewport
+  scans gated behind a signature, image encode caches bounded, off-window
+  `image_lines` evicted, message search debounced, and composer input
+  history capped (#490, #492).
+
+### Refactors and internal
+
+- Every remaining overlay, mode, and global key handler moved from `app.rs`
+  into `handlers/keys.rs`, and the inline test module split into
+  `app_tests.rs` (#494). `domain/` made a leaf layer (#495). The
+  `ui::draw()` mutation contract documented (#496).
+- New test coverage on the setup-wizard seams, the client stdout reader, DB
+  migration upgrade paths on populated databases, scrolled-state render
+  snapshots, and two new fuzz targets (cursor helpers, theme TOML) (#503).
+
+---
+
+## v1.9.1
+
+Patch release: `install.sh` now locates the signal-cli binary in the native
+tarball root (fixes fresh installs), and the release workflow supports manual
+dispatch with a tag input.
+
+---
+
+## v1.9.0
+
+A correctness-and-integrity release driven by a structured review sweep, plus
+README translations.
+
+### Bug fixes
+
+- **Send-status integrity** -- failed sends can no longer display as sent;
+  status transitions are guarded to be monotonic.
+- **Author verification** -- incoming edits and remote-deletes are applied
+  only when the sender is the original author.
+- **Receipt and read-marker integrity** -- a cluster of fixes around receipt
+  matching and read markers.
+- **Poll routing and buffering** -- poll events route to the correct
+  conversation and buffer correctly during sync.
+- **Scrollback pagination** -- stopped a pagination runaway and made older
+  history reachable again.
+- **Message ordering** -- messages re-sort after the server-timestamp
+  rewrite on send confirmation.
+- **Attachment-open vetting** -- `o` (open attachment) validates the target
+  path before shell-opening it.
+- **Theme parsing** -- multibyte hex colors in theme files are rejected
+  instead of panicking.
+- **Composer state** -- edit/reply targets clear when switching
+  conversations.
+- **Expiry sweep** -- positional indices shift correctly when disappearing
+  messages are removed.
+
+### Performance
+
+- SQLite `synchronous=NORMAL` plus batched drain-loop transactions
+  eliminate per-message fsyncs during sync bursts.
+
+### Docs
+
+- README translated into 11 languages under `translations/`.
+
+---
+
 ## v1.8.0
 
 A maintenance-and-cleanup release: one big new feature (session lock + boss key), one notable contributor PR (native inline images inside tmux), substantial idle-CPU and image-decode fixes, plus a deep tech-debt sweep across the codebase.
@@ -110,6 +227,91 @@ Thanks to:
   after the original incident.
 - [@shwoop](https://github.com/shwoop) for the passphrase-recovery review
   feedback on #437 that led directly to the `--reset-lock` flag.
+
+---
+
+## v1.7.1
+
+Patch release: the setup wizard verifies the signal-cli path is actually
+spawnable before advancing, instead of failing later with a confusing error.
+
+---
+
+## v1.7.0
+
+### New features
+
+- **Settings categories** -- the settings overlay groups toggles under
+  section headers instead of one flat list.
+- **Newline rendering** -- multi-line message bodies render their line
+  breaks (closes #318), and Shift+Enter newline input is documented
+  (closes #334).
+
+### Bug fixes
+
+- **UUID-only contacts** -- messages route correctly to contacts that have
+  no phone number visible (closes #315).
+- **@mention re-resolution** -- mentions re-resolve when the contact/group
+  list arrives after the message (closes #283).
+- **Viewport stability** -- the message viewport no longer jumps around
+  during the initial sync burst.
+- **Native image placement** -- aligned with Paragraph's actual word wrap,
+  fixing images drawn at the wrong row.
+
+### Performance
+
+- PNG pre-encoding moved to a background thread for all native image
+  protocols.
+
+### Internal
+
+- `ConversationStore` extracted from the `App` god object -- thanks to
+  [@Dowsley](https://github.com/Dowsley) for this contribution.
+- Rust toolchain pinned (1.95.0) and `cargo fmt` enforced in CI.
+
+---
+
+## v1.6.0
+
+### New features
+
+- **Sixel image protocol** -- native inline images on Windows Terminal and
+  other Sixel-capable terminals (closes #272).
+- **Open attachments and URLs from the action menu** -- `o` on a focused
+  message opens the attachment or link (closes #188).
+- **Multiple concurrent typing indicators** -- group chats show every
+  member currently typing, not just one (closes #218).
+- **Enhanced emoji support** -- broader shortcode coverage -- thanks to
+  [@shwoop](https://github.com/shwoop).
+- **Sidebar width persistence** -- the sidebar width setting survives
+  restarts.
+- **Stale conversation filtering** -- empty groups and unresolvable
+  contacts are hidden from the default sidebar view.
+
+### Bug fixes
+
+- **Wayland clipboard** -- enabled the data-control backend so copy works
+  on Wayland without a focused window -- thanks to
+  [@clinta](https://github.com/clinta).
+- **Vim normal-mode keybindings** -- a cluster of navigation fixes
+  (closes #288, #289, #290, #291).
+- **Redundant redraws** -- mouse-move events no longer trigger full
+  redraws (closes #281).
+- **JVM spawn** -- eliminated a redundant signal-cli JVM spawn on startup.
+- **Native image caches** -- preserved across conversation switches.
+
+### Internal
+
+- Began extracting domain state structs from the `App` god object; shared
+  list-overlay helpers introduced.
+
+---
+
+## v1.5.1
+
+Patch release: fixed the signal-cli native archive naming in `install.sh`
+(fresh installs failed to download signal-cli), plus major dependency bumps
+(ratatui 0.30, crossterm 0.29, rusqlite 0.38, toml 1.0).
 
 ---
 

--- a/docs/src/dev-guide/architecture.md
+++ b/docs/src/dev-guide/architecture.md
@@ -10,8 +10,8 @@ It is built on a Tokio async runtime with Ratatui for rendering.
 graph TB
     subgraph main["Main Thread"]
         KB["Keyboard Input<br/><i>crossterm poll 50ms</i>"]
-        APP["App State<br/><i>app.rs</i>"]
-        UI["Ratatui Renderer<br/><i>ui.rs</i>"]
+        APP["App State<br/><i>app.rs + domain/</i>"]
+        UI["Ratatui Renderer<br/><i>ui/</i>"]
         DB["SQLite<br/><i>db.rs · WAL mode</i>"]
     end
 
@@ -23,7 +23,7 @@ graph TB
     CLI["signal-cli<br/><i>child process</i>"]
 
     KB -- "InputAction" --> APP
-    APP -- "&App" --> UI
+    APP -- "&mut App" --> UI
     APP -- "persist" --> DB
     DB -- "load" --> APP
     APP -- "JsonRpcRequest<br/>(mpsc)" --> SW
@@ -84,16 +84,21 @@ sequenceDiagram
 
 | Crate | Purpose |
 |---|---|
-| `ratatui` 0.29 | Terminal UI framework |
-| `crossterm` 0.28 | Cross-platform terminal I/O |
+| `ratatui` 0.30 | Terminal UI framework |
+| `crossterm` 0.29 | Cross-platform terminal I/O |
 | `tokio` 1.x | Async runtime |
 | `serde` / `serde_json` | JSON serialization for signal-cli RPC |
-| `rusqlite` 0.32 | SQLite database (bundled) |
+| `rusqlite` 0.40 | SQLite database (bundled) |
 | `chrono` 0.4 | Timestamp handling |
 | `qrcode` 0.14 | QR code generation for device linking |
 | `image` 0.25 | Image decoding for inline previews |
-| `arboard` 3.x | Clipboard access for /paste |
+| `icy_sixel` 0.5 | Sixel image encoding |
+| `arboard` 3.x | Clipboard access for /paste (with Wayland data-control) |
+| `argon2` 0.5 | Session-lock passphrase hashing |
+| `notify-rust` 4.x | Desktop notifications |
+| `emojis` 0.9 | Emoji lookup and shortcodes |
+| `open` 5.x | Open attachments/URLs in the OS default app |
 | `anyhow` 1.x | Error handling |
-| `toml` 0.8 | Config file parsing |
+| `toml` 1.x | Config file parsing |
 | `dirs` 6.x | Platform-specific directory paths |
 | `uuid` 1.x | RPC request ID generation |

--- a/docs/src/dev-guide/data-flow.md
+++ b/docs/src/dev-guide/data-flow.md
@@ -32,7 +32,7 @@ sequenceDiagram
     participant SR as stdout reader
     participant A as App
     participant DB as SQLite
-    participant UI as ui.rs
+    participant UI as ui/
 
     CLI->>SR: JSON-RPC notification<br/>(method: "receive")
     SR->>A: SignalEvent::MessageReceived<br/>(mpsc channel)

--- a/docs/src/dev-guide/database.md
+++ b/docs/src/dev-guide/database.md
@@ -28,7 +28,9 @@ CREATE TABLE conversations (
     muted             INTEGER NOT NULL DEFAULT 0,  -- added in migration v2
     expiration_timer  INTEGER NOT NULL DEFAULT 0,  -- disappearing msg seconds (v7)
     accepted          INTEGER NOT NULL DEFAULT 1,  -- message request state (v8)
-    blocked           INTEGER NOT NULL DEFAULT 0   -- blocked state (v9)
+    blocked           INTEGER NOT NULL DEFAULT 0,  -- blocked state (v9)
+    mute_expires_at   TEXT,                        -- timed mute expiry, RFC 3339 (v14)
+    archived          INTEGER NOT NULL DEFAULT 0   -- hidden from sidebar (v15)
 );
 ```
 
@@ -56,7 +58,12 @@ CREATE TABLE messages (
     quote_ts_ms     INTEGER,                        -- quoted reply timestamp (v6)
     sender_id            TEXT NOT NULL DEFAULT '',       -- sender phone number (v6)
     expires_in_seconds   INTEGER NOT NULL DEFAULT 0,    -- disappearing timer (v7)
-    expiration_start_ms  INTEGER NOT NULL DEFAULT 0     -- timer start epoch ms (v7)
+    expiration_start_ms  INTEGER NOT NULL DEFAULT 0,    -- timer start epoch ms (v7)
+    pinned               INTEGER NOT NULL DEFAULT 0,    -- pinned flag (v10)
+    poll_data            TEXT,                           -- serialized poll JSON (v11)
+    link_preview         TEXT,                           -- serialized preview JSON (v12)
+    body_raw             TEXT,                           -- body with mention placeholders (v13)
+    mentions_json        TEXT                            -- serialized mention ranges (v13)
 );
 
 CREATE INDEX idx_messages_conv_ts ON messages(conversation_id, timestamp);
@@ -85,6 +92,22 @@ CREATE TABLE reactions (
 CREATE INDEX idx_reactions_target ON reactions(conversation_id, target_ts_ms);
 ```
 
+### `poll_votes`
+
+Votes on poll messages, one row per voter per poll (v11).
+
+```sql
+CREATE TABLE poll_votes (
+    conv_id        TEXT NOT NULL,
+    poll_timestamp INTEGER NOT NULL,
+    voter          TEXT NOT NULL,
+    voter_name     TEXT,
+    option_indexes TEXT NOT NULL,
+    vote_count     INTEGER NOT NULL DEFAULT 1,
+    UNIQUE(conv_id, poll_timestamp, voter)
+);
+```
+
 ### `read_markers`
 
 Tracks the last-read message per conversation for unread counting.
@@ -96,7 +119,9 @@ CREATE TABLE read_markers (
 );
 ```
 
-Unread count = messages with `rowid > last_read_rowid` and `is_system = 0`.
+Unread count = incoming messages with `rowid > last_read_rowid`, excluding
+system messages and your own sent messages. `/unread` moves the marker back
+so the newest incoming message counts as unread again.
 
 ## Migrations
 
@@ -113,6 +138,12 @@ Migrations are version-based and run sequentially in `Database::migrate()`:
 | 7 | Add `expiration_timer` to `conversations` and `expires_in_seconds`, `expiration_start_ms` to `messages` |
 | 8 | Add `accepted` column to `conversations` (message request tracking) |
 | 9 | Add `blocked` column to `conversations` (block/unblock state) |
+| 10 | Add `pinned` column to `messages` (pinned messages) |
+| 11 | Add `poll_data` column to `messages` and create `poll_votes` table (polls) |
+| 12 | Add `link_preview` column to `messages` (link preview persistence) |
+| 13 | Add `body_raw` and `mentions_json` columns to `messages` (mention re-resolution) |
+| 14 | Add `mute_expires_at` column to `conversations` (timed mutes) |
+| 15 | Add `archived` column to `conversations` (archive) |
 
 Each migration is wrapped in a transaction. The `schema_version` table tracks
 the current version.

--- a/docs/src/dev-guide/modules.md
+++ b/docs/src/dev-guide/modules.md
@@ -1,15 +1,20 @@
 # Module Reference
 
-siggy is organized into a flat module structure under `src/`.
+siggy is organized under `src/` with a few submodule trees (`handlers/`,
+`domain/`, `signal/`, `ui/`) around a flat core.
 
 ## Module dependency graph
 
 ```mermaid
 graph TD
     MAIN["main.rs<br/><i>entry point + event loop</i>"]
-    APP["app.rs<br/><i>all application state</i>"]
-    UI["ui.rs<br/><i>stateless rendering</i>"]
+    APP["app.rs<br/><i>application state</i>"]
+    HANDLERS["handlers/<br/><i>event + key handling</i>"]
+    DOMAIN["domain/<br/><i>extracted App sub-state</i>"]
+    STORE["conversation_store.rs<br/><i>conversations + ordering</i>"]
+    UI["ui/<br/><i>rendering</i>"]
     CLIENT["signal/client.rs<br/><i>signal-cli process</i>"]
+    PARSE["signal/parse/<br/><i>JSON-RPC parsing</i>"]
     TYPES["signal/types.rs<br/><i>shared types</i>"]
     DB["db.rs<br/><i>SQLite persistence</i>"]
     CONFIG["config.rs<br/><i>TOML config</i>"]
@@ -24,11 +29,14 @@ graph TD
     MAIN --> SETUP
     MAIN --> DB
     SETUP --> LINK
+    APP --> HANDLERS
+    APP --> DOMAIN
+    APP --> STORE
     APP --> DB
     APP --> TYPES
     APP --> INPUT
-    APP --> CONFIG
-    CLIENT --> TYPES
+    CLIENT --> PARSE
+    PARSE --> TYPES
     UI --> APP
 ```
 
@@ -36,95 +44,139 @@ graph TD
 
 ### `main.rs`
 
-Entry point. Parses CLI arguments, runs the setup wizard if needed, opens the
-database, spawns signal-cli, and runs the main event loop. Orchestrates the
-startup sequence: setup wizard -> device linking -> app startup.
+Entry point. Parses CLI arguments (including the non-interactive
+`--version` / `--check` / `--send` / `--list` / `--receive` /
+`--reset-account` / `--reset-lock` modes), runs the setup wizard if needed,
+opens the database, spawns signal-cli, and runs the main event loop.
 
 The event loop polls keyboard input (50ms timeout), drains signal events from
-the mpsc channel, and renders each frame with `ui::draw()`.
+the mpsc channel, and renders each frame with `ui::draw()`. `dispatch_send()`
+routes each `SendRequest` variant to its `SignalClient` RPC method, so
+handlers stay synchronous and the main loop owns all async I/O. A supervisor
+respawns signal-cli with backoff if the child exits.
 
 ### `app.rs`
 
-All application state lives in the `App` struct. Owns conversations (stored in
-a `HashMap` with an ordered `Vec` for sidebar ordering), the input buffer, and
-the current mode (Normal / Insert).
+Application state. The `App` struct holds the mode (Normal / Insert), the
+active conversation, and sub-structs extracted into `src/domain/`. A CI
+ratchet (`scripts/check-app-field-count.sh`) fails PRs that grow the direct
+field count past its committed baseline, which forces new state into
+`domain/` sub-structs.
 
-Key entry point: `handle_signal_event()` processes all backend events -- incoming
-messages, typing indicators, contact lists, group lists, and errors. This is the
-single place where signal-cli events modify application state.
+### `conversation_store.rs`
 
-`get_or_create_conversation()` is the single point for ensuring a conversation
-exists. It upserts to both the in-memory `HashMap` and SQLite. New conversations
-append to `conversation_order`; existing ones are no-ops.
+`ConversationStore`: the conversation map (`HashMap` keyed by phone number or
+group ID), the ordered `Vec` for sidebar display, contact/UUID name lookups,
+and read markers. `get_or_create_conversation()` is the single point for
+ensuring a conversation exists -- it upserts to both memory and SQLite.
+
+### `handlers/`
+
+Event and key handling extracted from `app.rs`:
+
+- `handlers/signal.rs` -- `handle_signal_event()`, the single entry point for
+  all backend events (messages, receipts, typing, contact/group lists,
+  errors).
+- `handlers/input.rs` -- composer text to `SendRequest` (send, edit, poll,
+  archive, export, and the other slash-command arms).
+- `handlers/keys.rs` -- global, Normal-mode, Insert-mode, overlay, and mouse
+  handlers.
+
+### `domain/`
+
+Extracted `App` sub-state, one module per concern: scroll, input, pending
+sends, overlays, image cache, lock, typing, search, mouse hit-areas, media
+(download dir + audio player), and the shared `SendRequest` value type.
+`domain/` is a leaf layer: it does not import from `app::`.
 
 ### `signal/client.rs`
 
-Spawns the signal-cli child process and manages communication. Two Tokio tasks:
+Spawns the signal-cli child process and manages communication. Two Tokio
+tasks:
 
-- **stdout reader** -- reads lines from signal-cli stdout, parses JSON-RPC into
-  `SignalEvent` variants, and sends them through the mpsc channel
-- **stdin writer** -- receives `JsonRpcRequest` structs and writes them as JSON
-  lines to signal-cli stdin
+- **stdout reader** -- reads lines from signal-cli stdout, parses JSON-RPC
+  into `SignalEvent` variants, and sends them through the mpsc channel
+- **stdin writer** -- receives `JsonRpcRequest` structs and writes them as
+  JSON lines to signal-cli stdin
 
-The `pending_requests` map tracks RPC call IDs to correlate responses with their
-original method (e.g., mapping a response ID back to `listContacts`).
+The `pending_requests` map tracks RPC call IDs to correlate responses with
+their original method (e.g., mapping a response ID back to `listContacts`).
+All `send_*` methods build params and go through a shared `send_rpc` helper.
+
+### `signal/parse/`
+
+JSON-RPC to `SignalEvent` parsing, split by concern: `envelope.rs`,
+`message.rs`, `helpers.rs` (attachments, mentions, text styles), `rpc.rs`,
+and `poll.rs`.
 
 ### `signal/types.rs`
 
 Shared types for signal-cli communication:
 
-- `SignalEvent` -- enum of all events the backend can produce (messages, receipts, typing, read sync, system messages)
+- `SignalEvent` -- enum of all events the backend can produce
 - `SignalMessage` -- a message with source, timestamp, body, attachments, group info, text styles
 - `TextStyle` / `StyleType` -- text formatting ranges (bold, italic, strikethrough, monospace, spoiler)
 - `Attachment` -- file metadata (content type, filename, local path)
 - `JsonRpcRequest` / `JsonRpcResponse` -- JSON-RPC protocol structs
 - `Contact` / `Group` -- address book and group info
 
-### `ui.rs`
+### `ui/`
 
-Stateless rendering. The `draw()` function takes an immutable `&App` reference and
-renders the full UI: sidebar, chat area, input bar, and status bar.
+Rendering: `mod.rs` (`draw()`), `chat_pane.rs`, `sidebar.rs`,
+`status_bar.rs`, `composer.rs`, `overlays/` (one file per overlay), and
+`links.rs` (URI span styling and the OSC 8 hyperlink post-render pass).
 
-Sender colors are hash-based (8 colors). Groups are prefixed with `#` in the sidebar.
-OSC 8 hyperlinks are injected in a post-render pass (written directly to the terminal
-after Ratatui's draw to avoid width calculation issues).
+Note that `draw()` takes `&mut App`: it writes layout feedback (scroll
+clamping, focus derivation, mouse hit-rects) during render.
 
 ### `db.rs`
 
-SQLite database layer with WAL mode. Four tables: `conversations`, `messages`,
-`read_markers`, `reactions`. Schema migration is version-based (currently at v9,
-see [Database Schema](database.md)).
+SQLite database layer with WAL mode. Tables: `conversations`, `messages`,
+`read_markers`, `reactions`, `poll_votes`. Schema migration is a static,
+version-based table (currently at v15, see [Database Schema](database.md)).
 
-Provides `open()` for disk-backed storage and `open_in_memory()` for incognito mode.
+Provides `open()` for disk-backed storage and `open_in_memory()` for
+incognito mode.
 
 ### `config.rs`
 
-TOML configuration. The `Config` struct is serialized/deserialized with serde.
-Fields: `account`, `signal_cli_path`, `download_dir`, `notify_direct`,
-`notify_group`, `desktop_notifications`, `inline_images`, `native_images`,
-`show_receipts`, `color_receipts`, `nerd_fonts`, `reaction_verbose`,
-`send_read_receipts`, `mouse_enabled`, `theme`. All fields have defaults.
-
-`Config::load()` reads from the platform-specific path (or a custom path).
-`Config::save()` writes the current config back to disk.
+TOML configuration serialized with serde. Core fields: `account` (E.164
+phone), `signal_cli_path`, `download_dir`, `db_path`, plus UI and behavior
+preferences (`image_mode`, `theme`, `lock_timeout`, `audio_player`,
+notification toggles, and more -- see
+[Configuration](../user-guide/configuration.md) for the full table). All
+fields have serde defaults so old config files keep loading.
 
 ### `input.rs`
 
-Input parsing. Converts text input into an `InputAction` enum. Handles all
-slash commands (`/join`, `/part`, `/quit`, `/sidebar`, `/bell`, `/mute`,
-`/block`, `/unblock`, `/attach`, `/paste`, `/search`, `/contacts`, `/settings`,
-`/disappearing`, `/group`, `/theme`, `/poll`, `/verify`, `/profile`,
-`/about`, `/help`) and their aliases.
+Input parsing. Converts composer text into an `InputAction` enum, covering
+every slash command and its aliases, and defines `CommandInfo` / the
+`COMMANDS` constant used by autocomplete and `/help`. Part of the fuzzable
+lib target (`fuzz_command_parse`, `fuzz_input_edit`).
 
-Also defines `CommandInfo` and the `COMMANDS` constant used for autocomplete.
+### Other modules
+
+- `audio.rs` -- inline voice-message playback via a detected CLI player
+- `compose.rs` -- composer markup parsing (`*bold*` etc.) to Signal style ranges
+- `export.rs` -- `/export` rendering (plain text, Markdown, JSON)
+- `autocomplete.rs` -- command and @mention completion state
+- `list_overlay.rs` -- shared list-overlay key/nav/scroll helpers
+- `keybindings.rs` / `theme.rs` -- keybinding profiles and color themes (both TOML-extensible)
+- `image_render.rs` -- halfblock/Kitty/iTerm2/Sixel image rendering
+- `mute.rs` -- mute state (permanent and timed)
+- `debug_log.rs` -- optional file logger gated by `--debug`
+- `demo.rs` -- `--demo` dummy data
+- `fs_migrate.rs` -- signal-tui to siggy path migration
 
 ### `setup.rs`
 
 Multi-step first-run wizard. Handles signal-cli detection (searching PATH),
-phone number input with validation, and triggers the device linking flow.
+phone number input with validation, relink safety checks against existing
+local data, and triggers the device linking flow.
 
 ### `link.rs`
 
-Device linking flow. Runs signal-cli's `link` command, captures the QR code URI,
-renders it in the terminal, and waits for the user to scan it with their phone.
-Checks for successful account registration afterward.
+Device linking flow. Runs signal-cli's `link` command, captures the QR code
+URI, renders it in the terminal, and waits for the user to scan it with
+their phone. Surfaces signal-cli's stderr on failure with recovery guidance
+(e.g. the 409 device-conflict case).

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -67,25 +67,39 @@
 - [x] Multi-line message input (Alt+Enter / Shift+Enter for newlines)
 - [x] Message history pagination (scroll-up to load older messages)
 - [x] Configurable keybindings (profiles, in-app rebinding, TOML overrides)
-- [x] Export chat history (`/export` to a plain text file)
+- [x] Export chat history (`/export` to plain text, Markdown, or JSON)
 - [x] Sidebar filter (type-to-filter from Normal mode)
 - [x] Jump to quoted message (`Q` to jump, `Ctrl+O` to jump back)
 - [x] Delete conversations (`/delete` removes locally + declines message requests)
 - [x] Session lock + boss key (`Ctrl-L`, `/lock`, `/lock-reset`, `--reset-lock`)
 - [x] Native inline images inside tmux (DCS passthrough wrapping, `SIGGY_IMAGE_PROTOCOL` override) -- thanks @cultlead3r
+- [x] Sixel image protocol (Windows Terminal and other Sixel terminals)
+- [x] Open attachments and URLs from the action menu
+- [x] Multiple concurrent typing indicators per group
+- [x] Enhanced emoji shortcode coverage -- thanks @shwoop
+- [x] Custom themes (drop-in TOML files + shipped template)
+- [x] Auto-lock idle timer (`lock_timeout` config)
+- [x] Bindable command actions (`open_contacts`, `open_settings`, `open_help`, `toggle_sidebar`, `attach`)
+- [x] Non-interactive CLI for scripting (`--version`, `--check`, `--send`, `--list`, `--receive`)
+- [x] Claude Code skill for the siggy CLI
+- [x] Scheduled messages via the OS scheduler (documented pattern)
+- [x] Side-by-side accounts via `db_path` config override
+- [x] Supervised signal-cli reconnect with backoff
+- [x] README translations (11 languages)
+- [x] Voice message playback (inline via a detected CLI player, `audio_player` override)
+- [x] Compose text formatting (`*bold*`, `_italic_`, `~strike~`, `` `mono` ``, `||spoiler||`)
+- [x] Spoiler reveal on focus (`J`/`K` unmasks while focused)
+- [x] Archive conversations + mark-as-unread (`/archive`, `/unread`)
 
 ## Future
 
 Tracked in GitHub issues:
 
-- [Auto-lock idle timer (#438)](https://github.com/johnsideserf/siggy/issues/438) -- round out the session-lock feature with a configurable idle timeout
-- [Multi-account switching (#260)](https://github.com/johnsideserf/siggy/issues/260)
-- [Voice message playback (#199)](https://github.com/johnsideserf/siggy/issues/199)
-- [Scheduled messages via OS scheduler (#259)](https://github.com/johnsideserf/siggy/issues/259)
-- [Non-interactive CLI mode for scripting (#257)](https://github.com/johnsideserf/siggy/issues/257)
-- [Claude Code skill for siggy CLI (#258)](https://github.com/johnsideserf/siggy/issues/258)
-- [Bridge keybinding system to support command actions (#202)](https://github.com/johnsideserf/siggy/issues/202)
-- [Link Previews enhancement (#267)](https://github.com/johnsideserf/siggy/issues/267)
-- [Translations of README and docs site (#353)](https://github.com/johnsideserf/siggy/issues/353)
+- [Outgoing link previews (#267)](https://github.com/johnsideserf/siggy/issues/267) -- generate preview cards for links you send (incoming previews already render)
+- [Render sticker images inline (#610)](https://github.com/johnsideserf/siggy/issues/610)
+- [Signal username support (#612)](https://github.com/johnsideserf/siggy/issues/612)
+- [Fuzzy command palette (#614)](https://github.com/johnsideserf/siggy/issues/614)
+- [Scriptable message triggers / auto-responder (#615)](https://github.com/johnsideserf/siggy/issues/615)
+- [Voice message duration + progress indicator (#618)](https://github.com/johnsideserf/siggy/issues/618)
 
 Have an idea? [Open an issue](https://github.com/johnsideserf/siggy/issues).

--- a/docs/src/dev-guide/testing.md
+++ b/docs/src/dev-guide/testing.md
@@ -32,8 +32,8 @@ is declared in `[dev-dependencies]`.
 
 Two `#[fixture]` functions provide pre-built test objects:
 
-- **`app()`** in `app.rs` — returns an `App` with an in-memory DB and connected state.
-- **`db()`** in `db.rs` — returns an in-memory `Database`.
+- **`app()`** in `app_tests.rs` -- returns an `App` with an in-memory DB and connected state.
+- **`db()`** in `db.rs` -- returns an in-memory `Database`.
 
 To use a fixture, mark the test `#[rstest]` and add the fixture as a parameter:
 
@@ -160,10 +160,10 @@ Input parser tests cover:
 - Commands with and without arguments
 - Unknown command handling
 
-### `app.rs` tests
+### `app_tests.rs` tests
 
-Application state tests cover signal event handling, conversation management,
-and mode transitions.
+Application state tests (split out of `app.rs`) cover signal event handling,
+conversation management, and mode transitions.
 
 ### `signal/client.rs` tests
 

--- a/docs/src/user-guide/keybindings.md
+++ b/docs/src/user-guide/keybindings.md
@@ -63,6 +63,22 @@ insert_newline = ["shift+enter", "alt+enter"]
 
 Arrays are supported for binding multiple keys to the same action.
 
+### Command actions
+
+Five commands are also exposed as bindable actions, so you can open overlays
+directly from a key instead of typing the slash command: `open_contacts`,
+`open_settings`, `open_help`, `toggle_sidebar`, and `attach`. They are
+unbound by default (so they never conflict with profile defaults); bind them
+like any other action:
+
+```toml
+[global]
+open_contacts = "ctrl+b"
+open_help = "f1"
+```
+
+They also appear in the `/keybindings` overlay for in-app rebinding.
+
 ### In-app rebinding
 
 Open the keybindings overlay with `/keybindings` (alias `/kb`). Navigate


### PR DESCRIPTION
The docsite had fallen behind the releases. This brings every page current.

## Changelog
Added the seven missing releases: v1.5.1, v1.6.0, v1.7.0, v1.7.1, v1.9.0, v1.9.1, and v1.10.0 (the page jumped from v1.8.0 straight to v1.5.0). Entries are curated from the release notes in the existing changelog style.

## Roadmap
- Moved 19 shipped features to Completed (Sixel, non-interactive CLI, auto-lock, custom themes, bindable command actions, db_path accounts, reconnect supervision, translations, voice playback, compose formatting, export formats, archive/unread, spoiler reveal, and more).
- Future list refreshed to the actual open backlog (#267, #610, #612, #614, #615, #618) - the old list was entirely shipped/closed issues.

## User guide
- keybindings.md: documented the v1.10.0 bindable command actions (open_contacts, open_settings, open_help, toggle_sidebar, attach) - this feature had no docs at all.

## Dev guide
- database.md: schema and migration table updated v9 -> v15 (pinned, polls, link previews, mention persistence, timed mutes, archive), poll_votes table documented, unread-count rule corrected to exclude outgoing messages.
- modules.md: rewritten to match the post-refactor tree (handlers/, domain/, conversation_store.rs, signal/parse/, ui/, plus audio/compose/export). The old page still described app.rs as holding all handlers and ui.rs as stateless.
- architecture.md: dependency table refreshed to current versions; diagram labels corrected (&mut App, ui/).
- testing.md / data-flow.md: app_tests.rs split and ui/ path corrections.

Docs-only change; no code touched. (Direct-to-master push is now blocked by required status checks, hence the PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)