### PR TITLE
feat: voice message duration and live playback progress

### DIFF
--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -17,12 +17,14 @@ linked devices) sync into the TUI automatically.
   Requires tmux 3.3+ with `set -g allow-passthrough on` plus the
   `SIGGY_IMAGE_PROTOCOL` env var to name the outer terminal (auto-detection
   cannot see through tmux). See the Troubleshooting page.
-- **Voice messages** -- audio attachments show as `[voice ▶ name]`. Press `o`
-  (open) on the focused message to play it inline through a detected command-line
-  player (`mpv`, `ffplay`, `afplay`, `cvlc`, `paplay`, or `aplay`, in that order).
-  Set `audio_player` in the config to use a specific command instead (see
-  [Configuration](configuration.md)). If no player is available it falls back
-  to opening the file in your OS default app.
+- **Voice messages** -- audio attachments show as `[voice ▶ name 0:12]` (the
+  duration is read from the Ogg Opus file). Press `o` (open) on the focused
+  message to play it inline through a detected command-line player (`mpv`,
+  `ffplay`, `afplay`, `cvlc`, `paplay`, or `aplay`, in that order); the status
+  bar shows live progress (`playing name 0:05 / 0:12`) and pressing `o` again
+  stops playback. Set `audio_player` in the config to use a specific command
+  instead (see [Configuration](configuration.md)). If no player is available
+  it falls back to opening the file in your OS default app.
 - **Other files** -- shown as `[attachment: filename]` with the download path
 - **Send files** -- use `/attach` to open a file browser and attach a file to
   your next message

--- a/src/app.rs
+++ b/src/app.rs
@@ -1197,6 +1197,52 @@ impl App {
         }
     }
 
+    /// Kill and reap the voice player child, if one is playing (#618).
+    /// Returns true when something was actually stopped.
+    pub(crate) fn stop_voice_playback(&mut self) -> bool {
+        if let Some(mut playing) = self.media.playing.take() {
+            let _ = playing.child.kill();
+            let _ = playing.child.wait();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Advance voice-playback bookkeeping each tick (#618): reap the player
+    /// when it exits and keep the status-bar progress line fresh. Returns
+    /// true when the status line changed (so the caller redraws).
+    pub fn tick_voice_playback(&mut self) -> bool {
+        let Some(playing) = &mut self.media.playing else {
+            return false;
+        };
+        if matches!(playing.child.try_wait(), Ok(Some(_))) {
+            self.media.playing = None;
+            self.update_status();
+            return true;
+        }
+        let elapsed = playing.started.elapsed();
+        let line = match playing.duration {
+            Some(total) => format!(
+                "playing {} {} / {} (o to stop)",
+                playing.label,
+                crate::audio::format_mmss(elapsed.min(total)),
+                crate::audio::format_mmss(total)
+            ),
+            None => format!(
+                "playing {} {} (o to stop)",
+                playing.label,
+                crate::audio::format_mmss(elapsed)
+            ),
+        };
+        if self.status_message != line {
+            self.status_message = line;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Open the fuzzy command palette (#614).
     pub(crate) fn open_palette(&mut self) {
         self.palette.query.clear();
@@ -3839,13 +3885,31 @@ impl App {
                     .unwrap_or_else(|| path.clone());
                 // Voice/audio: play inline via a detected CLI player (#199)
                 // instead of handing off to the OS default app. Falls back to
-                // open::that when no player is installed.
+                // open::that when no player is installed. Pressing `o` on the
+                // message that is already playing stops it instead (#618).
                 if crate::audio::is_audio_path(&canon)
+                    && self.media.playing.as_ref().is_some_and(|p| p.path == canon)
+                {
+                    self.stop_voice_playback();
+                    self.status_message = format!("Stopped {filename}");
+                } else if crate::audio::is_audio_path(&canon)
                     && let Some(player) =
                         crate::audio::detect_player(self.media.audio_player.as_deref())
                 {
+                    // Only one voice plays at a time.
+                    self.stop_voice_playback();
                     match crate::audio::play(&canon, &player) {
-                        Ok(_) => self.status_message = format!("Playing {filename}"),
+                        Ok(child) => {
+                            let duration = crate::audio::ogg_opus_duration(&canon);
+                            self.media.playing = Some(crate::domain::PlayingVoice {
+                                child,
+                                started: Instant::now(),
+                                duration,
+                                label: filename.clone(),
+                                path: canon.clone(),
+                            });
+                            self.status_message = format!("Playing {filename}");
+                        }
                         Err(e) => self.status_message = format!("Failed to play {filename}: {e}"),
                     }
                 } else {

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -94,6 +94,78 @@ pub fn is_audio(content_type: &str) -> bool {
     content_type.starts_with("audio/")
 }
 
+/// Duration of an Ogg Opus file (Signal voice notes), or `None` for other
+/// formats or malformed files (#618). No decoder needed: Opus granule
+/// positions count 48 kHz samples, so duration = (last page granule -
+/// OpusHead pre-skip) / 48000.
+pub fn ogg_opus_duration(path: &Path) -> Option<std::time::Duration> {
+    // Voice notes are small (a few hundred KB per minute); cap the read so a
+    // mislabeled giant file cannot balloon memory.
+    const MAX_READ: u64 = 16 * 1024 * 1024;
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() > MAX_READ {
+        return None;
+    }
+    let data = std::fs::read(path).ok()?;
+    ogg_opus_duration_from_bytes(&data)
+}
+
+/// Parse the duration out of in-memory Ogg Opus data. Split from the file
+/// read so it can be unit-tested on synthetic pages.
+fn ogg_opus_duration_from_bytes(data: &[u8]) -> Option<std::time::Duration> {
+    const SAMPLE_RATE: u64 = 48_000;
+    let mut pos = 0usize;
+    let mut pre_skip: Option<u64> = None;
+    let mut last_granule: Option<u64> = None;
+
+    while pos + 27 <= data.len() {
+        if &data[pos..pos + 4] != b"OggS" {
+            break;
+        }
+        let granule = u64::from_le_bytes(data[pos + 6..pos + 14].try_into().ok()?);
+        let n_segments = data[pos + 26] as usize;
+        let seg_table_end = pos + 27 + n_segments;
+        if seg_table_end > data.len() {
+            break;
+        }
+        let payload_len: usize = data[pos + 27..seg_table_end]
+            .iter()
+            .map(|&b| b as usize)
+            .sum();
+        let payload_end = seg_table_end + payload_len;
+        if payload_end > data.len() {
+            break;
+        }
+
+        if pre_skip.is_none() {
+            // The first page's payload must be the OpusHead identification
+            // header; anything else is not an Ogg Opus stream.
+            let payload = &data[seg_table_end..payload_end];
+            if !payload.starts_with(b"OpusHead") || payload.len() < 12 {
+                return None;
+            }
+            pre_skip = Some(u64::from(u16::from_le_bytes([payload[10], payload[11]])));
+        }
+
+        // Granule of -1 marks a page where no packet ends; skip those.
+        if granule != u64::MAX {
+            last_granule = Some(granule);
+        }
+        pos = payload_end;
+    }
+
+    let samples = last_granule?.saturating_sub(pre_skip?);
+    Some(std::time::Duration::from_millis(
+        samples * 1000 / SAMPLE_RATE,
+    ))
+}
+
+/// Format a duration as m:ss for the voice label / progress line.
+pub fn format_mmss(d: std::time::Duration) -> String {
+    let secs = d.as_secs();
+    format!("{}:{:02}", secs / 60, secs % 60)
+}
+
 /// Whether a file path looks like a playable audio file by extension. Used to
 /// decide, at open time, whether to play inline rather than hand off to the OS.
 pub fn is_audio_path(path: &Path) -> bool {
@@ -127,6 +199,81 @@ mod tests {
         );
         assert_eq!(player_args("afplay"), Some([].as_slice()));
         assert_eq!(player_args("not-a-player"), None);
+    }
+
+    /// Build one Ogg page: header + segment table + payload.
+    fn ogg_page(granule: u64, payload: &[u8]) -> Vec<u8> {
+        assert!(payload.len() < 255 * 255);
+        let mut segments: Vec<u8> = Vec::new();
+        let mut remaining = payload.len();
+        loop {
+            if remaining >= 255 {
+                segments.push(255);
+                remaining -= 255;
+            } else {
+                segments.push(remaining as u8);
+                break;
+            }
+        }
+        let mut page = Vec::new();
+        page.extend_from_slice(b"OggS");
+        page.extend_from_slice(&[0, 0]); // version, header type
+        page.extend_from_slice(&granule.to_le_bytes());
+        page.extend_from_slice(&[0; 12]); // serial, sequence, checksum
+        page.push(segments.len() as u8);
+        page.extend_from_slice(&segments);
+        page.extend_from_slice(payload);
+        page
+    }
+
+    /// A minimal OpusHead payload with the given pre-skip.
+    fn opus_head(pre_skip: u16) -> Vec<u8> {
+        let mut head = b"OpusHead".to_vec();
+        head.push(1); // version
+        head.push(1); // channels
+        head.extend_from_slice(&pre_skip.to_le_bytes());
+        head.extend_from_slice(&[0; 7]); // rate + gain + mapping
+        head
+    }
+
+    #[test]
+    fn ogg_opus_duration_reads_last_granule_minus_preskip() {
+        // 48_312 samples - 312 pre-skip = 48_000 samples = exactly 1s.
+        let mut data = ogg_page(0, &opus_head(312));
+        data.extend(ogg_page(24_000, &[0u8; 10]));
+        data.extend(ogg_page(48_312, &[0u8; 10]));
+        assert_eq!(
+            ogg_opus_duration_from_bytes(&data),
+            Some(std::time::Duration::from_secs(1))
+        );
+    }
+
+    #[test]
+    fn ogg_opus_duration_skips_no_packet_pages_and_rejects_non_opus() {
+        // A granule of u64::MAX means "no packet ends here" and is skipped.
+        let mut data = ogg_page(0, &opus_head(0));
+        data.extend(ogg_page(96_000, &[0u8; 4]));
+        data.extend(ogg_page(u64::MAX, &[0u8; 4]));
+        assert_eq!(
+            ogg_opus_duration_from_bytes(&data),
+            Some(std::time::Duration::from_secs(2))
+        );
+
+        // Not opus: first payload is not OpusHead.
+        let vorbis = ogg_page(48_000, b"vorbis-ish");
+        assert_eq!(ogg_opus_duration_from_bytes(&vorbis), None);
+        // Garbage and empty input.
+        assert_eq!(ogg_opus_duration_from_bytes(b"not an ogg"), None);
+        assert_eq!(ogg_opus_duration_from_bytes(&[]), None);
+    }
+
+    #[test]
+    fn format_mmss_formats() {
+        use std::time::Duration;
+        assert_eq!(format_mmss(Duration::from_secs(0)), "0:00");
+        assert_eq!(format_mmss(Duration::from_secs(5)), "0:05");
+        assert_eq!(format_mmss(Duration::from_secs(72)), "1:12");
+        assert_eq!(format_mmss(Duration::from_secs(3600)), "60:00");
     }
 
     #[test]

--- a/src/domain/media.rs
+++ b/src/domain/media.rs
@@ -6,8 +6,24 @@
 
 use std::path::PathBuf;
 use std::sync::mpsc;
+use std::time::{Duration, Instant};
 
 use crate::signal::types::LinkPreview;
+
+/// A voice message currently playing through the spawned CLI player (#618).
+pub struct PlayingVoice {
+    /// The player child process; killed to stop playback early.
+    pub child: std::process::Child,
+    /// When playback started, for the elapsed side of the progress line.
+    pub started: Instant,
+    /// Total length when the file was parseable (Ogg Opus only).
+    pub duration: Option<Duration>,
+    /// Display label (usually the attachment filename).
+    pub label: String,
+    /// Canonical path being played, so a second `o` on the same message
+    /// stops instead of double-playing.
+    pub path: PathBuf,
+}
 
 /// Media-handling configuration snapshot and preview-draft state.
 #[derive(Default)]
@@ -25,4 +41,6 @@ pub struct MediaState {
     pub pending_preview: Option<LinkPreview>,
     /// Receiver for an in-flight `/preview` fetch (`Some` while fetching).
     pub preview_rx: Option<mpsc::Receiver<Result<LinkPreview, String>>>,
+    /// The voice message currently playing, if any (#618).
+    pub playing: Option<PlayingVoice>,
 }

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -28,7 +28,7 @@ pub use image::{ImageMode, ImageRenderResult, ImageState, LinkRegion, VisibleIma
 pub use input::InputState;
 pub use lock::{LockPhase, LockState};
 pub use lock::{hash_passphrase, load_hash, lock_hash_path, save_hash, verify_passphrase};
-pub use media::MediaState;
+pub use media::{MediaState, PlayingVoice};
 pub use mouse::MouseState;
 pub use notification::{NotificationPreview, NotificationState};
 pub use overlays::{

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -527,9 +527,16 @@ fn resolve_incoming(app: &App, msg: &SignalMessage) -> Option<ResolvedMessage> {
             });
         } else if crate::audio::is_audio(&att.content_type) {
             // Voice notes / audio: a play affordance instead of a generic
-            // attachment label. `o` (open) plays it inline (#199).
+            // attachment label. `o` (open) plays it inline (#199), and the
+            // label carries the duration when the file is Ogg Opus (#618).
+            let duration = att
+                .local_path
+                .as_deref()
+                .and_then(|p| crate::audio::ogg_opus_duration(Path::new(p)))
+                .map(|d| format!(" {}", crate::audio::format_mmss(d)))
+                .unwrap_or_default();
             entries.push(ResolvedEntry {
-                body: format!("[voice \u{25b6} {label}]{path_info}"),
+                body: format!("[voice \u{25b6} {label}{duration}]{path_info}"),
                 image_lines: None,
                 image_path: None,
                 mention_ranges: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1788,6 +1788,10 @@ async fn run_app(
         if app.poll_preview_fetch() {
             needs_redraw = true;
         }
+        // Voice playback progress (#618): reap the player / refresh the line.
+        if app.tick_voice_playback() {
+            needs_redraw = true;
+        }
         // Keep the encode caches bounded (#492). Cheap O(1) length check per tick.
         app.image.enforce_cache_caps();
 
@@ -2068,6 +2072,9 @@ async fn run_app(
             break;
         }
     }
+
+    // Stop any voice playback so the player does not outlive the app (#618).
+    app.stop_voice_playback();
 
     // Restore terminal title on exit
     execute!(terminal.backend_mut(), crossterm::terminal::SetTitle("")).ok();


### PR DESCRIPTION
Closes #618.

## What

- Voice labels include the note's length: `[voice ▶ name 0:12]`.
- Playback shows live progress in the status bar (`playing name 0:05 / 0:12 (o to stop)`), pressing `o` on the playing message stops it, starting another voice stops the previous one, and quitting siggy kills the player child.

## How

**Duration without a decoder dependency.** Signal voice notes are Ogg Opus, and Opus granule positions count 48 kHz output samples, so duration = (last page granule - OpusHead pre-skip) / 48000. `audio::ogg_opus_duration` walks the Ogg pages (validating the OpusHead identification header, skipping granule = -1 pages), capped at a 16 MB read. Non-Opus audio degrades gracefully to the old label with no duration. This was the deferred piece of #199 - the alternative was an audio dependency (symphonia) or shelling to ffprobe; ~60 lines of container parsing beats both.

**Playback tracking.** `audio::play`'s child handle is no longer dropped: it lives in `MediaState.playing` (domain sub-struct, no App field change) with the start instant, duration, and path. A per-tick `tick_voice_playback` reaps the child when it exits and refreshes the status line only when the displayed second changes.

## Testing

- Unit tests parse synthetic Ogg pages (hand-built page/OpusHead constructors): duration math with pre-skip, skipping no-packet pages, rejecting non-Opus/garbage/empty input, and m:ss formatting.
- `cargo clippy --tests -D warnings` clean, all 1014 tests pass, field count 66.

## Live-test notes

Play a real voice note: label should show the length, status bar should tick, `o` should toggle stop. The progress line is wall-clock based (we do not poll the player's position), so pausing inside the player itself would drift - fire-and-forget players have no pause anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)