### PR TITLE
feat: render cached stickers as inline images

### DIFF
--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -277,9 +277,11 @@ re-add them if you want the edit to stay formatted.
 
 ## Sticker messages
 
-Incoming stickers display as `[Sticker: emoji]` in the chat area (e.g.
-`[Sticker: 👍]`). If the sticker has no associated emoji, it shows as
-`[Sticker]`.
+Incoming stickers render as inline images (like photo attachments) when
+signal-cli has the sticker pack cached locally, using your configured
+`image_mode`. When the pack is not cached, they fall back to a
+`[Sticker: emoji]` placeholder (e.g. `[Sticker: 👍]`), or `[Sticker]` when
+the sticker has no associated emoji.
 
 ## View-once messages
 

--- a/src/signal/parse/helpers.rs
+++ b/src/signal/parse/helpers.rs
@@ -3,6 +3,50 @@
 
 use crate::signal::types::*;
 
+/// Relative path of a sticker inside signal-cli's data dir, or `None` when
+/// the pack id is not plain lowercase hex. Pack ids come off the wire, so
+/// the hex check doubles as a path-traversal guard (#610).
+pub(super) fn sticker_relative_path(pack_id: &str, sticker_id: i64) -> Option<std::path::PathBuf> {
+    if pack_id.is_empty()
+        || sticker_id < 0
+        || !pack_id
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+    {
+        return None;
+    }
+    Some(
+        std::path::PathBuf::from("signal-cli")
+            .join("stickers")
+            .join(pack_id)
+            .join(sticker_id.to_string()),
+    )
+}
+
+/// Absolute path of a locally cached sticker file, or `None` when it is not
+/// on disk. signal-cli caches sticker packs as WebP files under
+/// `{data_dir}/signal-cli/stickers/<packId>/<stickerId>`; like
+/// `find_signal_cli_attachment`, both the platform-native data dir and the
+/// POSIX-style `~/.local/share` are checked (plus `XDG_DATA_HOME`).
+pub(super) fn sticker_local_path(pack_id: &str, sticker_id: i64) -> Option<String> {
+    let relative = sticker_relative_path(pack_id, sticker_id)?;
+    let mut bases = Vec::new();
+    if let Some(x) = std::env::var_os("XDG_DATA_HOME").filter(|x| !x.is_empty()) {
+        bases.push(std::path::PathBuf::from(x));
+    }
+    if let Some(data_dir) = dirs::data_dir() {
+        bases.push(data_dir);
+    }
+    if let Some(home) = dirs::home_dir() {
+        bases.push(home.join(".local").join("share"));
+    }
+    bases
+        .into_iter()
+        .map(|base| base.join(&relative))
+        .find(|path| path.is_file())
+        .map(|path| path.to_string_lossy().into_owned())
+}
+
 pub(super) fn parse_attachment(
     value: &serde_json::Value,
     download_dir: &std::path::Path,
@@ -283,4 +327,25 @@ pub(super) fn parse_text_styles(data: &serde_json::Value) -> Vec<TextStyle> {
             .collect()
     })
     .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sticker_relative_path_builds_hex_paths_only() {
+        assert_eq!(
+            sticker_relative_path("3044281a51307306e5442f2e9070953a", 5),
+            Some(std::path::PathBuf::from(
+                "signal-cli/stickers/3044281a51307306e5442f2e9070953a/5"
+            ))
+        );
+        // Wire-controlled pack ids must not escape the stickers directory.
+        assert_eq!(sticker_relative_path("../../../etc", 0), None);
+        assert_eq!(sticker_relative_path("abc/def", 0), None);
+        assert_eq!(sticker_relative_path("ABCDEF", 0), None); // uppercase
+        assert_eq!(sticker_relative_path("", 0), None);
+        assert_eq!(sticker_relative_path("abcdef", -1), None);
+    }
 }

--- a/src/signal/parse/message.rs
+++ b/src/signal/parse/message.rs
@@ -186,13 +186,34 @@ fn parse_common_message_fields(
     let timestamp_ms = data.get("timestamp").and_then(|v| v.as_i64()).unwrap_or(0);
     let timestamp = DateTime::from_timestamp_millis(timestamp_ms).unwrap_or_default();
 
-    let sticker_body =
-        data.get("sticker").map(
-            |sticker| match sticker.get("emoji").and_then(|v| v.as_str()) {
-                Some(emoji) => format!("[Sticker: {}]", emoji),
-                None => "[Sticker]".to_string(),
-            },
-        );
+    // Stickers render as inline images when signal-cli has the pack cached
+    // locally (#610); otherwise fall back to the [Sticker: emoji] placeholder.
+    let sticker = data.get("sticker");
+    let sticker_emoji = sticker
+        .and_then(|s| s.get("emoji"))
+        .and_then(|v| v.as_str());
+    let sticker_attachment = sticker.and_then(|s| {
+        let pack_id = s.get("packId").and_then(|v| v.as_str())?;
+        let sticker_id = s.get("stickerId").and_then(|v| v.as_i64())?;
+        let local_path = super::helpers::sticker_local_path(pack_id, sticker_id)?;
+        Some(crate::signal::types::Attachment {
+            id: format!("sticker:{pack_id}:{sticker_id}"),
+            content_type: "image/webp".to_string(),
+            filename: Some(match sticker_emoji {
+                Some(emoji) => format!("sticker {emoji}"),
+                None => "sticker".to_string(),
+            }),
+            local_path: Some(local_path),
+        })
+    });
+    let sticker_body = if sticker_attachment.is_some() {
+        None
+    } else {
+        sticker.map(|_| match sticker_emoji {
+            Some(emoji) => format!("[Sticker: {emoji}]"),
+            None => "[Sticker]".to_string(),
+        })
+    };
 
     let mut body = data
         .get("message")
@@ -212,7 +233,7 @@ fn parse_common_message_fields(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let mut attachments = data
+    let mut attachments: Vec<crate::signal::types::Attachment> = data
         .get("attachments")
         .and_then(|v| v.as_array())
         .map(|arr| {
@@ -221,6 +242,10 @@ fn parse_common_message_fields(
                 .collect()
         })
         .unwrap_or_default();
+    // A locally cached sticker joins the attachments so the existing image
+    // pipeline (halfblock / native protocols) renders it (#610). Placed
+    // before the view-once check so ephemeral stickers stay suppressed.
+    attachments.extend(sticker_attachment);
 
     let mut previews = parse_link_previews(data, download_dir);
 


### PR DESCRIPTION
Closes #610.

## What

Incoming stickers render as inline images instead of the `[Sticker: emoji]` placeholder, whenever signal-cli has the sticker pack cached locally. Uncached packs keep the placeholder fallback (unchanged behavior, covered by the existing parse tests).

## How

signal-cli caches sticker packs as WebP files at `{data_dir}/signal-cli/stickers/<packId>/<stickerId>` (verified on disk on this machine). When the file exists, the parser attaches it as an `image/webp` attachment - `image/webp` is already in the image pipeline's accepted types, so halfblock rendering, Kitty/iTerm2/Sixel native protocols, sizing caps from #631, and `o`-to-open all work with zero new rendering code.

- Path discovery mirrors `find_signal_cli_attachment`: `XDG_DATA_HOME`, the platform-native data dir, and POSIX `~/.local/share` are all checked.
- **Security:** pack ids come off the wire, so the path builder accepts only lowercase-hex ids - this doubles as a path-traversal guard, unit-tested against `../`, separators, and uppercase.
- Sticker attachments join the list before the view-once check, so ephemeral stickers stay suppressed.

## Notes

- Animated WebP stickers: the `image` crate decodes what it can; if decode fails the entry degrades to the `[image: sticker emoji]` label without inline art. Same behavior as any undecodable image attachment.
- Needs a live sticker to verify end-to-end: send one from the phone; if the pack was installed via a linked client, signal-cli should have it cached.

## Testing

- Unit tests for the path builder / traversal guard.
- Existing sticker parse tests cover the uncached fallback.
- `cargo clippy --tests -D warnings` clean, all 1020 tests pass, field count 66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)