### PR TITLE
chore(release): bump version to 1.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.11.0"
+version = "1.12.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.11.0"
+version = "1.12.0"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,54 @@
 # Changelog
 
+## v1.12.0
+
+The power-user release: a fuzzy command palette, sender-generated link
+previews, voice playback progress, inline stickers, and the long-awaited
+Sixel tuning contribution.
+
+### New features
+
+- **Command palette** -- `Ctrl+P` opens a fuzzy finder over conversations
+  and slash commands in one list. Type to filter (fuzzy subsequence
+  matching, so names containing `j`/`k` stay typeable; navigate with
+  Up/Down), Enter jumps to the conversation, runs argument-less commands
+  immediately, or prefills the composer for commands that take arguments.
+  Bound in the Default and Minimal profiles; bindable as `command_palette`
+  in Emacs, where `Ctrl+P` stays line-up (closes #614).
+- **Outgoing link previews** -- `/preview <url>` fetches the page in the
+  background, extracts Open Graph metadata (title, description, thumbnail),
+  and attaches the preview card to your next message; `/preview` with no
+  argument discards it. Previews are never fetched automatically while
+  typing: fetching a URL reveals your IP to that site, so it only happens
+  on the explicit command (closes #267).
+- **Voice playback progress** -- voice labels show the note's length
+  (`[voice ▶ name 0:12]`, parsed from the Ogg Opus container with no
+  decoder dependency), the status bar ticks live progress while playing,
+  pressing `o` on the playing message stops it, and quitting siggy kills
+  the player (closes #618).
+- **Inline stickers** -- stickers render as inline images through the
+  regular image pipeline when signal-cli has the pack cached locally,
+  falling back to the `[Sticker: emoji]` placeholder otherwise. Wire-
+  controlled pack ids are hex-validated as a path-traversal guard
+  (closes #610).
+- **Sixel image tuning** -- image sizing config (`image_max_width`,
+  `preview_image_max_width`, `image_max_height`) with a no-upscale clamp
+  against the actual pane width, plus Sixel encode options
+  (`sixel_max_colors`, `sixel_diffusion`) and browser-terminal flicker
+  improvements. A blank guard row below each Sixel image keeps sub-row
+  pixel overflow from bleeding into the next text line. Thanks to
+  [@justinledwards](https://github.com/justinledwards) for this
+  contribution (closes #520).
+
+### Internal
+
+- New dependency: `ureq` (minimal HTTP client) for `/preview` fetches.
+- New shared fuzzy scorer in `list_overlay`; the loose sidebar-filter
+  fields moved into a `domain` sub-struct.
+- +100 tests since v1.11.0 (1,020 total).
+
+---
+
 ## v1.11.0
 
 The messaging-parity release: voice messages play inline, you can compose

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -87,19 +87,20 @@
 - [x] Supervised signal-cli reconnect with backoff
 - [x] README translations (11 languages)
 - [x] Voice message playback (inline via a detected CLI player, `audio_player` override)
+- [x] Voice message duration + live playback progress (`o` toggles stop)
 - [x] Compose text formatting (`*bold*`, `_italic_`, `~strike~`, `` `mono` ``, `||spoiler||`)
 - [x] Spoiler reveal on focus (`J`/`K` unmasks while focused)
 - [x] Archive conversations + mark-as-unread (`/archive`, `/unread`)
+- [x] Fuzzy command palette (`Ctrl+P` over conversations and commands)
+- [x] Outgoing link previews (`/preview <url>`, explicit fetch only)
+- [x] Inline sticker rendering (cached packs via the image pipeline)
+- [x] Sixel image tuning (sizing config, palette/dithering options, guard row) -- thanks @justinledwards
 
 ## Future
 
 Tracked in GitHub issues:
 
-- [Outgoing link previews (#267)](https://github.com/johnsideserf/siggy/issues/267) -- generate preview cards for links you send (incoming previews already render)
-- [Render sticker images inline (#610)](https://github.com/johnsideserf/siggy/issues/610)
 - [Signal username support (#612)](https://github.com/johnsideserf/siggy/issues/612)
-- [Fuzzy command palette (#614)](https://github.com/johnsideserf/siggy/issues/614)
 - [Scriptable message triggers / auto-responder (#615)](https://github.com/johnsideserf/siggy/issues/615)
-- [Voice message duration + progress indicator (#618)](https://github.com/johnsideserf/siggy/issues/618)
 
 Have an idea? [Open an issue](https://github.com/johnsideserf/siggy/issues).

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.11.0                                 │t too                   │
+                     ││[0│  siggy v1.12.0                                 │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
Release prep for v1.12.0:

- Cargo.toml version 1.11.0 -> 1.12.0 (+ Cargo.lock)
- About overlay snapshot regenerated
- docs/src/changelog.md entry for v1.12.0 (command palette, /preview, voice progress, inline stickers, Sixel tuning by @justinledwards)
- Roadmap: five shipped items moved to Completed; Future list is down to #612 and #615

After merge: tag v1.12.0 to trigger release.yml. cargo publish stays a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)