### PR TITLE
feat: scriptable message triggers with /triggers and --watch

### DIFF
--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -16,6 +16,7 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 | `/preview` | | `[url]` | Fetch a link preview for your next message (no arg discards) |
 | `/archive` | | | Archive / unarchive current conversation |
 | `/unread` | | | Mark current conversation unread and close it |
+| `/triggers` | | | Reload message trigger rules from triggers.toml |
 | `/sidebar` | `/sb` | | Toggle sidebar visibility |
 | `/bell` | `/notify` | `[type]` | Toggle notifications (`direct`, `group`, or both) |
 | `/mute` | | | Mute/unmute current conversation |

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -108,6 +108,7 @@ CLI flags override config file values for the current session:
 | `--send <TO> <MSG>` | Send one message non-interactively and exit (`TO` = `+E164` for a 1:1 or a group id); exit 0 on confirmed send, 1 on failure/timeout |
 | `--list` | Print cached conversations as tab-separated rows (`unread`, `type`, `name`, `id`) and exit; reads the local DB, no signal-cli needed |
 | `--receive` | Stream incoming messages as tab-separated rows (`timestamp_ms`, `sender`, `group-id`, `body`) until signal-cli disconnects or interrupted (Ctrl-C) |
+| `--watch` | Headless trigger mode: run `triggers.toml` rules over the incoming stream (auto-reply / run commands) without the TUI |
 | `-V`, `--version` | Print `siggy <version>` to stdout and exit |
 
 ## Environment variables

--- a/docs/src/user-guide/features.md
+++ b/docs/src/user-guide/features.md
@@ -542,6 +542,46 @@ done
 > queries the signal-cli version (no account lock) and `--list` reads the cached
 > database.
 
+### Message triggers
+
+Rules in `triggers.toml` (next to `config.toml`) auto-respond to incoming
+messages: "on a message matching X from Y, reply Z and/or run a command".
+The same rules fire in two places: inside the TUI while you chat, and in a
+headless `siggy --watch` mode for always-on bots (remember: one signal-cli
+process per account, so `--watch` and the TUI cannot run simultaneously).
+
+```toml
+# Any run rule stays dormant without this explicit opt-in.
+allow_run = true
+
+[[trigger]]
+match = "ping"              # case-insensitive; also: match_mode = "exact" | "prefix"
+match_mode = "exact"
+from = "+15551234567"       # optional sender filter (recommended)
+reply = "pong"
+
+[[trigger]]
+match = "garage"
+conversation = "Home"       # conversation id or exact name
+run = ["C:/scripts/garage.ps1"]   # argv array - never a shell string
+rate_limit_secs = 60        # per rule per conversation (default 30)
+```
+
+Safety rails, because message bodies are controlled by whoever messages you:
+
+- `run` commands are spawned directly from the argv array (no shell), and
+  the message arrives as JSON on stdin - message content can never become
+  command arguments. `run` rules require the top-level `allow_run = true`.
+- Rules never fire on your own messages, nor on history replayed by the
+  initial sync (only messages newer than engine start).
+- Each rule is rate limited per conversation, so two auto-responders cannot
+  reply to each other forever.
+- Rules with no `from`/`conversation` filter load with a warning.
+
+In the TUI, `/triggers` reloads the file and reports the rule count;
+warnings go to the debug log. In `--watch` mode, each firing logs a
+tab-separated line to stdout.
+
 ### Scheduled messages
 
 There is no built-in scheduler; use your OS scheduler with `siggy --send`, which

--- a/src/app.rs
+++ b/src/app.rs
@@ -476,8 +476,9 @@ pub struct App {
     pub status_message: String,
     /// Whether the app should quit
     pub should_quit: bool,
-    /// Pending quit confirmation (unsent text in input buffer)
-    pub quit_confirm: bool,
+    /// Message trigger rules and cooldown state (#615). Empty in tests and
+    /// demo mode; loaded from triggers.toml at startup and by /triggers.
+    pub triggers: crate::trigger::TriggerEngine,
     /// Our own account number for identifying outgoing messages
     pub account: String,
     /// Resizable sidebar width (min 14, max 40)
@@ -2003,7 +2004,7 @@ impl App {
             scroll: ScrollState::default(),
             status_message: "connecting...".to_string(),
             should_quit: false,
-            quit_confirm: false,
+            triggers: crate::trigger::TriggerEngine::default(),
             account,
             sidebar_width: 22,
             sidebar_on_right: false,

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -3429,6 +3429,62 @@ fn preview_command_validates_and_clears(mut app: App) {
 }
 
 #[rstest]
+fn trigger_reply_queues_send_and_echoes_locally(mut app: App) {
+    app.triggers = crate::trigger::TriggerEngine::from_toml_str(
+        r#"
+        [[trigger]]
+        match = "ping"
+        match_mode = "exact"
+        from = "+1"
+        reply = "pong"
+        "#,
+        0,
+    );
+
+    app.handle_signal_event(SignalEvent::MessageReceived(SignalMessage {
+        body: Some("ping".to_string()),
+        ..msg_from("+1")
+    }));
+
+    // The auto-reply is queued for the main loop's dispatch...
+    assert_eq!(app.pending.trigger_sends.len(), 1);
+    let SendRequest::Message {
+        recipient, body, ..
+    } = &app.pending.trigger_sends[0]
+    else {
+        panic!("expected a queued Message");
+    };
+    assert_eq!(recipient, "+1");
+    assert_eq!(body, "pong");
+    // ...and locally echoed as an outgoing message.
+    let last = app.store.conversations["+1"].messages.last().unwrap();
+    assert_eq!(last.body, "pong");
+    assert!(last.is_outgoing());
+
+    // Non-matching and repeat-within-cooldown messages queue nothing more.
+    app.handle_signal_event(SignalEvent::MessageReceived(SignalMessage {
+        body: Some("hello".to_string()),
+        ..msg_from("+1")
+    }));
+    app.handle_signal_event(SignalEvent::MessageReceived(SignalMessage {
+        body: Some("ping".to_string()),
+        ..msg_from("+1")
+    }));
+    assert_eq!(app.pending.trigger_sends.len(), 1);
+}
+
+#[rstest]
+fn trigger_engine_empty_by_default_in_app(mut app: App) {
+    // App::new never loads the user's triggers.toml (tests/demo isolation).
+    assert_eq!(app.triggers.rule_count(), 0);
+    app.handle_signal_event(SignalEvent::MessageReceived(SignalMessage {
+        body: Some("ping".to_string()),
+        ..msg_from("+1")
+    }));
+    assert!(app.pending.trigger_sends.is_empty());
+}
+
+#[rstest]
 fn palette_empty_query_lists_conversations_then_commands(mut app: App) {
     app.store
         .get_or_create_conversation("+1", "Alice", false, &app.db);

--- a/src/domain/input.rs
+++ b/src/domain/input.rs
@@ -21,6 +21,8 @@ pub struct InputState {
     pub history_index: Option<usize>,
     /// Saves in-progress input when browsing history.
     pub history_draft: String,
+    /// `/quit` (or the quit key) pressed once; the next press confirms.
+    pub quit_confirm: bool,
 }
 
 impl InputState {

--- a/src/domain/pending.rs
+++ b/src/domain/pending.rs
@@ -46,4 +46,7 @@ pub struct PendingState {
     pub typing_stop: Option<SendRequest>,
     /// Queued read receipts to dispatch: `(recipient_phone, timestamps)`.
     pub read_receipts: Vec<(String, Vec<i64>)>,
+    /// Auto-replies queued by message triggers (#615), drained by the main
+    /// loop into `dispatch_send` like any composer send.
+    pub trigger_sends: Vec<SendRequest>,
 }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -49,10 +49,10 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
             None
         }
         InputAction::Quit => {
-            if app.input.buffer.is_empty() || app.quit_confirm {
+            if app.input.buffer.is_empty() || app.input.quit_confirm {
                 app.should_quit = true;
             } else {
-                app.quit_confirm = true;
+                app.input.quit_confirm = true;
             }
             None
         }
@@ -172,6 +172,20 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
         }
         InputAction::Preview(opt_url) => {
             preview(app, opt_url);
+            None
+        }
+        InputAction::TriggersReload => {
+            app.triggers = crate::trigger::TriggerEngine::load_default();
+            for warning in &app.triggers.warnings {
+                crate::debug_log::logf(format_args!("triggers.toml: {warning}"));
+            }
+            let rules = app.triggers.rule_count();
+            let warnings = app.triggers.warnings.len();
+            app.status_message = if warnings > 0 {
+                format!("triggers: {rules} rule(s) loaded, {warnings} warning(s) (see debug log)")
+            } else {
+                format!("triggers: {rules} rule(s) loaded")
+            };
             None
         }
         InputAction::Archive => {

--- a/src/handlers/keys.rs
+++ b/src/handlers/keys.rs
@@ -807,16 +807,16 @@ pub fn handle_global_key(app: &mut App, modifiers: KeyModifiers, code: KeyCode) 
     let action = app
         .keybindings
         .resolve(modifiers, code, BindingMode::Global);
-    if app.quit_confirm && !matches!(action, Some(KeyAction::Quit)) {
-        app.quit_confirm = false;
+    if app.input.quit_confirm && !matches!(action, Some(KeyAction::Quit)) {
+        app.input.quit_confirm = false;
         app.update_status();
     }
     match action {
         Some(KeyAction::Quit) => {
-            if app.input.buffer.is_empty() || app.quit_confirm {
+            if app.input.buffer.is_empty() || app.input.quit_confirm {
                 app.should_quit = true;
             } else {
-                app.quit_confirm = true;
+                app.input.quit_confirm = true;
             }
             true
         }

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -908,6 +908,101 @@ fn handle_message(app: &mut App, msg: SignalMessage) {
         .unwrap_or(false);
     let conv_accepted = push_resolved(app, &resolved, is_active);
     apply_notification_policy(app, &resolved, is_active, conv_accepted);
+    evaluate_triggers(app, &msg, &resolved);
+}
+
+/// Run the message through the trigger engine (#615). Replies queue on
+/// `pending.trigger_sends` (drained into the normal send path by the main
+/// loop); `run` actions spawn immediately, fire-and-forget.
+fn evaluate_triggers(app: &mut App, msg: &SignalMessage, resolved: &ResolvedMessage) {
+    if app.triggers.rule_count() == 0 {
+        return;
+    }
+    let Some(body) = msg.body.as_deref().filter(|b| !b.is_empty()) else {
+        return;
+    };
+    let ctx = crate::trigger::MessageContext {
+        body,
+        sender_id: &msg.source,
+        sender_name: msg.source_name.as_deref(),
+        conv_id: &resolved.conv_id,
+        conv_name: &resolved.conv_name,
+        is_group: resolved.is_group,
+        is_outgoing: msg.is_outgoing,
+        timestamp_ms: msg.timestamp.timestamp_millis(),
+    };
+    let actions = app.triggers.evaluate(&ctx, std::time::Instant::now());
+    for action in actions {
+        match action {
+            crate::trigger::TriggerAction::Reply {
+                conv_id,
+                is_group,
+                text,
+            } => queue_trigger_reply(app, conv_id, is_group, text),
+            crate::trigger::TriggerAction::Run { argv, stdin_json } => {
+                if let Err(e) = crate::trigger::execute_run(&argv, stdin_json) {
+                    app.status_message = format!("trigger run failed: {e}");
+                    crate::debug_log::logf(format_args!("trigger run {argv:?} failed: {e}"));
+                }
+            }
+        }
+    }
+}
+
+/// Locally echo a trigger auto-reply and queue its send. Mirrors the plain
+/// path of `send_text` (no markup, mentions, or attachments).
+fn queue_trigger_reply(app: &mut App, conv_id: String, is_group: bool, text: String) {
+    let now = Utc::now();
+    let local_ts_ms = now.timestamp_millis();
+    let out_expires = app
+        .store
+        .conversations
+        .get(&conv_id)
+        .map(|c| c.expiration_timer)
+        .unwrap_or(0);
+    let echo = DisplayMessage {
+        sender: "you".to_string(),
+        timestamp: now,
+        body: text.clone(),
+        is_system: false,
+        image_lines: None,
+        image_path: None,
+        status: Some(MessageStatus::Sending),
+        timestamp_ms: local_ts_ms,
+        reactions: Vec::new(),
+        mention_ranges: Vec::new(),
+        style_ranges: Vec::new(),
+        body_raw: None,
+        mentions: Vec::new(),
+        quote: None,
+        is_edited: false,
+        is_deleted: false,
+        is_pinned: false,
+        sender_id: app.account.clone(),
+        expires_in_seconds: out_expires,
+        expiration_start_ms: if out_expires > 0 { local_ts_ms } else { 0 },
+        poll_data: None,
+        poll_votes: Vec::new(),
+        preview: None,
+        preview_image_lines: None,
+        preview_image_path: None,
+    };
+    app.on_message_added(&conv_id, echo, WireQuote::default(), false);
+    app.pending
+        .trigger_sends
+        .push(crate::app::SendRequest::Message {
+            recipient: conv_id,
+            body: text,
+            is_group,
+            local_ts_ms,
+            mentions: Vec::new(),
+            text_styles: Vec::new(),
+            attachment: None,
+            preview: None,
+            quote_timestamp: None,
+            quote_author: None,
+            quote_body: None,
+        });
 }
 
 pub(super) fn handle_system_message(

--- a/src/input.rs
+++ b/src/input.rs
@@ -189,6 +189,12 @@ pub const COMMANDS: &[CommandInfo] = &[
         description: "Fetch a link preview for your next message (no arg clears)",
     },
     CommandInfo {
+        name: "/triggers",
+        alias: "",
+        args: "",
+        description: "Reload message trigger rules from triggers.toml",
+    },
+    CommandInfo {
         name: "/help",
         alias: "/h",
         args: "",
@@ -282,6 +288,8 @@ pub enum InputAction {
     },
     /// Fetch a link preview to attach to the next message (None clears it)
     Preview(Option<String>),
+    /// Reload triggers.toml and report the rule count
+    TriggersReload,
     /// Toggle the archived flag on the current conversation
     Archive,
     /// Mark the current conversation unread and close it
@@ -386,6 +394,7 @@ pub fn parse_input(input: &str) -> InputAction {
         }
         "/archive" => InputAction::Archive,
         "/unread" => InputAction::MarkUnread,
+        "/triggers" => InputAction::TriggersReload,
         "/help" | "/h" => InputAction::Help,
         _ => InputAction::Unknown(format!("Unknown command: {cmd}")),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod settings_profile;
 mod setup;
 mod signal;
 mod theme;
+mod trigger;
 mod ui;
 
 use std::collections::HashMap;
@@ -207,6 +208,78 @@ async fn run_receive_stream(config: &Config) -> Result<()> {
     }
 }
 
+/// Headless trigger mode (#615): evaluate `triggers.toml` rules over the
+/// incoming stream and execute their actions, logging one line per firing.
+/// For 1:1 chats the conversation "name" is the phone number here (no
+/// contact list without the TUI), so `conversation` filters should use ids.
+async fn run_watch(config: &Config) -> Result<()> {
+    use std::io::Write;
+    let mut engine = trigger::TriggerEngine::load_default();
+    for warning in &engine.warnings {
+        eprintln!("warning: {warning}");
+    }
+    if engine.rule_count() == 0 {
+        let path = trigger::TriggerEngine::rules_path()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "triggers.toml".to_string());
+        anyhow::bail!("no trigger rules loaded; create {path}");
+    }
+    println!("watching with {} rule(s)", engine.rule_count());
+
+    let mut client = SignalClient::spawn(config).await?;
+    loop {
+        match client.event_rx.recv().await {
+            Some(signal::types::SignalEvent::MessageReceived(msg)) => {
+                let Some(body) = msg.body.as_deref().filter(|b| !b.is_empty()) else {
+                    continue;
+                };
+                let conv_id = msg.group_id.clone().unwrap_or_else(|| msg.source.clone());
+                let is_group = msg.group_id.is_some();
+                let ctx = trigger::MessageContext {
+                    body,
+                    sender_id: &msg.source,
+                    sender_name: msg.source_name.as_deref(),
+                    conv_id: &conv_id,
+                    conv_name: msg.group_name.as_deref().unwrap_or(&conv_id),
+                    is_group,
+                    is_outgoing: msg.is_outgoing,
+                    timestamp_ms: msg.timestamp.timestamp_millis(),
+                };
+                for action in engine.evaluate(&ctx, Instant::now()) {
+                    let now_ms = chrono::Utc::now().timestamp_millis();
+                    match action {
+                        trigger::TriggerAction::Reply {
+                            conv_id,
+                            is_group,
+                            text,
+                        } => match client
+                            .send_message(&conv_id, &text, is_group, &[], &[], &[], None, None)
+                            .await
+                        {
+                            Ok(_) => println!("{now_ms}\treply\t{conv_id}\t{text}"),
+                            Err(e) => eprintln!("reply to {conv_id} failed: {e}"),
+                        },
+                        trigger::TriggerAction::Run { argv, stdin_json } => {
+                            match trigger::execute_run(&argv, stdin_json) {
+                                Ok(()) => println!("{now_ms}\trun\t{}", argv.join(" ")),
+                                Err(e) => eprintln!("run {} failed: {e}", argv.join(" ")),
+                            }
+                        }
+                    }
+                }
+                let _ = std::io::stdout().flush();
+            }
+            Some(signal::types::SignalEvent::Disconnected) | None => break,
+            Some(_) => {}
+        }
+    }
+    let _ = client.shutdown().await;
+    match cli_stderr_hint(&client.stderr_output()) {
+        Some(hint) => Err(anyhow::anyhow!("{hint}")),
+        None => Ok(()),
+    }
+}
+
 /// Whether the session should auto-lock now (#438). `timeout_mins == 0` disables
 /// it; otherwise lock once keyboard `idle` reaches that many minutes and we are
 /// not already locked. Only keypresses reset idle (the caller excludes mouse
@@ -266,6 +339,7 @@ async fn main() -> Result<()> {
     let mut check = false;
     let mut list = false;
     let mut receive = false;
+    let mut watch = false;
     let mut send_args: Option<(String, String)> = None;
 
     let mut i = 1;
@@ -327,6 +401,10 @@ async fn main() -> Result<()> {
             }
             "--receive" => {
                 receive = true;
+                i += 1;
+            }
+            "--watch" => {
+                watch = true;
                 i += 1;
             }
             "--send" => {
@@ -504,6 +582,18 @@ async fn main() -> Result<()> {
             Ok(()) => std::process::exit(0),
             Err(e) => {
                 eprintln!("receive failed: {e}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    // Headless trigger mode (#615). Mutually exclusive with the TUI on the
+    // same account: signal-cli allows one process per account.
+    if watch {
+        match run_watch(&config).await {
+            Ok(()) => std::process::exit(0),
+            Err(e) => {
+                eprintln!("watch failed: {e}");
                 std::process::exit(1);
             }
         }
@@ -1676,6 +1766,12 @@ async fn run_app(
     app.incognito = incognito;
     app.media.download_dir = config.download_dir.clone();
     app.media.audio_player = config.audio_player.clone();
+    // Message triggers (#615): loaded here (not in App::new) so tests and
+    // demo mode never pick up the user's triggers.toml.
+    app.triggers = trigger::TriggerEngine::load_default();
+    for warning in &app.triggers.warnings {
+        debug_log::logf(format_args!("triggers.toml: {warning}"));
+    }
     app.sidebar_width = config.sidebar_width.clamp(14, 40);
     if config.cell_pixel_width > 0 && config.cell_pixel_height > 0 {
         app.image.cell_px = (config.cell_pixel_width, config.cell_pixel_height);
@@ -2034,6 +2130,11 @@ async fn run_app(
                     },
                 )
                 .await;
+        }
+
+        // Dispatch auto-replies queued by message triggers (#615)
+        for req in std::mem::take(&mut app.pending.trigger_sends) {
+            backend.dispatch(&mut app, req).await;
         }
 
         // Expire stale typing indicators

--- a/src/trigger.rs
+++ b/src/trigger.rs
@@ -1,0 +1,473 @@
+//! Scriptable message triggers (#615).
+//!
+//! Config-driven rules over incoming messages, loaded from `triggers.toml`
+//! next to the main config: "on a message matching X from Y, auto-reply Z
+//! and/or run a command". One engine, two hosts: the TUI evaluates rules in
+//! `handle_signal_event` (replies queue through the normal send path) and
+//! `siggy --watch` runs the same rules headless.
+//!
+//! Message bodies are remote-controlled, so the engine is built around
+//! safety rails rather than raw power:
+//! - `run` commands are argv arrays spawned directly (never through a
+//!   shell); the message reaches the command as JSON on stdin, so hostile
+//!   bodies cannot inject arguments.
+//! - `run` rules stay dormant unless the file sets a top-level
+//!   `allow_run = true`.
+//! - Rules never fire on outgoing/synced-own messages, nor on messages
+//!   older than engine start (the initial sync replays history).
+//! - Each (rule, conversation) pair is rate limited (default 30s) so two
+//!   auto-responders cannot ping-pong.
+//!
+//! Matching is dependency-free: case-insensitive `substring` (default),
+//! `exact`, or `prefix` -- `run` commands receive the full message and can
+//! do finer filtering themselves.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use serde::Deserialize;
+
+/// Default per-(rule, conversation) cooldown in seconds.
+const DEFAULT_RATE_LIMIT_SECS: u64 = 30;
+
+/// How a rule's `match` text is compared against the message body
+/// (always case-insensitively).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchMode {
+    Substring,
+    Exact,
+    Prefix,
+}
+
+/// One armed rule.
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pub match_text: String,
+    pub match_mode: MatchMode,
+    /// Sender filter: the sender's phone number / id must equal this.
+    pub from: Option<String>,
+    /// Conversation filter: matches the conversation id or exact name.
+    pub conversation: Option<String>,
+    pub reply: Option<String>,
+    pub run: Option<Vec<String>>,
+    pub rate_limit_secs: u64,
+}
+
+/// The incoming message being evaluated.
+pub struct MessageContext<'a> {
+    pub body: &'a str,
+    pub sender_id: &'a str,
+    pub sender_name: Option<&'a str>,
+    pub conv_id: &'a str,
+    pub conv_name: &'a str,
+    pub is_group: bool,
+    pub is_outgoing: bool,
+    pub timestamp_ms: i64,
+}
+
+/// An action the host must execute for a fired rule.
+#[derive(Debug, PartialEq)]
+pub enum TriggerAction {
+    /// Send `text` into the conversation the message arrived in.
+    Reply {
+        conv_id: String,
+        is_group: bool,
+        text: String,
+    },
+    /// Spawn `argv` with `stdin_json` written to its stdin.
+    Run {
+        argv: Vec<String>,
+        stdin_json: String,
+    },
+}
+
+/// Rule engine: rules plus the per-conversation cooldown bookkeeping.
+#[derive(Default)]
+pub struct TriggerEngine {
+    rules: Vec<Rule>,
+    allow_run: bool,
+    /// Wall-clock ms at load; messages stamped earlier never fire (guards
+    /// against the initial-sync history replay).
+    armed_since_ms: i64,
+    /// Last firing per (rule index, conversation id).
+    last_fired: HashMap<(usize, String), Instant>,
+    /// Load-time diagnostics, surfaced by both hosts.
+    pub warnings: Vec<String>,
+}
+
+// --- TOML shapes ---------------------------------------------------------
+
+#[derive(Deserialize)]
+struct TriggersFile {
+    #[serde(default)]
+    allow_run: bool,
+    #[serde(default, rename = "trigger")]
+    triggers: Vec<RuleToml>,
+}
+
+#[derive(Deserialize)]
+struct RuleToml {
+    #[serde(rename = "match")]
+    match_text: String,
+    match_mode: Option<String>,
+    from: Option<String>,
+    conversation: Option<String>,
+    reply: Option<String>,
+    run: Option<Vec<String>>,
+    rate_limit_secs: Option<u64>,
+}
+
+impl TriggerEngine {
+    /// The path rules are loaded from: `<config dir>/siggy/triggers.toml`.
+    pub fn rules_path() -> Option<std::path::PathBuf> {
+        Some(dirs::config_dir()?.join("siggy").join("triggers.toml"))
+    }
+
+    /// Load rules from the default path. A missing file is a normal empty
+    /// engine; a malformed file is an empty engine with a warning.
+    pub fn load_default() -> Self {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let Some(path) = Self::rules_path() else {
+            return Self::default();
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(text) => Self::from_toml_str(&text, now_ms),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Self::default(),
+            Err(e) => Self {
+                warnings: vec![format!("triggers.toml read error: {e}")],
+                ..Self::default()
+            },
+        }
+    }
+
+    /// Parse rules from TOML text. `now_ms` becomes the armed-since floor.
+    pub fn from_toml_str(text: &str, now_ms: i64) -> Self {
+        let mut engine = Self {
+            armed_since_ms: now_ms,
+            ..Self::default()
+        };
+        let file: TriggersFile = match toml::from_str(text) {
+            Ok(f) => f,
+            Err(e) => {
+                engine
+                    .warnings
+                    .push(format!("triggers.toml parse error: {e}"));
+                return engine;
+            }
+        };
+        engine.allow_run = file.allow_run;
+        for (i, rule) in file.triggers.into_iter().enumerate() {
+            let n = i + 1;
+            let match_mode = match rule.match_mode.as_deref() {
+                None | Some("substring") => MatchMode::Substring,
+                Some("exact") => MatchMode::Exact,
+                Some("prefix") => MatchMode::Prefix,
+                Some(other) => {
+                    engine.warnings.push(format!(
+                        "trigger {n}: unknown match_mode \"{other}\" (use substring, exact, or prefix); rule skipped"
+                    ));
+                    continue;
+                }
+            };
+            if rule.match_text.trim().is_empty() {
+                engine
+                    .warnings
+                    .push(format!("trigger {n}: empty match; rule skipped"));
+                continue;
+            }
+            if rule.reply.is_none() && rule.run.is_none() {
+                engine
+                    .warnings
+                    .push(format!("trigger {n}: no reply or run action; rule skipped"));
+                continue;
+            }
+            if rule.run.is_some() && !engine.allow_run {
+                engine.warnings.push(format!(
+                    "trigger {n}: run action ignored (set top-level allow_run = true to arm it)"
+                ));
+            }
+            if let Some(argv) = &rule.run
+                && argv.is_empty()
+            {
+                engine
+                    .warnings
+                    .push(format!("trigger {n}: empty run command; rule skipped"));
+                continue;
+            }
+            if rule.from.is_none() && rule.conversation.is_none() {
+                engine.warnings.push(format!(
+                    "trigger {n}: no from/conversation filter - it fires for any sender"
+                ));
+            }
+            engine.rules.push(Rule {
+                match_text: rule.match_text.to_lowercase(),
+                match_mode,
+                from: rule.from,
+                conversation: rule.conversation,
+                reply: rule.reply,
+                run: rule.run,
+                rate_limit_secs: rule.rate_limit_secs.unwrap_or(DEFAULT_RATE_LIMIT_SECS),
+            });
+        }
+        engine
+    }
+
+    pub fn rule_count(&self) -> usize {
+        self.rules.len()
+    }
+
+    /// Evaluate an incoming message against every rule, applying the safety
+    /// rails, and return the actions the host must execute. `now` is passed
+    /// in (rather than read from the clock) so rate limiting is testable.
+    pub fn evaluate(&mut self, ctx: &MessageContext<'_>, now: Instant) -> Vec<TriggerAction> {
+        let mut actions = Vec::new();
+        if self.rules.is_empty()
+            || ctx.is_outgoing
+            || ctx.body.is_empty()
+            || ctx.timestamp_ms < self.armed_since_ms
+        {
+            return actions;
+        }
+        let body_lower = ctx.body.to_lowercase();
+
+        for (i, rule) in self.rules.iter().enumerate() {
+            if let Some(from) = &rule.from
+                && from != ctx.sender_id
+            {
+                continue;
+            }
+            if let Some(conv) = &rule.conversation
+                && conv != ctx.conv_id
+                && conv != ctx.conv_name
+            {
+                continue;
+            }
+            let matched = match rule.match_mode {
+                MatchMode::Substring => body_lower.contains(&rule.match_text),
+                MatchMode::Exact => body_lower.trim() == rule.match_text,
+                MatchMode::Prefix => body_lower.starts_with(&rule.match_text),
+            };
+            if !matched {
+                continue;
+            }
+            // Cooldown per (rule, conversation): the loop-guard against two
+            // auto-responders answering each other forever.
+            let key = (i, ctx.conv_id.to_string());
+            if let Some(last) = self.last_fired.get(&key)
+                && rule.rate_limit_secs > 0
+                && now.duration_since(*last) < Duration::from_secs(rule.rate_limit_secs)
+            {
+                continue;
+            }
+            self.last_fired.insert(key, now);
+
+            if let Some(text) = &rule.reply {
+                actions.push(TriggerAction::Reply {
+                    conv_id: ctx.conv_id.to_string(),
+                    is_group: ctx.is_group,
+                    text: text.clone(),
+                });
+            }
+            if let Some(argv) = &rule.run
+                && self.allow_run
+            {
+                actions.push(TriggerAction::Run {
+                    argv: argv.clone(),
+                    stdin_json: message_json(ctx, i),
+                });
+            }
+        }
+        actions
+    }
+}
+
+/// The JSON document a `run` command receives on stdin. The body travels
+/// here (serde-escaped) rather than in the command line, so message content
+/// can never become arguments.
+fn message_json(ctx: &MessageContext<'_>, rule_index: usize) -> String {
+    serde_json::json!({
+        "timestamp_ms": ctx.timestamp_ms,
+        "sender": ctx.sender_id,
+        "sender_name": ctx.sender_name,
+        "conversation_id": ctx.conv_id,
+        "conversation_name": ctx.conv_name,
+        "is_group": ctx.is_group,
+        "body": ctx.body,
+        "rule": rule_index + 1,
+    })
+    .to_string()
+}
+
+/// Spawn a `run` action's command, detached, writing the message JSON to its
+/// stdin from a helper thread so the caller never blocks. Spawn failures are
+/// returned for the host to surface; the child itself is fire-and-forget.
+pub fn execute_run(argv: &[String], stdin_json: String) -> std::io::Result<()> {
+    let (exe, args) = argv.split_first().ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "empty run command")
+    })?;
+    let mut child = std::process::Command::new(exe)
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        std::thread::spawn(move || {
+            use std::io::Write;
+            let _ = stdin.write_all(stdin_json.as_bytes());
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx<'a>(body: &'a str, sender: &'a str, ts: i64) -> MessageContext<'a> {
+        MessageContext {
+            body,
+            sender_id: sender,
+            sender_name: None,
+            conv_id: sender,
+            conv_name: "Alice",
+            is_group: false,
+            is_outgoing: false,
+            timestamp_ms: ts,
+        }
+    }
+
+    const PING: &str = r#"
+        [[trigger]]
+        match = "ping"
+        match_mode = "exact"
+        reply = "pong"
+    "#;
+
+    #[test]
+    fn exact_match_replies_case_insensitively() {
+        let mut e = TriggerEngine::from_toml_str(PING, 1000);
+        let now = Instant::now();
+        assert_eq!(
+            e.evaluate(&ctx("PING", "+1", 2000), now),
+            vec![TriggerAction::Reply {
+                conv_id: "+1".into(),
+                is_group: false,
+                text: "pong".into()
+            }]
+        );
+        assert!(e.evaluate(&ctx("ping pong", "+2", 2000), now).is_empty());
+    }
+
+    #[test]
+    fn rails_skip_outgoing_and_presync_messages() {
+        let mut e = TriggerEngine::from_toml_str(PING, 1000);
+        let now = Instant::now();
+        // Older than engine start: history replayed by the initial sync.
+        assert!(e.evaluate(&ctx("ping", "+1", 999), now).is_empty());
+        // Own messages never fire rules.
+        let mut own = ctx("ping", "+1", 2000);
+        own.is_outgoing = true;
+        assert!(e.evaluate(&own, now).is_empty());
+    }
+
+    #[test]
+    fn rate_limit_is_per_rule_per_conversation() {
+        let mut e = TriggerEngine::from_toml_str(PING, 1000);
+        let t0 = Instant::now();
+        assert_eq!(e.evaluate(&ctx("ping", "+1", 2000), t0).len(), 1);
+        // Same conversation, inside the window: suppressed.
+        assert!(e.evaluate(&ctx("ping", "+1", 2001), t0).is_empty());
+        // Different conversation: its own cooldown.
+        assert_eq!(e.evaluate(&ctx("ping", "+2", 2002), t0).len(), 1);
+        // Past the window: fires again.
+        let later = t0 + Duration::from_secs(31);
+        assert_eq!(e.evaluate(&ctx("ping", "+1", 2003), later).len(), 1);
+    }
+
+    #[test]
+    fn sender_and_conversation_filters_gate() {
+        let toml = r#"
+            [[trigger]]
+            match = "hi"
+            from = "+1"
+            conversation = "Alice"
+            reply = "hello"
+        "#;
+        let mut e = TriggerEngine::from_toml_str(toml, 0);
+        let now = Instant::now();
+        assert_eq!(e.evaluate(&ctx("hi", "+1", 1), now).len(), 1);
+        // Wrong sender.
+        assert!(e.evaluate(&ctx("hi", "+9", 1), now).is_empty());
+        // Conversation filter also accepts the conv id.
+        let toml_id = r#"
+            [[trigger]]
+            match = "hi"
+            conversation = "+1"
+            reply = "hello"
+        "#;
+        let mut e2 = TriggerEngine::from_toml_str(toml_id, 0);
+        assert_eq!(e2.evaluate(&ctx("hi", "+1", 1), now).len(), 1);
+    }
+
+    #[test]
+    fn run_requires_allow_run_and_body_travels_via_stdin_json() {
+        let gated = r#"
+            [[trigger]]
+            match = "deploy"
+            from = "+1"
+            run = ["deploy.sh", "--now"]
+        "#;
+        let mut e = TriggerEngine::from_toml_str(gated, 0);
+        assert!(
+            e.warnings.iter().any(|w| w.contains("allow_run")),
+            "expected an allow_run warning, got {:?}",
+            e.warnings
+        );
+        assert!(
+            e.evaluate(&ctx("deploy", "+1", 1), Instant::now())
+                .is_empty()
+        );
+
+        let armed = format!("allow_run = true\n{gated}");
+        let mut e = TriggerEngine::from_toml_str(&armed, 0);
+        let actions = e.evaluate(&ctx("deploy; rm -rf /", "+1", 1), Instant::now());
+        let TriggerAction::Run { argv, stdin_json } = &actions[0] else {
+            panic!("expected Run action");
+        };
+        // argv is fixed from config; the hostile body only exists inside
+        // the JSON payload.
+        assert_eq!(argv, &["deploy.sh".to_string(), "--now".to_string()]);
+        let v: serde_json::Value = serde_json::from_str(stdin_json).unwrap();
+        assert_eq!(v["body"], "deploy; rm -rf /");
+        assert_eq!(v["sender"], "+1");
+    }
+
+    #[test]
+    fn load_warnings_and_skips() {
+        let toml = r#"
+            [[trigger]]
+            match = "no action here"
+
+            [[trigger]]
+            match = ""
+            reply = "x"
+
+            [[trigger]]
+            match = "bad mode"
+            match_mode = "regex"
+            reply = "x"
+
+            [[trigger]]
+            match = "broad"
+            reply = "ok"
+        "#;
+        let e = TriggerEngine::from_toml_str(toml, 0);
+        assert_eq!(e.rule_count(), 1, "only the last rule is valid");
+        assert_eq!(e.warnings.len(), 4); // 3 skips + 1 "fires for any sender"
+        // Parse errors degrade to an empty engine with a warning.
+        let bad = TriggerEngine::from_toml_str("not [ toml", 0);
+        assert_eq!(bad.rule_count(), 0);
+        assert!(!bad.warnings.is_empty());
+    }
+}

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -22,7 +22,7 @@ pub(super) fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, sidebar_
     let theme = &app.theme;
 
     // Override status bar with quit confirmation prompt
-    if app.quit_confirm {
+    if app.input.quit_confirm {
         let bar = Line::from(Span::styled(
             " Unsent message in buffer. Press quit again to confirm.",
             Style::default()


### PR DESCRIPTION
Closes #615.

## What

Config-driven message triggers per the design we settled on: **one rule engine, two hosts**.

- **In the TUI**: rules fire while you chat; auto-replies go through the normal send path (local echo + dispatch + status tracking). `/triggers` reloads the file and reports the rule count.
- **Headless**: `siggy --watch` runs the same rules without the TUI, logging one tab-separated line per firing. (One signal-cli process per account, so `--watch` and the TUI are mutually exclusive - documented.)

```toml
allow_run = true            # run rules stay dormant without this

[[trigger]]
match = "ping"
match_mode = "exact"        # substring (default) | exact | prefix, case-insensitive
from = "+15551234567"
reply = "pong"

[[trigger]]
match = "garage"
conversation = "Home"
run = ["C:/scripts/garage.ps1"]
rate_limit_secs = 60
```

## Safety rails (the actual point of the feature)

Message bodies are remote-controlled, so:

1. **No shell, ever** - `run` is an argv array spawned directly; the message arrives as JSON on stdin, so hostile bodies can never become arguments (tested with a `deploy; rm -rf /` body).
2. **Explicit opt-in for `run`** - without top-level `allow_run = true`, run rules load with a warning and never execute.
3. **Sync-replay guard** - rules only fire on messages stamped after engine load, so the initial sync's history replay cannot trigger anything.
4. **Own messages never fire rules**, and rate limiting per (rule, conversation) - default 30s - is the loop guard against two auto-responders ping-ponging.
5. Rules with no `from`/`conversation` filter load with a "fires for any sender" warning; malformed files degrade to an empty engine with a warning, never a crash.

Matching is dependency-free (no regex crate, per the issue): case-insensitive substring/exact/prefix. `run` commands get the full message JSON and can do finer filtering themselves.

## Field-count ratchet

`quit_confirm` moves into `domain::InputState` (it is the composer's quit-confirmation state), freeing the slot the `triggers` engine field occupies. App stays at 66.

## Testing

- 6 engine unit tests: match modes + case-insensitivity, outgoing/pre-sync rails, per-rule-per-conversation rate limiting (with injected clock), sender/conversation filters, allow_run gating + injection-safety of the stdin JSON, load warnings/skips/parse-error degradation.
- 2 app tests: an incoming message queues the reply on `pending.trigger_sends` with a local echo (and cooldown suppresses repeats); App::new never loads the user's triggers.toml (test/demo isolation - it loads in `run_app` only).
- `cargo clippy --tests -D warnings` clean, all 1028 tests pass, field count 66.

## Docs

- features.md: new "Message triggers" section under Automation with the TOML example and rails.
- commands.md `/triggers` row; configuration.md `--watch` CLI flag row.

## Live-test notes

Create `%APPDATA%\siggy\triggers.toml` with the ping/pong rule, `/triggers` in the TUI, then text "ping" from your phone. For `--watch`, close the TUI first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
