### PR TITLE
feat: support Signal usernames (@handle) alongside phone numbers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ signal-cli → JsonRpcResponse → SignalEvent (mpsc) → App state → SQLite +
 
 ### Conversations
 
-Keyed by phone number (1:1) or group ID (groups). `get_or_create_conversation()` is the single point for ensuring a conversation exists — it upserts to both the in-memory HashMap and SQLite. New conversations append to `conversation_order`; existing ones are no-ops.
+Keyed by phone number (1:1), ACI uuid (1:1 with username-only contacts who share no number, #612), or group ID (groups). Don't assume a non-group conversation id starts with `+`. `get_or_create_conversation()` is the single point for ensuring a conversation exists — it upserts to both the in-memory HashMap and SQLite. New conversations append to `conversation_order`; existing ones are no-ops.
 
 ### Signal-CLI Communication
 

--- a/docs/src/user-guide/commands.md
+++ b/docs/src/user-guide/commands.md
@@ -6,7 +6,7 @@ All commands start with `/`. Type `/` in Insert mode to open the autocomplete po
 
 | Command | Alias | Arguments | Description |
 |---|---|---|---|
-| `/join` | `/j` | `<name>` | Switch to a conversation by contact name, number, or group |
+| `/join` | `/j` | `<name>` | Switch to a conversation by contact name, number, `@username`, or group |
 | `/part` | `/p` | | Leave current conversation |
 | `/delete` | | | Delete current conversation (declines pending message requests) |
 | `/search` | `/s` | `<query>` | Search messages across all conversations |
@@ -200,3 +200,19 @@ phone number in E.164 format:
 ```
 
 The conversation will appear in your sidebar once the first message is exchanged.
+
+## Signal usernames
+
+Contacts who use Signal's phone-number privacy are reachable by username
+instead of number. `/join` accepts `@` handles:
+
+```
+/join @alice.42
+```
+
+Known contacts resolve instantly; an unknown handle needs the full form with
+its numeric discriminator (`name.123`) and is looked up on the Signal servers.
+Usernames of your contacts also show next to their name in the chat header —
+toggle this off with the **Show usernames** setting (`Ctrl+P` → Settings).
+
+The non-interactive sender accepts the same forms: `siggy --send @alice.42 -m hi`.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1224,6 +1224,18 @@ impl App {
     }
 
     /// Build the filtered contacts list from contact_names using the current filter.
+    /// Whether a contacts-overlay row identifier already has a conversation.
+    /// Rows display `@handle` for uuid-keyed contacts, so handles must be
+    /// resolved back to the conversation key before the lookup (#612).
+    pub fn contact_row_has_conversation(&self, id: &str) -> bool {
+        let key = id
+            .strip_prefix('@')
+            .and_then(|handle| self.store.username_to_id.get(&handle.to_lowercase()))
+            .map(|k| k.as_str())
+            .unwrap_or(id);
+        self.store.conversation_order.iter().any(|c| c == key)
+    }
+
     pub fn refresh_contacts_filter(&mut self) {
         let pairs: Vec<(String, String)> = self
             .store
@@ -3075,17 +3087,21 @@ impl App {
             let mut candidates: Vec<(String, String)> = Vec::new();
 
             // Collect contacts from contact_names
-            for (phone, name) in &self.store.contact_names {
-                // Skip group IDs (they don't start with '+')
-                if !phone.starts_with('+') {
+            for (key, name) in &self.store.contact_names {
+                // Non-phone keys are group ids or uuid-keyed username-only
+                // contacts; the latter complete as @handle (#612)
+                let (display, value) = if key.starts_with('+') {
+                    (format!("{name} ({key})"), key.clone())
+                } else if let Some(handle) = self.store.usernames.get(key) {
+                    (format!("{name} (@{handle})"), format!("@{handle}"))
+                } else {
                     continue;
-                }
-                let display = format!("{name} ({phone})");
+                };
                 if filter_lower.is_empty()
                     || name.to_lowercase().contains(&filter_lower)
-                    || phone.contains(&filter_lower)
+                    || value.to_lowercase().contains(&filter_lower)
                 {
-                    candidates.push((display, phone.clone()));
+                    candidates.push((display, value));
                 }
             }
 
@@ -3617,13 +3633,27 @@ impl App {
         self.update_status();
     }
 
+    /// Create (if needed) and focus a 1:1 conversation for a known contact
+    /// key, preferring the contact's display name over `fallback_name`.
+    fn open_contact_conversation(&mut self, key: &str, fallback_name: &str) {
+        let name = self
+            .store
+            .contact_names
+            .get(key)
+            .cloned()
+            .unwrap_or_else(|| fallback_name.to_string());
+        self.store
+            .get_or_create_conversation(key, &name, false, &self.db);
+        self.activate_conversation(key);
+    }
+
     /// Switch to (or create) the conversation named by `target`.
     ///
-    /// Returns `Some(username)` when the target is an unknown `@handle` that
-    /// needs a getUserStatus round-trip; the caller turns that into a
-    /// [`SendRequest::ResolveUsername`] and the response is correlated via
+    /// An unknown `@handle` needs a getUserStatus round-trip: the request is
+    /// queued on `pending.trigger_sends` (drained by the main loop, so every
+    /// call site dispatches it uniformly) and the response is correlated via
     /// `pending.username_resolve` (#612).
-    pub(crate) fn join_conversation(&mut self, target: &str) -> Option<String> {
+    pub(crate) fn join_conversation(&mut self, target: &str) {
         self.leave_active_conversation();
         // Stale from the previous conversation; the next render sets it. Prevents
         // evicting the new conversation's image_lines before it has drawn (#492).
@@ -3638,33 +3668,43 @@ impl App {
             if let Some(key) = self.store.username_to_id.get(&handle_lower).cloned() {
                 // Known contact: open (or create) its conversation under the
                 // contact key (phone number, or uuid for username-only contacts).
-                let name = self
-                    .store
-                    .contact_names
-                    .get(&key)
-                    .cloned()
-                    .unwrap_or_else(|| format!("@{handle}"));
-                self.store
-                    .get_or_create_conversation(&key, &name, false, &self.db);
-                self.activate_conversation(&key);
-                return None;
+                self.open_contact_conversation(&key, &format!("@{handle}"));
+                return;
+            }
+            // A conversation literally named "@handle" (e.g. restored from
+            // the DB before listContacts repopulates the username maps) is a
+            // local match — don't burn a network round-trip on it.
+            let found_id = self
+                .store
+                .conversations
+                .iter()
+                .find(|(_, conv)| conv.name.eq_ignore_ascii_case(target))
+                .map(|(id, _)| id.clone());
+            if let Some(id) = found_id {
+                self.activate_conversation(&id);
+                return;
             }
             // Unknown handle: a full username (name.discriminator) can be
             // resolved to a uuid via getUserStatus; a bare nickname cannot.
             if handle_lower.contains('.') {
                 self.pending.username_resolve = Some(handle_lower.clone());
+                self.pending
+                    .trigger_sends
+                    .push(SendRequest::ResolveUsername {
+                        username: handle_lower.clone(),
+                    });
                 self.status_message = format!("Resolving @{handle_lower}...");
-                return Some(handle_lower);
+                return;
             }
             self.status_message =
                 format!("Unknown username @{handle} - use the full handle (name.123)");
-            return None;
+            return;
         }
 
         // Try exact match first
         if self.store.conversations.contains_key(target) {
             self.activate_conversation(target);
-            return None;
+            return;
         }
 
         // Try matching by name (case-insensitive)
@@ -3678,16 +3718,17 @@ impl App {
 
         if let Some(id) = found_id {
             self.activate_conversation(&id);
-            return None;
+            return;
         }
 
-        // Known contact key without a conversation yet (e.g. a username-only
-        // contact selected in the contacts overlay, keyed by uuid) (#612)
-        if let Some(name) = self.store.contact_names.get(target).cloned() {
-            self.store
-                .get_or_create_conversation(target, &name, false, &self.db);
-            self.activate_conversation(target);
-            return None;
+        // Known 1:1 contact key without a conversation yet (e.g. a
+        // username-only contact selected in the contacts overlay, keyed by
+        // uuid). Group ids also live in contact_names — those must not be
+        // resurrected as 1:1 conversations (#612).
+        if self.store.contact_names.contains_key(target) && !self.store.groups.contains_key(target)
+        {
+            self.open_contact_conversation(target, target);
+            return;
         }
 
         // Create a new 1:1 conversation if target looks like a phone number
@@ -3701,7 +3742,6 @@ impl App {
         } else {
             self.status_message = format!("Conversation not found: {target}");
         }
-        None
     }
 
     /// Capture the viewport pin anchor on the first sync message arrival

--- a/src/app.rs
+++ b/src/app.rs
@@ -646,8 +646,8 @@ pub struct SettingDef {
 
 /// Section boundary indices within the SETTINGS array.
 pub const SETTINGS_SECTION_DISPLAY: usize = 3;
-pub const SETTINGS_SECTION_MESSAGES: usize = 9;
-pub const SETTINGS_SECTION_INTERFACE: usize = 12;
+pub const SETTINGS_SECTION_MESSAGES: usize = 10;
+pub const SETTINGS_SECTION_INTERFACE: usize = 13;
 
 /// Visual order of settings items (logical indices into the combined toggle+special list).
 /// Toggle indices 0..SETTINGS.len() map to SETTINGS entries.
@@ -655,13 +655,13 @@ pub const SETTINGS_SECTION_INTERFACE: usize = 12;
 /// Navigation walks this array so j/k follows the visual layout.
 pub const SETTINGS_VISUAL_ORDER: &[usize] = &[
     // Notifications
-    0, 1, 2, 15, // DM, Group, Desktop, Notification preview
+    0, 1, 2, 16, // DM, Group, Desktop, Notification preview
     // Display
-    3, 4, 5, 6, 7, 8, 16, // Link previews .. Emoji to text, Image mode
+    3, 4, 5, 6, 7, 8, 9, 17, // Link previews .. Show usernames, Image mode
     // Messages
-    9, 10, 11, // Show reactions, Verbose reactions, Send read receipts
+    10, 11, 12, // Show reactions, Verbose reactions, Send read receipts
     // Interface
-    12, 13, 14, 17, // Sidebar visible, Mouse, Sidebar on right, Customize...
+    13, 14, 15, 18, // Sidebar visible, Mouse, Sidebar on right, Customize...
 ];
 
 pub const SETTINGS: &[SettingDef] = &[
@@ -739,7 +739,15 @@ pub const SETTINGS: &[SettingDef] = &[
         save: Some(|c, v| c.emoji_to_text = v),
         load: Some(|c| c.emoji_to_text),
     },
-    // — Messages (9–11) —
+    SettingDef {
+        label: "Show usernames",
+        hint: "Show @handle next to 1:1 conversation names",
+        get: |a| a.store.show_usernames,
+        set: |a, v| a.store.show_usernames = v,
+        save: Some(|c, v| c.show_usernames = v),
+        load: Some(|c| c.show_usernames),
+    },
+    // — Messages (10–12) —
     SettingDef {
         label: "Show reactions",
         hint: "Show emoji reactions on messages",
@@ -764,7 +772,7 @@ pub const SETTINGS: &[SettingDef] = &[
         save: Some(|c, v| c.send_read_receipts = v),
         load: Some(|c| c.send_read_receipts),
     },
-    // — Interface (12–14) —
+    // — Interface (13–15) —
     SettingDef {
         label: "Sidebar visible",
         hint: "Show the conversation list sidebar",
@@ -1222,7 +1230,19 @@ impl App {
             .contact_names
             .iter()
             .filter(|(_, name)| !name.is_empty())
-            .map(|(number, name)| (number.clone(), name.clone()))
+            .map(|(key, name)| {
+                // uuid-keyed (username-only) contacts show their @handle
+                // instead of an opaque uuid; @handles re-resolve on select
+                // via the /join username path (#612)
+                let id = if !key.starts_with('+')
+                    && let Some(username) = self.store.usernames.get(key)
+                {
+                    format!("@{username}")
+                } else {
+                    key.clone()
+                };
+                (id, name.clone())
+            })
             .collect();
         self.contacts_overlay.filtered =
             list_overlay::filter_name_number_pairs(pairs, &self.contacts_overlay.filter);
@@ -3583,24 +3603,68 @@ impl App {
         self.clear_kitty_placements();
     }
 
-    pub(crate) fn join_conversation(&mut self, target: &str) {
+    /// Focus an existing conversation: queue read receipts, clear unread,
+    /// restore scroll. Callers ensure the conversation exists.
+    fn activate_conversation(&mut self, id: &str) {
+        let read_from = self.store.last_read_index.get(id).copied().unwrap_or(0);
+        self.queue_read_receipts_for_conv(id, read_from);
+        self.active_conversation = Some(id.to_string());
+        if let Some(conv) = self.store.conversations.get_mut(id) {
+            conv.unread = 0;
+        }
+        self.restore_scroll_position(id);
+
+        self.update_status();
+    }
+
+    /// Switch to (or create) the conversation named by `target`.
+    ///
+    /// Returns `Some(username)` when the target is an unknown `@handle` that
+    /// needs a getUserStatus round-trip; the caller turns that into a
+    /// [`SendRequest::ResolveUsername`] and the response is correlated via
+    /// `pending.username_resolve` (#612).
+    pub(crate) fn join_conversation(&mut self, target: &str) -> Option<String> {
         self.leave_active_conversation();
         // Stale from the previous conversation; the next render sets it. Prevents
         // evicting the new conversation's image_lines before it has drawn (#492).
         self.scroll.render_window_start = 0;
 
+        // Username target: @handle or u:handle (#612)
+        if let Some(handle) = target
+            .strip_prefix('@')
+            .or_else(|| target.strip_prefix("u:"))
+        {
+            let handle_lower = handle.to_lowercase();
+            if let Some(key) = self.store.username_to_id.get(&handle_lower).cloned() {
+                // Known contact: open (or create) its conversation under the
+                // contact key (phone number, or uuid for username-only contacts).
+                let name = self
+                    .store
+                    .contact_names
+                    .get(&key)
+                    .cloned()
+                    .unwrap_or_else(|| format!("@{handle}"));
+                self.store
+                    .get_or_create_conversation(&key, &name, false, &self.db);
+                self.activate_conversation(&key);
+                return None;
+            }
+            // Unknown handle: a full username (name.discriminator) can be
+            // resolved to a uuid via getUserStatus; a bare nickname cannot.
+            if handle_lower.contains('.') {
+                self.pending.username_resolve = Some(handle_lower.clone());
+                self.status_message = format!("Resolving @{handle_lower}...");
+                return Some(handle_lower);
+            }
+            self.status_message =
+                format!("Unknown username @{handle} - use the full handle (name.123)");
+            return None;
+        }
+
         // Try exact match first
         if self.store.conversations.contains_key(target) {
-            let read_from = self.store.last_read_index.get(target).copied().unwrap_or(0);
-            self.queue_read_receipts_for_conv(target, read_from);
-            self.active_conversation = Some(target.to_string());
-            if let Some(conv) = self.store.conversations.get_mut(target) {
-                conv.unread = 0;
-            }
-            self.restore_scroll_position(target);
-
-            self.update_status();
-            return;
+            self.activate_conversation(target);
+            return None;
         }
 
         // Try matching by name (case-insensitive)
@@ -3613,16 +3677,17 @@ impl App {
             .map(|(id, _)| id.clone());
 
         if let Some(id) = found_id {
-            let read_from = self.store.last_read_index.get(&id).copied().unwrap_or(0);
-            self.queue_read_receipts_for_conv(&id, read_from);
-            self.active_conversation = Some(id.clone());
-            if let Some(conv) = self.store.conversations.get_mut(&id) {
-                conv.unread = 0;
-            }
-            self.restore_scroll_position(&id);
+            self.activate_conversation(&id);
+            return None;
+        }
 
-            self.update_status();
-            return;
+        // Known contact key without a conversation yet (e.g. a username-only
+        // contact selected in the contacts overlay, keyed by uuid) (#612)
+        if let Some(name) = self.store.contact_names.get(target).cloned() {
+            self.store
+                .get_or_create_conversation(target, &name, false, &self.db);
+            self.activate_conversation(target);
+            return None;
         }
 
         // Create a new 1:1 conversation if target looks like a phone number
@@ -3636,6 +3701,7 @@ impl App {
         } else {
             self.status_message = format!("Conversation not found: {target}");
         }
+        None
     }
 
     /// Capture the viewport pin anchor on the first sync message arrival

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::db::Database;
 use crate::signal::types::{
     Attachment, Contact, Group, IdentityInfo, Mention, PollData, PollOption, ReceiptKind,
-    SignalEvent, SignalMessage, StyleType, TextStyle, TrustLevel,
+    SignalEvent, SignalMessage, StyleType, TextStyle, TrustLevel, UserStatus,
 };
 use crossterm::event::{KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use rstest::{fixture, rstest};
@@ -28,14 +28,16 @@ fn contact_list_does_not_create_conversations(mut app: App) {
 
     app.handle_signal_event(SignalEvent::ContactList(vec![
         Contact {
-            number: "+1".to_string(),
+            number: Some("+1".to_string()),
             name: Some("Alice".to_string()),
             uuid: None,
+            username: None,
         },
         Contact {
-            number: "+2".to_string(),
+            number: Some("+2".to_string()),
             name: Some("Bob".to_string()),
             uuid: None,
+            username: None,
         },
     ]));
 
@@ -87,9 +89,10 @@ fn contact_name_updates_existing_conversation(mut app: App) {
 
     // Contact list arrives with a proper name — updates existing conv
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+15551234567".to_string(),
+        number: Some("+15551234567".to_string()),
         name: Some("Alice".to_string()),
         uuid: None,
+        username: None,
     }]));
 
     assert_eq!(app.store.conversations["+15551234567"].name, "Alice");
@@ -110,9 +113,10 @@ fn contact_without_name_does_not_overwrite_existing_name(mut app: App) {
 
     // Contact arrives with no name — should NOT overwrite
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+1".to_string(),
+        number: Some("+1".to_string()),
         name: None,
         uuid: None,
+        username: None,
     }]));
 
     assert_eq!(app.store.conversations["+1"].name, "Alice");
@@ -124,9 +128,10 @@ fn contact_without_name_does_not_overwrite_existing_name(mut app: App) {
 fn message_uses_contact_name_lookup(mut app: App) {
     // Contacts loaded first (no conversations created)
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+1".to_string(),
+        number: Some("+1".to_string()),
         name: Some("Alice".to_string()),
         uuid: None,
+        username: None,
     }]));
     assert!(app.store.conversations.is_empty());
 
@@ -177,9 +182,10 @@ fn message_in_known_group_uses_name_lookup(mut app: App) {
 #[rstest]
 fn no_duplicate_on_repeated_messages(mut app: App) {
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+1".to_string(),
+        number: Some("+1".to_string()),
         name: Some("Alice".to_string()),
         uuid: None,
+        username: None,
     }]));
 
     for _ in 0..3 {
@@ -2227,14 +2233,16 @@ fn contact_list_resolves_reactions_and_quotes(mut app: App) {
     // Contact list arrives — only +2 is a formal contact
     app.handle_signal_event(SignalEvent::ContactList(vec![
         Contact {
-            number: "+1".to_string(),
+            number: Some("+1".to_string()),
             name: Some("Alice".to_string()),
             uuid: None,
+            username: None,
         },
         Contact {
-            number: "+2".to_string(),
+            number: Some("+2".to_string()),
             name: Some("Bob".to_string()),
             uuid: None,
+            username: None,
         },
     ]));
 
@@ -2330,9 +2338,10 @@ fn mention_reresolves_when_contact_arrives_after_message(mut app: App) {
 
     // Contact list arrives with the mentioned user.
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+15550002222".to_string(),
+        number: Some("+15550002222".to_string()),
         name: Some("Bob".to_string()),
         uuid: Some("bbbbbbbb-2222-2222-2222-222222222222".to_string()),
+        username: None,
     }]));
 
     // Mention should now resolve to the real name.
@@ -2528,13 +2537,58 @@ fn send_text_without_markup_is_unchanged(mut app: App) {
 #[rstest]
 fn contact_list_builds_uuid_maps(mut app: App) {
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+1".to_string(),
+        number: Some("+1".to_string()),
         name: Some("Alice".to_string()),
         uuid: Some("uuid-alice".to_string()),
+        username: None,
     }]));
 
     assert_eq!(app.store.uuid_to_name.get("uuid-alice").unwrap(), "Alice");
     assert_eq!(app.store.number_to_uuid.get("+1").unwrap(), "uuid-alice");
+}
+
+#[rstest]
+fn contact_list_builds_username_maps(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![
+        Contact {
+            number: Some("+1".to_string()),
+            name: Some("Alice".to_string()),
+            uuid: Some("uuid-alice".to_string()),
+            username: Some("alice.42".to_string()),
+        },
+        // Username-only contact: no phone number, keyed by uuid (#612)
+        Contact {
+            number: None,
+            name: Some("Carol".to_string()),
+            uuid: Some("uuid-carol".to_string()),
+            username: Some("carol.99".to_string()),
+        },
+    ]));
+
+    // conv-key → username (for display)
+    assert_eq!(app.store.usernames.get("+1").unwrap(), "alice.42");
+    assert_eq!(app.store.usernames.get("uuid-carol").unwrap(), "carol.99");
+    // username (lowercased) → conv-key (for /join @handle resolution)
+    assert_eq!(app.store.username_to_id.get("alice.42").unwrap(), "+1");
+    assert_eq!(
+        app.store.username_to_id.get("carol.99").unwrap(),
+        "uuid-carol"
+    );
+    // Username-only contact's display name lands under its uuid key
+    assert_eq!(app.store.contact_names.get("uuid-carol").unwrap(), "Carol");
+}
+
+#[rstest]
+fn contact_list_username_only_without_profile_name_displays_handle(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: None,
+        uuid: Some("uuid-dave".to_string()),
+        username: Some("dave.7".to_string()),
+    }]));
+
+    // No profile name → the @handle is the identity we can show (#612)
+    assert_eq!(app.store.contact_names.get("uuid-dave").unwrap(), "@dave.7");
 }
 
 #[rstest]
@@ -2658,6 +2712,206 @@ fn clears_edit_and_reply_targets_on_prev_conversation(mut app: App) {
     app.prev_conversation();
     assert!(app.editing_message.is_none());
     assert!(app.reply_target.is_none());
+}
+
+#[rstest]
+fn join_known_username_opens_conversation(mut app: App) {
+    // Username-only contact learned from the contact list (#612)
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: Some("Carol".to_string()),
+        uuid: Some("uuid-carol".to_string()),
+        username: Some("carol.99".to_string()),
+    }]));
+
+    let resolve = app.join_conversation("@carol.99");
+
+    assert_eq!(resolve, None, "known username needs no resolution");
+    assert_eq!(app.active_conversation.as_deref(), Some("uuid-carol"));
+    let conv = app.store.conversations.get("uuid-carol").unwrap();
+    assert_eq!(conv.name, "Carol");
+    assert!(!conv.is_group);
+}
+
+#[rstest]
+fn join_unknown_full_username_requests_resolution(mut app: App) {
+    app.input.buffer = "/join @ghost.1".to_string();
+    app.input.cursor = app.input.buffer.len();
+    let req = app.handle_input();
+
+    let Some(SendRequest::ResolveUsername { username }) = req else {
+        panic!("expected SendRequest::ResolveUsername");
+    };
+    assert_eq!(username, "ghost.1");
+    // Pending marker survives until the UserStatusList response correlates
+    assert_eq!(app.pending.username_resolve.as_deref(), Some("ghost.1"));
+    assert!(app.active_conversation.is_none());
+}
+
+#[rstest]
+fn join_unknown_username_without_discriminator_errors(mut app: App) {
+    let resolve = app.join_conversation("@nosuchperson");
+
+    assert_eq!(resolve, None, "cannot resolve without a discriminator");
+    assert!(app.pending.username_resolve.is_none());
+    assert!(app.active_conversation.is_none());
+    assert!(app.status_message.contains("nosuchperson"));
+}
+
+#[rstest]
+fn join_known_contact_key_creates_conversation(mut app: App) {
+    // Selecting a username-only contact in the contacts overlay joins by its
+    // uuid key even though no conversation exists yet (#612).
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: Some("Carol".to_string()),
+        uuid: Some("uuid-carol".to_string()),
+        username: Some("carol.99".to_string()),
+    }]));
+
+    app.join_conversation("uuid-carol");
+
+    assert_eq!(app.active_conversation.as_deref(), Some("uuid-carol"));
+    assert_eq!(
+        app.store.conversations.get("uuid-carol").unwrap().name,
+        "Carol"
+    );
+}
+
+#[rstest]
+fn contacts_filter_shows_handle_for_username_only_contact(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![
+        Contact {
+            number: Some("+1".to_string()),
+            name: Some("Alice".to_string()),
+            uuid: Some("uuid-alice".to_string()),
+            username: Some("alice.42".to_string()),
+        },
+        Contact {
+            number: None,
+            name: Some("Carol".to_string()),
+            uuid: Some("uuid-carol".to_string()),
+            username: Some("carol.99".to_string()),
+        },
+    ]));
+
+    app.refresh_contacts_filter();
+
+    // Phone contacts keep their number as the identifier; uuid-keyed contacts
+    // show their @handle instead of an opaque uuid (#612)
+    assert!(
+        app.contacts_overlay
+            .filtered
+            .contains(&("+1".to_string(), "Alice".to_string()))
+    );
+    assert!(
+        app.contacts_overlay
+            .filtered
+            .contains(&("@carol.99".to_string(), "Carol".to_string()))
+    );
+}
+
+#[rstest]
+fn display_title_appends_username_when_enabled(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: Some("+1".to_string()),
+        name: Some("Alice".to_string()),
+        uuid: Some("uuid-alice".to_string()),
+        username: Some("alice.42".to_string()),
+    }]));
+    app.store
+        .get_or_create_conversation("+1", "Alice", false, &app.db);
+
+    assert!(app.store.show_usernames, "defaults on");
+    assert_eq!(app.store.display_title("+1"), "Alice (@alice.42)");
+
+    app.store.show_usernames = false;
+    assert_eq!(app.store.display_title("+1"), "Alice");
+}
+
+#[rstest]
+fn display_title_skips_username_when_name_is_the_handle(mut app: App) {
+    // Username-only contact with no profile name: the conversation is already
+    // named "@dave.7" — don't render "@dave.7 (@dave.7)" (#612)
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: None,
+        uuid: Some("uuid-dave".to_string()),
+        username: Some("dave.7".to_string()),
+    }]));
+    app.join_conversation("@dave.7");
+
+    assert_eq!(app.store.display_title("uuid-dave"), "@dave.7");
+}
+
+#[rstest]
+fn display_title_plain_for_groups_and_unknown(mut app: App) {
+    app.store
+        .get_or_create_conversation("g1", "Family", true, &app.db);
+    assert_eq!(app.store.display_title("g1"), "Family");
+    assert_eq!(app.store.display_title("missing"), "missing");
+}
+
+#[test]
+fn config_show_usernames_defaults_true() {
+    assert!(crate::config::Config::default().show_usernames);
+}
+
+#[rstest]
+fn user_status_resolves_pending_username_join(mut app: App) {
+    app.join_conversation("@carol.99");
+    assert_eq!(app.pending.username_resolve.as_deref(), Some("carol.99"));
+
+    app.handle_signal_event(SignalEvent::UserStatusList(vec![UserStatus {
+        recipient: "carol.99".to_string(),
+        username: Some("carol.99".to_string()),
+        uuid: Some("uuid-carol".to_string()),
+        registered: true,
+    }]));
+
+    assert!(app.pending.username_resolve.is_none());
+    assert_eq!(app.active_conversation.as_deref(), Some("uuid-carol"));
+    assert_eq!(
+        app.store.conversations.get("uuid-carol").unwrap().name,
+        "@carol.99"
+    );
+    // Future contact-list refreshes and /join hits resolve via the maps
+    assert_eq!(app.store.usernames.get("uuid-carol").unwrap(), "carol.99");
+    assert_eq!(
+        app.store.username_to_id.get("carol.99").unwrap(),
+        "uuid-carol"
+    );
+}
+
+#[rstest]
+fn user_status_unregistered_reports_error(mut app: App) {
+    app.join_conversation("@ghost.1");
+    assert_eq!(app.pending.username_resolve.as_deref(), Some("ghost.1"));
+
+    app.handle_signal_event(SignalEvent::UserStatusList(vec![UserStatus {
+        recipient: "ghost.1".to_string(),
+        username: None,
+        uuid: None,
+        registered: false,
+    }]));
+
+    assert!(app.pending.username_resolve.is_none());
+    assert!(app.active_conversation.is_none());
+    assert!(app.store.conversations.is_empty());
+    assert!(app.status_message.contains("ghost.1"));
+}
+
+#[rstest]
+fn user_status_without_pending_join_is_ignored(mut app: App) {
+    app.handle_signal_event(SignalEvent::UserStatusList(vec![UserStatus {
+        recipient: "random.5".to_string(),
+        username: Some("random.5".to_string()),
+        uuid: Some("uuid-random".to_string()),
+        registered: true,
+    }]));
+
+    assert!(app.active_conversation.is_none());
+    assert!(app.store.conversations.is_empty());
 }
 
 #[rstest]
@@ -3729,9 +3983,10 @@ fn contact_sync_auto_accepts_matching_conversations(mut app: App) {
 
     // Contact list arrives with +1 → auto-accept
     app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
-        number: "+1".to_string(),
+        number: Some("+1".to_string()),
         name: Some("Alice".to_string()),
         uuid: None,
+        username: None,
     }]));
     assert!(app.store.conversations["+1"].accepted);
 }

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -2724,9 +2724,12 @@ fn join_known_username_opens_conversation(mut app: App) {
         username: Some("carol.99".to_string()),
     }]));
 
-    let resolve = app.join_conversation("@carol.99");
+    app.join_conversation("@carol.99");
 
-    assert_eq!(resolve, None, "known username needs no resolution");
+    assert!(
+        app.pending.trigger_sends.is_empty(),
+        "known username needs no resolution"
+    );
     assert_eq!(app.active_conversation.as_deref(), Some("uuid-carol"));
     let conv = app.store.conversations.get("uuid-carol").unwrap();
     assert_eq!(conv.name, "Carol");
@@ -2734,26 +2737,176 @@ fn join_known_username_opens_conversation(mut app: App) {
 }
 
 #[rstest]
-fn join_unknown_full_username_requests_resolution(mut app: App) {
+fn join_unknown_full_username_queues_resolve_request(mut app: App) {
     app.input.buffer = "/join @ghost.1".to_string();
     app.input.cursor = app.input.buffer.len();
     let req = app.handle_input();
 
-    let Some(SendRequest::ResolveUsername { username }) = req else {
-        panic!("expected SendRequest::ResolveUsername");
-    };
-    assert_eq!(username, "ghost.1");
+    // The request is queued on pending.trigger_sends (drained by the main
+    // loop) so every join_conversation call site dispatches it uniformly —
+    // not returned, which only the composer path would propagate (#612).
+    assert!(req.is_none());
+    assert_eq!(app.pending.trigger_sends.len(), 1);
+    assert!(matches!(
+        &app.pending.trigger_sends[0],
+        SendRequest::ResolveUsername { username } if username == "ghost.1"
+    ));
     // Pending marker survives until the UserStatusList response correlates
     assert_eq!(app.pending.username_resolve.as_deref(), Some("ghost.1"));
     assert!(app.active_conversation.is_none());
 }
 
 #[rstest]
-fn join_unknown_username_without_discriminator_errors(mut app: App) {
-    let resolve = app.join_conversation("@nosuchperson");
+fn join_group_id_in_contact_names_does_not_create_1to1(mut app: App) {
+    // handle_group_list stores group_id → name in contact_names; the
+    // known-contact-key fallback must not resurrect a deleted group
+    // conversation as a 1:1 (#612 review).
+    app.handle_signal_event(SignalEvent::GroupList(vec![Group {
+        id: "g1".to_string(),
+        name: "Family".to_string(),
+        members: vec![],
+        member_uuids: vec![],
+    }]));
+    app.store.conversations.remove("g1");
+    app.store.conversation_order.retain(|c| c != "g1");
 
-    assert_eq!(resolve, None, "cannot resolve without a discriminator");
+    app.join_conversation("g1");
+
+    assert!(app.store.conversations.is_empty());
+    assert!(app.status_message.contains("not found"));
+}
+
+#[rstest]
+fn user_status_without_matching_entry_clears_pending(mut app: App) {
+    app.join_conversation("@ghost.1");
+    assert!(app.pending.username_resolve.is_some());
+
+    app.handle_signal_event(SignalEvent::UserStatusList(vec![]));
+
     assert!(app.pending.username_resolve.is_none());
+    assert!(app.status_message.contains("ghost.1"));
+    assert!(app.active_conversation.is_none());
+}
+
+#[rstest]
+fn get_user_status_rpc_error_clears_pending(mut app: App) {
+    app.join_conversation("@ghost.1");
+    assert!(app.pending.username_resolve.is_some());
+
+    app.handle_signal_event(SignalEvent::Error(
+        "getUserStatus: Invalid username".to_string(),
+    ));
+
+    assert!(app.pending.username_resolve.is_none());
+}
+
+#[rstest]
+fn user_status_reuses_phone_keyed_identity(mut app: App) {
+    // Alice is already known by phone number; resolving her username must not
+    // create a second, uuid-keyed conversation (#612 review).
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: Some("+1".to_string()),
+        name: Some("Alice".to_string()),
+        uuid: Some("uuid-alice".to_string()),
+        username: None,
+    }]));
+    app.join_conversation("@alice.42");
+    assert!(app.pending.username_resolve.is_some());
+
+    app.handle_signal_event(SignalEvent::UserStatusList(vec![UserStatus {
+        recipient: "alice.42".to_string(),
+        username: Some("alice.42".to_string()),
+        uuid: Some("uuid-alice".to_string()),
+        registered: true,
+    }]));
+
+    assert_eq!(app.active_conversation.as_deref(), Some("+1"));
+    assert!(!app.store.conversations.contains_key("uuid-alice"));
+    assert_eq!(app.store.usernames.get("+1").unwrap(), "alice.42");
+}
+
+#[rstest]
+fn contact_list_does_not_downgrade_learned_name(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: Some("Carol".to_string()),
+        uuid: Some("uuid-carol".to_string()),
+        username: Some("carol.99".to_string()),
+    }]));
+    // Second sync without a profile name (e.g. profile fetch failed)
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: None,
+        uuid: Some("uuid-carol".to_string()),
+        username: Some("carol.99".to_string()),
+    }]));
+
+    assert_eq!(app.store.contact_names.get("uuid-carol").unwrap(), "Carol");
+}
+
+#[rstest]
+fn join_at_target_matches_existing_conversation_name(mut app: App) {
+    // After a restart the username maps are empty until listContacts arrives;
+    // an existing conversation literally named "@carol.99" must still be
+    // joinable without a network round-trip (#612 review).
+    app.store
+        .get_or_create_conversation("uuid-carol", "@carol.99", false, &app.db);
+
+    app.join_conversation("@carol.99");
+
+    assert_eq!(app.active_conversation.as_deref(), Some("uuid-carol"));
+    assert!(app.pending.username_resolve.is_none());
+    assert!(app.pending.trigger_sends.is_empty());
+}
+
+#[rstest]
+fn contact_row_has_conversation_resolves_handles(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: Some("Carol".to_string()),
+        uuid: Some("uuid-carol".to_string()),
+        username: Some("carol.99".to_string()),
+    }]));
+    app.store
+        .get_or_create_conversation("uuid-carol", "Carol", false, &app.db);
+
+    // The contacts overlay displays "@carol.99" but the conversation is keyed
+    // by uuid; the checkmark lookup must bridge the two (#612 review).
+    assert!(app.contact_row_has_conversation("@carol.99"));
+    assert!(!app.contact_row_has_conversation("+1"));
+}
+
+#[rstest]
+fn join_autocomplete_includes_username_only_contacts(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![Contact {
+        number: None,
+        name: Some("Carol".to_string()),
+        uuid: Some("uuid-carol".to_string()),
+        username: Some("carol.99".to_string()),
+    }]));
+    app.input.buffer = "/join car".to_string();
+    app.update_autocomplete();
+
+    assert!(app.is_overlay(OverlayKind::Autocomplete));
+    let found = app
+        .autocomplete
+        .join_candidates
+        .iter()
+        .any(|(display, value)| display.contains("@carol.99") && value == "@carol.99");
+    assert!(
+        found,
+        "expected @carol.99 candidate, got {:?}",
+        app.autocomplete.join_candidates
+    );
+}
+
+#[rstest]
+fn join_unknown_username_without_discriminator_errors(mut app: App) {
+    app.join_conversation("@nosuchperson");
+
+    // Cannot resolve without a discriminator: no pending, no queued request
+    assert!(app.pending.username_resolve.is_none());
+    assert!(app.pending.trigger_sends.is_empty());
     assert!(app.active_conversation.is_none());
     assert!(app.status_message.contains("nosuchperson"));
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,6 +203,10 @@ pub struct Config {
     #[serde(default)]
     pub reaction_verbose: bool,
 
+    /// Show Signal usernames (@handle) next to 1:1 conversation names (#612)
+    #[serde(default = "default_true")]
+    pub show_usernames: bool,
+
     /// Send read receipts to message senders when viewing conversations
     #[serde(default = "default_true")]
     pub send_read_receipts: bool,
@@ -322,6 +326,7 @@ impl Default for Config {
             emoji_to_text: false,
             show_reactions: true,
             reaction_verbose: false,
+            show_usernames: true,
             send_read_receipts: true,
             mouse_enabled: true,
             sidebar_on_right: false,

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -285,6 +285,15 @@ pub struct ConversationStore {
     pub uuid_to_name: HashMap<String, String>,
     /// Phone number → UUID mapping (for sending mentions).
     pub number_to_uuid: HashMap<String, String>,
+    /// Conversation key → Signal username with discriminator, no `@`
+    /// (e.g. `alice.42`), for display next to names (#612).
+    pub usernames: HashMap<String, String>,
+    /// Lowercased username → conversation key, for `/join @handle` (#612).
+    pub username_to_id: HashMap<String, String>,
+    /// Show `@handle` next to 1:1 conversation names. Display preference
+    /// living beside the username maps it gates; persisted via
+    /// `Config::show_usernames` (#612).
+    pub show_usernames: bool,
     /// Last-read message index per conversation (for unread marker).
     pub last_read_index: HashMap<String, usize>,
     /// Groups indexed by group_id (with member lists for @mention autocomplete).
@@ -301,6 +310,9 @@ impl ConversationStore {
             contact_names: HashMap::new(),
             uuid_to_name: HashMap::new(),
             number_to_uuid: HashMap::new(),
+            usernames: HashMap::new(),
+            username_to_id: HashMap::new(),
+            show_usernames: true,
             last_read_index: HashMap::new(),
             groups: HashMap::new(),
             has_more_messages: HashSet::new(),
@@ -347,6 +359,24 @@ impl ConversationStore {
             }
         }
         self.conversations.get_mut(id).unwrap()
+    }
+
+    /// Chat-pane title for a conversation: its name, with ` (@handle)`
+    /// appended for 1:1 conversations whose contact has a Signal username —
+    /// gated by [`Self::show_usernames`]. Skipped when the name already *is*
+    /// the handle (username-only contact with no profile name) (#612).
+    pub fn display_title(&self, id: &str) -> String {
+        let Some(conv) = self.conversations.get(id) else {
+            return id.to_string();
+        };
+        if !conv.is_group
+            && self.show_usernames
+            && let Some(username) = self.usernames.get(id)
+            && conv.name != format!("@{username}")
+        {
+            return format!("{} (@{username})", conv.name);
+        }
+        conv.name.clone()
     }
 
     /// Remember a contact's display name if not already known.

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -372,7 +372,7 @@ impl ConversationStore {
         if !conv.is_group
             && self.show_usernames
             && let Some(username) = self.usernames.get(id)
-            && conv.name != format!("@{username}")
+            && conv.name.strip_prefix('@') != Some(username.as_str())
         {
             return format!("{} (@{username})", conv.name);
         }

--- a/src/domain/pending.rs
+++ b/src/domain/pending.rs
@@ -49,4 +49,8 @@ pub struct PendingState {
     /// Auto-replies queued by message triggers (#615), drained by the main
     /// loop into `dispatch_send` like any composer send.
     pub trigger_sends: Vec<SendRequest>,
+    /// Username awaiting getUserStatus resolution from `/join @handle`
+    /// (lowercased, no `@`). Cleared when the `UserStatusList` response
+    /// arrives (#612).
+    pub username_resolve: Option<String>,
 }

--- a/src/domain/send.rs
+++ b/src/domain/send.rs
@@ -133,6 +133,11 @@ pub enum SendRequest {
         poll_timestamp: i64,
     },
     ListIdentities,
+    /// Resolve a Signal username (`name.123`, no `@`) to an account uuid via
+    /// getUserStatus, for `/join @handle` on unknown handles (#612).
+    ResolveUsername {
+        username: String,
+    },
     TrustIdentity {
         recipient: String,
         safety_number: String,

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -33,8 +33,9 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
     match action {
         InputAction::SendText(raw_text) => send_text(app, raw_text),
         InputAction::Join(target) => {
-            app.join_conversation(&target);
-            None
+            // An unknown @handle needs a getUserStatus round-trip (#612)
+            app.join_conversation(&target)
+                .map(|username| SendRequest::ResolveUsername { username })
         }
         InputAction::Part => {
             close_active_conversation(app);

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -33,9 +33,8 @@ pub fn handle_input(app: &mut App) -> Option<SendRequest> {
     match action {
         InputAction::SendText(raw_text) => send_text(app, raw_text),
         InputAction::Join(target) => {
-            // An unknown @handle needs a getUserStatus round-trip (#612)
-            app.join_conversation(&target)
-                .map(|username| SendRequest::ResolveUsername { username })
+            app.join_conversation(&target);
+            None
         }
         InputAction::Part => {
             close_active_conversation(app);

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -276,6 +276,7 @@ pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
         SignalEvent::ContactList(contacts) => handle_contact_list(app, contacts),
         SignalEvent::GroupList(groups) => handle_group_list(app, groups),
         SignalEvent::IdentityList(identities) => handle_identity_list(app, identities),
+        SignalEvent::UserStatusList(statuses) => handle_user_status_list(app, statuses),
         SignalEvent::Error(ref err) => {
             crate::debug_log::logf(format_args!("signal event error: {err}"));
             match SignalCliHint::classify(err) {
@@ -1399,17 +1400,69 @@ fn handle_read_sync(app: &mut App, read_messages: Vec<(String, i64)>) {
     }
 }
 
+/// Handle a getUserStatus response: complete a pending `/join @handle`
+/// username resolution (#612). Responses with no pending join are ignored —
+/// nothing else issues getUserStatus.
+fn handle_user_status_list(app: &mut App, statuses: Vec<crate::signal::types::UserStatus>) {
+    let Some(pending) = app.pending.username_resolve.clone() else {
+        return;
+    };
+    let Some(status) = statuses.iter().find(|s| {
+        s.recipient.eq_ignore_ascii_case(&pending)
+            || s.username
+                .as_deref()
+                .is_some_and(|u| u.eq_ignore_ascii_case(&pending))
+    }) else {
+        return;
+    };
+    app.pending.username_resolve = None;
+
+    let (true, Some(uuid)) = (status.registered, status.uuid.as_deref()) else {
+        app.status_message = format!("No Signal account found for @{pending}");
+        return;
+    };
+    let handle = status.username.clone().unwrap_or_else(|| pending.clone());
+    // Remember the resolution so future /join hits skip the round-trip
+    app.store.usernames.insert(uuid.to_string(), handle.clone());
+    app.store
+        .username_to_id
+        .insert(handle.to_lowercase(), uuid.to_string());
+    let name = format!("@{handle}");
+    app.store
+        .get_or_create_conversation(uuid, &name, false, &app.db);
+    // Re-join through the username path, which now resolves locally
+    app.join_conversation(&name);
+}
+
 fn handle_contact_list(app: &mut App, contacts: Vec<Contact>) {
     app.loading = false;
     app.startup_status.clear();
     for contact in contacts {
-        // Store name in lookup for future message resolution
+        // Conversation/map key: phone number, else uuid for username-only
+        // contacts (#612). Entries with neither are dropped at parse time.
+        let Some(key) = contact.key().map(|k| k.to_string()) else {
+            continue;
+        };
+        // Store name in lookup for future message resolution. A username-only
+        // contact with no profile name still gets a displayable identity: the
+        // @handle (#612).
         if let Some(ref name) = contact.name
             && !name.is_empty()
         {
+            app.store.contact_names.insert(key.clone(), name.clone());
+        } else if contact.number.is_none()
+            && let Some(ref username) = contact.username
+        {
             app.store
                 .contact_names
-                .insert(contact.number.clone(), name.clone());
+                .insert(key.clone(), format!("@{username}"));
+        }
+        // Username maps: key → handle for display, handle → key for /join (#612)
+        if let Some(ref username) = contact.username {
+            app.store.usernames.insert(key.clone(), username.clone());
+            app.store
+                .username_to_id
+                .insert(username.to_lowercase(), key.clone());
         }
         // Build UUID maps for @mention resolution
         if let Some(ref uuid) = contact.uuid {
@@ -1418,20 +1471,21 @@ fn handle_contact_list(app: &mut App, contacts: Vec<Contact>) {
             {
                 app.store.uuid_to_name.insert(uuid.clone(), name.clone());
             }
-            app.store
-                .number_to_uuid
-                .insert(contact.number.clone(), uuid.clone());
+            if let Some(ref number) = contact.number {
+                app.store
+                    .number_to_uuid
+                    .insert(number.clone(), uuid.clone());
+            }
         }
         // Update name on existing conversations only — don't create new ones
-        if let Some(conv) = app.store.conversations.get_mut(&contact.number)
+        if let Some(conv) = app.store.conversations.get_mut(&key)
             && let Some(ref contact_name) = contact.name
             && !contact_name.is_empty()
             && conv.name != *contact_name
         {
             conv.name = contact_name.clone();
             db_warn(
-                app.db
-                    .upsert_conversation(&contact.number, contact_name, false),
+                app.db.upsert_conversation(&key, contact_name, false),
                 "upsert_conversation",
             );
         }

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -279,6 +279,13 @@ pub fn handle_signal_event(app: &mut App, event: SignalEvent) {
         SignalEvent::UserStatusList(statuses) => handle_user_status_list(app, statuses),
         SignalEvent::Error(ref err) => {
             crate::debug_log::logf(format_args!("signal event error: {err}"));
+            // A getUserStatus RPC error means the pending /join @handle
+            // resolution will never get a UserStatusList — clear the marker
+            // so the join doesn't wedge on "Resolving..." (#612). The error
+            // text itself lands in the status bar below.
+            if err.starts_with("getUserStatus") {
+                app.pending.username_resolve = None;
+            }
             match SignalCliHint::classify(err) {
                 Some(hint) => {
                     // Show the actionable hint once per session per category;
@@ -1402,36 +1409,51 @@ fn handle_read_sync(app: &mut App, read_messages: Vec<(String, i64)>) {
 
 /// Handle a getUserStatus response: complete a pending `/join @handle`
 /// username resolution (#612). Responses with no pending join are ignored —
-/// nothing else issues getUserStatus.
+/// nothing else issues getUserStatus. A response arriving while a join is
+/// pending always terminates the pending state, so the UI can never wedge on
+/// "Resolving..." (only one getUserStatus is ever in flight).
 fn handle_user_status_list(app: &mut App, statuses: Vec<crate::signal::types::UserStatus>) {
     let Some(pending) = app.pending.username_resolve.clone() else {
         return;
     };
-    let Some(status) = statuses.iter().find(|s| {
-        s.recipient.eq_ignore_ascii_case(&pending)
+    app.pending.username_resolve = None;
+
+    // Tolerate signal-cli echoing the queried recipient with the u: prefix.
+    let status = statuses.iter().find(|s| {
+        s.recipient
+            .trim_start_matches("u:")
+            .eq_ignore_ascii_case(&pending)
             || s.username
                 .as_deref()
                 .is_some_and(|u| u.eq_ignore_ascii_case(&pending))
-    }) else {
+    });
+    let Some(status) = status else {
+        app.status_message = format!("Username lookup failed for @{pending}");
         return;
     };
-    app.pending.username_resolve = None;
 
     let (true, Some(uuid)) = (status.registered, status.uuid.as_deref()) else {
         app.status_message = format!("No Signal account found for @{pending}");
         return;
     };
     let handle = status.username.clone().unwrap_or_else(|| pending.clone());
+    // The resolved account may already be a phone-keyed contact whose
+    // username simply wasn't in the local contact list — reuse that key, or
+    // incoming messages (keyed by sourceNumber) would land in a parallel,
+    // uuid-keyed conversation.
+    let key = app
+        .store
+        .number_to_uuid
+        .iter()
+        .find(|(_, u)| u.as_str() == uuid)
+        .map(|(number, _)| number.clone())
+        .unwrap_or_else(|| uuid.to_string());
     // Remember the resolution so future /join hits skip the round-trip
-    app.store.usernames.insert(uuid.to_string(), handle.clone());
-    app.store
-        .username_to_id
-        .insert(handle.to_lowercase(), uuid.to_string());
-    let name = format!("@{handle}");
-    app.store
-        .get_or_create_conversation(uuid, &name, false, &app.db);
-    // Re-join through the username path, which now resolves locally
-    app.join_conversation(&name);
+    app.store.usernames.insert(key.clone(), handle.clone());
+    app.store.username_to_id.insert(handle.to_lowercase(), key);
+    // Re-join through the username path, which now resolves locally and
+    // creates the conversation under the right key with the right name.
+    app.join_conversation(&format!("@{handle}"));
 }
 
 fn handle_contact_list(app: &mut App, contacts: Vec<Contact>) {
@@ -1453,9 +1475,12 @@ fn handle_contact_list(app: &mut App, contacts: Vec<Contact>) {
         } else if contact.number.is_none()
             && let Some(ref username) = contact.username
         {
+            // Fallback identity only — never downgrade a name learned from an
+            // earlier sync (phone contacts keep theirs the same way).
             app.store
                 .contact_names
-                .insert(key.clone(), format!("@{username}"));
+                .entry(key.clone())
+                .or_insert_with(|| format!("@{username}"));
         }
         // Username maps: key → handle for display, handle → key for /join (#612)
         if let Some(ref username) = contact.username {

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,9 +108,14 @@ fn cli_stderr_hint(stderr: &str) -> Option<&'static str> {
 /// or `u:name.123`, normalized to signal-cli's `u:` form) are 1:1 targets;
 /// anything else is treated as a group id (#257, #612).
 fn oneshot_target(recipient: &str) -> (String, bool) {
-    if let Some(handle) = recipient.strip_prefix('@') {
-        (format!("u:{handle}"), false)
-    } else if recipient.starts_with('+') || recipient.starts_with("u:") {
+    if let Some(handle) = recipient
+        .strip_prefix('@')
+        .or_else(|| recipient.strip_prefix("u:"))
+    {
+        // Lowercase like the interactive /join path (usernames are
+        // case-insensitive; nicknames are canonically lowercase)
+        (format!("u:{}", handle.to_lowercase()), false)
+    } else if recipient.starts_with('+') {
         (recipient.to_string(), false)
     } else {
         (recipient.to_string(), true)
@@ -2264,9 +2269,11 @@ mod tests {
             oneshot_target("+15551234567"),
             ("+15551234567".into(), false)
         );
-        // Username forms: 1:1, normalized to signal-cli's u: prefix (#612)
+        // Username forms: 1:1, normalized to signal-cli's u: prefix and
+        // lowercased like the interactive /join path (#612)
         assert_eq!(oneshot_target("@alice.42"), ("u:alice.42".into(), false));
-        assert_eq!(oneshot_target("u:alice.42"), ("u:alice.42".into(), false));
+        assert_eq!(oneshot_target("@Alice.42"), ("u:alice.42".into(), false));
+        assert_eq!(oneshot_target("u:Alice.42"), ("u:alice.42".into(), false));
         // Anything else: group id
         assert_eq!(oneshot_target("grpid=="), ("grpid==".into(), true));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,15 +104,27 @@ fn cli_stderr_hint(stderr: &str) -> Option<&'static str> {
     }
 }
 
+/// Classify a `--send` recipient: phone numbers and usernames (`@name.123`
+/// or `u:name.123`, normalized to signal-cli's `u:` form) are 1:1 targets;
+/// anything else is treated as a group id (#257, #612).
+fn oneshot_target(recipient: &str) -> (String, bool) {
+    if let Some(handle) = recipient.strip_prefix('@') {
+        (format!("u:{handle}"), false)
+    } else if recipient.starts_with('+') || recipient.starts_with("u:") {
+        (recipient.to_string(), false)
+    } else {
+        (recipient.to_string(), true)
+    }
+}
+
 /// Send a single message non-interactively, await confirmation, and return
 /// whether it was accepted (#257). Spawns signal-cli, sends, then waits up to
-/// 30s for the correlated `SendTimestamp` (ok) or `SendFailed`. A recipient that
-/// does not start with `+` is treated as a group id.
+/// 30s for the correlated `SendTimestamp` (ok) or `SendFailed`.
 async fn run_send_oneshot(config: &Config, recipient: &str, body: &str) -> Result<bool> {
     let mut client = SignalClient::spawn(config).await?;
-    let is_group = !recipient.starts_with('+');
+    let (target, is_group) = oneshot_target(recipient);
     let rpc_id = client
-        .send_message(recipient, body, is_group, &[], &[], &[], None, None)
+        .send_message(&target, body, is_group, &[], &[], &[], None, None)
         .await?;
 
     let outcome = tokio::time::timeout(Duration::from_secs(30), async {
@@ -1617,6 +1629,12 @@ async fn dispatch_send(signal_client: &mut SignalClient, app: &mut App, req: Sen
         SendRequest::ListIdentities => {
             let _ = signal_client.list_identities().await;
         }
+        SendRequest::ResolveUsername { username } => {
+            if let Err(e) = signal_client.get_user_status(&username).await {
+                app.pending.username_resolve = None;
+                app.status_message = format!("Username lookup failed: {e}");
+            }
+        }
         SendRequest::TrustIdentity {
             recipient,
             safety_number,
@@ -2238,6 +2256,20 @@ async fn run_app(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn oneshot_target_classifies_recipients() {
+        // Phone number: 1:1, passed through
+        assert_eq!(
+            oneshot_target("+15551234567"),
+            ("+15551234567".into(), false)
+        );
+        // Username forms: 1:1, normalized to signal-cli's u: prefix (#612)
+        assert_eq!(oneshot_target("@alice.42"), ("u:alice.42".into(), false));
+        assert_eq!(oneshot_target("u:alice.42"), ("u:alice.42".into(), false));
+        // Anything else: group id
+        assert_eq!(oneshot_target("grpid=="), ("grpid==".into(), true));
+    }
 
     #[test]
     fn should_auto_lock_respects_timeout_and_state() {

--- a/src/signal/client.rs
+++ b/src/signal/client.rs
@@ -358,6 +358,21 @@ impl SignalClient {
         Ok(())
     }
 
+    /// Resolve a Signal username (`name.123`, no `@`/`u:` prefix) to its
+    /// account uuid and registration status (#612). The correlated response
+    /// parses into [`SignalEvent::UserStatusList`].
+    pub async fn get_user_status(&self, username: &str) -> Result<()> {
+        self.send_rpc(
+            "getUserStatus",
+            serde_json::json!({
+                "account": self.account,
+                "username": [username],
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
     pub async fn trust_identity(&self, recipient: &str, safety_number: &str) -> Result<()> {
         let params = serde_json::json!({
             "recipient": [recipient],

--- a/src/signal/parse/mod.rs
+++ b/src/signal/parse/mod.rs
@@ -57,9 +57,9 @@ mod tests {
         match event {
             SignalEvent::ContactList(contacts) => {
                 assert_eq!(contacts.len(), 2);
-                assert_eq!(contacts[0].number, "+15551234567");
+                assert_eq!(contacts[0].number.as_deref(), Some("+15551234567"));
                 assert_eq!(contacts[0].name.as_deref(), Some("Alice"));
-                assert_eq!(contacts[1].number, "+15559876543");
+                assert_eq!(contacts[1].number.as_deref(), Some("+15559876543"));
                 assert_eq!(contacts[1].name.as_deref(), Some("Bob"));
             }
             _ => panic!("Expected ContactList"),
@@ -99,7 +99,7 @@ mod tests {
         match event {
             SignalEvent::ContactList(contacts) => {
                 assert_eq!(contacts.len(), 1);
-                assert_eq!(contacts[0].number, "+1");
+                assert_eq!(contacts[0].number.as_deref(), Some("+1"));
             }
             _ => panic!("Expected ContactList"),
         }
@@ -586,6 +586,65 @@ mod tests {
                 assert_eq!(contacts[1].uuid, None);
             }
             _ => panic!("Expected ContactList"),
+        }
+    }
+
+    #[test]
+    fn parse_list_contacts_with_username() {
+        let result = json!([
+            {"number": "+15551234567", "profileName": "Alice", "uuid": "abc-def-123", "username": "alice.42"},
+            {"number": "+15559876543", "contactName": "Bob"}
+        ]);
+        let event = parse_rpc_result("listContacts", &result, None).unwrap();
+        match event {
+            SignalEvent::ContactList(contacts) => {
+                assert_eq!(contacts[0].username.as_deref(), Some("alice.42"));
+                assert_eq!(contacts[1].username, None);
+            }
+            _ => panic!("Expected ContactList"),
+        }
+    }
+
+    #[test]
+    fn parse_list_contacts_username_only_contact_kept() {
+        // Username-only contacts (phone-number-privacy users) have no "number"
+        // field but do carry a uuid; they must not be dropped (#612).
+        let result = json!([
+            {"uuid": "u-u-i-d", "username": "carol.99", "profileName": "Carol"}
+        ]);
+        let event = parse_rpc_result("listContacts", &result, None).unwrap();
+        match event {
+            SignalEvent::ContactList(contacts) => {
+                assert_eq!(contacts.len(), 1);
+                assert_eq!(contacts[0].number, None);
+                assert_eq!(contacts[0].uuid.as_deref(), Some("u-u-i-d"));
+                assert_eq!(contacts[0].username.as_deref(), Some("carol.99"));
+                assert_eq!(contacts[0].name.as_deref(), Some("Carol"));
+            }
+            _ => panic!("Expected ContactList"),
+        }
+    }
+
+    #[test]
+    fn parse_get_user_status_username_resolution() {
+        // getUserStatus queried by username: uuid present when registered (#612).
+        let result = json!([
+            {"recipient": "carol.99", "username": "carol.99", "uuid": "u-u-i-d", "isRegistered": true},
+            {"recipient": "ghost.1", "uuid": null, "isRegistered": false}
+        ]);
+        let event = parse_rpc_result("getUserStatus", &result, None).unwrap();
+        match event {
+            SignalEvent::UserStatusList(statuses) => {
+                assert_eq!(statuses.len(), 2);
+                assert_eq!(statuses[0].recipient, "carol.99");
+                assert_eq!(statuses[0].username.as_deref(), Some("carol.99"));
+                assert_eq!(statuses[0].uuid.as_deref(), Some("u-u-i-d"));
+                assert!(statuses[0].registered);
+                assert_eq!(statuses[1].recipient, "ghost.1");
+                assert_eq!(statuses[1].uuid, None);
+                assert!(!statuses[1].registered);
+            }
+            _ => panic!("Expected UserStatusList"),
         }
     }
 

--- a/src/signal/parse/rpc.rs
+++ b/src/signal/parse/rpc.rs
@@ -28,7 +28,10 @@ pub fn parse_rpc_result(
             let contacts: Vec<Contact> = arr
                 .iter()
                 .filter_map(|obj| {
-                    let number = obj.get("number").and_then(|v| v.as_str())?;
+                    let number = obj
+                        .get("number")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
                     let name = obj
                         .get("profileName")
                         .and_then(|v| v.as_str())
@@ -40,10 +43,21 @@ pub fn parse_rpc_result(
                         .get("uuid")
                         .and_then(|v| v.as_str())
                         .map(|s| s.to_string());
+                    let username = obj
+                        .get("username")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.to_string());
+                    // Username-only contacts have no number; keep them as long
+                    // as some stable identifier exists (#612).
+                    if number.is_none() && uuid.is_none() {
+                        return None;
+                    }
                     Some(Contact {
-                        number: number.to_string(),
+                        number,
                         name,
                         uuid,
+                        username,
                     })
                 })
                 .collect();
@@ -131,6 +145,27 @@ pub fn parse_rpc_result(
                 })
                 .collect();
             Some(SignalEvent::IdentityList(identities))
+        }
+        "getUserStatus" => {
+            let arr = result.as_array()?;
+            let statuses: Vec<UserStatus> = arr
+                .iter()
+                .filter_map(|obj| {
+                    let recipient = obj.get("recipient").and_then(|v| v.as_str())?;
+                    let get_str =
+                        |k: &str| obj.get(k).and_then(|v| v.as_str()).map(|s| s.to_string());
+                    Some(UserStatus {
+                        recipient: recipient.to_string(),
+                        username: get_str("username"),
+                        uuid: get_str("uuid"),
+                        registered: obj
+                            .get("isRegistered")
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false),
+                    })
+                })
+                .collect();
+            Some(SignalEvent::UserStatusList(statuses))
         }
         "sendPollCreate" => {
             let id = rpc_id?.to_string();

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -256,6 +256,9 @@ pub enum SignalEvent {
     ContactList(Vec<Contact>),
     GroupList(Vec<Group>),
     IdentityList(Vec<IdentityInfo>),
+    /// getUserStatus response: registration status per queried recipient,
+    /// used for username → uuid resolution (#612).
+    UserStatusList(Vec<UserStatus>),
     Error(String),
     /// The signal-cli stdout reader reached EOF (the child exited). Emitted
     /// explicitly so the app can mark itself disconnected and fail any in-flight
@@ -378,6 +381,9 @@ impl SignalEvent {
             Self::ContactList(contacts) => format!("ContactList(count={})", contacts.len()),
             Self::GroupList(groups) => format!("GroupList(count={})", groups.len()),
             Self::IdentityList(ids) => format!("IdentityList(count={})", ids.len()),
+            Self::UserStatusList(statuses) => {
+                format!("UserStatusList(count={})", statuses.len())
+            }
             Self::Error(e) => format!("Error({e})"),
             Self::Disconnected => "Disconnected".to_string(),
         }
@@ -526,9 +532,32 @@ impl StyleType {
 /// Contact info from signal-cli
 #[derive(Debug, Clone)]
 pub struct Contact {
-    pub number: String,
+    /// E.164 phone number. `None` for username-only contacts
+    /// (phone-number-privacy users) — those carry a uuid instead (#612).
+    pub number: Option<String>,
     pub name: Option<String>,
     pub uuid: Option<String>,
+    /// Signal username with discriminator (e.g. `alice.42`), without `@` (#612).
+    pub username: Option<String>,
+}
+
+impl Contact {
+    /// Stable conversation/map key for this contact: phone number when
+    /// present, else the ACI uuid. `None` only for malformed entries.
+    pub fn key(&self) -> Option<&str> {
+        self.number.as_deref().or(self.uuid.as_deref())
+    }
+}
+
+/// One entry of a getUserStatus response (#612). `recipient` echoes the
+/// queried identifier (for usernames, without the `u:` prefix); `uuid` is
+/// present only when the account is registered.
+#[derive(Debug, Clone)]
+pub struct UserStatus {
+    pub recipient: String,
+    pub username: Option<String>,
+    pub uuid: Option<String>,
+    pub registered: bool,
 }
 
 /// Group info from signal-cli

--- a/src/ui/chat_pane.rs
+++ b/src/ui/chat_pane.rs
@@ -177,7 +177,7 @@ fn draw_messages(frame: &mut Frame, app: &mut App, area: Rect) {
             let conv = &app.store.conversations[id];
             let prefix = if conv.is_group { " #" } else { " " };
             let mut spans = vec![Span::styled(
-                format!("{prefix}{} ", conv.name),
+                format!("{prefix}{} ", app.store.display_title(id)),
                 Style::default()
                     .fg(theme.accent)
                     .add_modifier(Modifier::BOLD),

--- a/src/ui/overlays/contacts.rs
+++ b/src/ui/overlays/contacts.rs
@@ -58,7 +58,7 @@ pub(in crate::ui) fn draw_contacts(frame: &mut Frame, app: &App, area: Rect) {
         {
             let actual_index = scroll_offset + i;
             let is_selected = actual_index == app.contacts_overlay.index;
-            let has_conversation = app.store.conversation_order.contains(number);
+            let has_conversation = app.contact_row_has_conversation(number);
 
             // Checkmark for contacts that already have a conversation
             let marker = if has_conversation { " \u{2713}" } else { "  " };

--- a/src/ui/overlays/help.rs
+++ b/src/ui/overlays/help.rs
@@ -23,7 +23,7 @@ pub(in crate::ui) fn draw_help(frame: &mut Frame, app: &App, area: Rect) {
 
     // Help table entries: (key, description)
     let commands: &[(&str, &str)] = &[
-        ("/join <name>", "Switch to a conversation"),
+        ("/join <name>", "Switch to a conversation (@handle works)"),
         ("/part", "Leave current conversation"),
         ("/delete", "Delete current conversation"),
         ("/attach", "Attach a file"),

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__help_overlay.snap
@@ -1,11 +1,12 @@
 ---
 source: src/ui/mod.rs
+assertion_line: 640
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
   ? +15550007777 (1) ││╭ Help ──────────────────────────────────────────────╮                      │
   • ##Family (2)     │││  Commands                                          │                      │
-  • Carol (1)        │││  /join <name>        Switch to a conversation      │                      │
+  • Carol (1)        │││  /join <name>        Switch to a conversation (@han│                      │
     ##Rust Devs      │││  /part               Leave current conversation    │                      │
     Bob              │││  /delete             Delete current conversation   │ run                  │
 ▸   Alice            │││  /attach             Attach a file                 │d before 7            │

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__settings_overlay.snap
@@ -1,6 +1,6 @@
 ---
-source: src/ui.rs
-assertion_line: 4364
+source: src/ui/mod.rs
+assertion_line: 698
 expression: output
 ---
  Chats               │╭ Alice ─────────────────────────────────────────────────────────────────────╮
@@ -18,17 +18,17 @@ expression: output
                      ││✓ │    [x] Receipt colors                          │                        │
                      ││[0│    [ ] Nerd Font icons                         │                        │
                      ││[0│    [ ] Emoji to text                           │/localmarket.example.com│
-                     ││  │    Image mode: halfblock                       │                        │
-                     ││  │  Messages                                      │ry Saturday…            │
-                     ││  │    [x] Show reactions                          │                        │
-                     ││○ │    [ ] Verbose reactions                       │                        │
-                     ││✓ │    [x] Send read receipts                      │owded.                  │
+                     ││  │    [x] Show usernames                          │                        │
+                     ││  │    Image mode: halfblock                       │ry Saturday…            │
+                     ││  │  Messages                                      │                        │
+                     ││○ │    [x] Show reactions                          │                        │
+                     ││✓ │    [ ] Verbose reactions                       │owded.                  │
+                     ││○ │    [x] Send read receipts                      │                        │
                      ││○ │  Interface                                     │                        │
-                     ││○ │    [x] Sidebar visible                         │                        │
-                     ││○ │    [x] Mouse support                           │nt to browse early      │
-                     ││[0│    [ ] Sidebar on right                        │                        │
-                     ││  │    Customize...                                │                        │
-                     │╰──│  Play a sound for incoming direct messages     │────────────────────────╯
+                     ││○ │    [x] Sidebar visible                         │nt to browse early      │
+                     ││[0│    [x] Mouse support                           │                        │
+                     ││  │    [ ] Sidebar on right                        │                        │
+                     │╰──│    Customize...                                │────────────────────────╯
                      │╭──╰────────────────────────────────────────────────╯────────────────────────╮
                      ││  Type a message...                                                         │
                      │╰────────────────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
## Summary

Implements #612: siggy can now resolve, address, and display Signal username (@handle) contacts — the identity model Signal is moving toward with phone-number privacy.

### What changed

**Parsing / types**
- `Contact.number` is now `Option<String>`; username-only contacts (no shared number) were previously **dropped** by the listContacts parser and are now kept, keyed by their ACI uuid via `Contact::key()`
- New `username` field parsed from listContacts; new `getUserStatus` response parsing into `SignalEvent::UserStatusList`

**Conversation keying**
- Username-only contacts key conversations by uuid — consistent with the existing `sourceUuid` envelope fallback, so incoming messages and the send path route with no changes to `set_target`

**/join @handle**
- Known handles resolve locally via new `usernames` / `username_to_id` store maps
- Unknown full handles (`name.123`) trigger a `getUserStatus` round-trip (new `SendRequest::ResolveUsername`, correlated via `pending.username_resolve`); registered accounts open a conversation keyed by the resolved uuid, unregistered ones report a status error
- Bare nicknames without a discriminator get a helpful error

**UI**
- Contacts overlay shows `@handle` for uuid-keyed contacts instead of a raw uuid; selecting one creates the conversation
- Chat header shows `Name (@handle)`, behind a new **Show usernames** toggle (Display section, persisted as `show_usernames`, default on) — per the toggle request in #612's comments
- Username-only contacts with no profile name display as `@handle`

**CLI**
- `siggy --send @name.123 -m hi` (also `u:name.123`) now classifies as a 1:1 recipient

### Testing

- TDD throughout: 17 new tests (parse layer, store maps, join flows, resolution round-trip, display title, config default, oneshot classification)
- `cargo clippy --tests -- -D warnings` clean, all 1049 tests green, App field-count ratchet untouched (66/66 — new state lives on `ConversationStore` / `PendingState`)
- Two snapshot updates (settings overlay gains the toggle; help overlay text)
- Not verified against live servers: my linked-device registration has lapsed, and username-only contacts require a counterpart using phone-number privacy. The signal-cli 0.14.0 contract (listContacts `username` field, `u:` recipients, `getUserStatus --username`) was verified against upstream source

closes #612

🤖 Generated with [Claude Code](https://claude.com/claude-code)