### PR TITLE
chore(release): bump version to 1.13.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.12.0"
+version = "1.13.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.12.0"
+version = "1.13.0"
 edition = "2024"
 license = "GPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## v1.13.0
+
+The automation and identity release: scriptable message triggers with a
+headless watch mode, and Signal username (@handle) support.
+
+### New features
+
+- **Message triggers** -- declarative rules in `triggers.toml` (next to
+  `config.toml`) fire on incoming messages: auto-`reply` with a canned
+  text, or `run` an external command that receives the message as JSON on
+  stdin. Matching is dependency-free (case-insensitive `substring`,
+  `exact`, or `prefix`), rules can be scoped by sender and conversation,
+  and `/triggers` reloads the file live. Safety rails: `run` commands are
+  argv arrays spawned without a shell and require a top-level
+  `allow_run = true` opt-in, message content only ever reaches the child
+  as JSON (injection-proof), history replayed during initial sync never
+  fires, your own messages never fire, and a per-rule per-conversation
+  rate limit (default 30s) guards against auto-responder loops
+  (closes #615).
+- **Headless watch mode** -- `siggy --watch` runs the same trigger rules
+  as a standalone bot with no TUI, logging one line per firing. Note
+  signal-cli allows one process per account, so `--watch` and the TUI are
+  mutually exclusive.
+- **Signal usernames** -- @handle contacts are now first-class: username-
+  only contacts (no shared phone number) appear in the contacts overlay as
+  `@handle` instead of being dropped, `/join @name.123` resolves unknown
+  handles through the server, the chat header shows `Name (@handle)`
+  behind a new **Show usernames** setting, and `siggy --send @name.123`
+  works from the CLI (closes #612).
+
+### Internal
+
+- New `trigger` module (engine, TOML rules, evaluation rails) shared by
+  the TUI and `--watch` hosts.
+- `Contact.number` is now optional; conversations for username-only
+  contacts key by ACI uuid, consistent with the existing envelope
+  fallback.
+- +37 tests since v1.12.0 (1,057 total).
+
+---
+
 ## v1.12.0
 
 The power-user release: a fuzzy command palette, sender-generated link

--- a/docs/src/dev-guide/roadmap.md
+++ b/docs/src/dev-guide/roadmap.md
@@ -95,12 +95,13 @@
 - [x] Outgoing link previews (`/preview <url>`, explicit fetch only)
 - [x] Inline sticker rendering (cached packs via the image pipeline)
 - [x] Sixel image tuning (sizing config, palette/dithering options, guard row) -- thanks @justinledwards
+- [x] Scriptable message triggers (`triggers.toml`, `/triggers`, headless `--watch` mode)
+- [x] Signal username support (@handle contacts, `/join @name.123`, `--send @name.123`)
 
 ## Future
 
 Tracked in GitHub issues:
 
-- [Signal username support (#612)](https://github.com/johnsideserf/siggy/issues/612)
-- [Scriptable message triggers / auto-responder (#615)](https://github.com/johnsideserf/siggy/issues/615)
+- [Native backend (presage) epic (#637)](https://github.com/johnsideserf/siggy/issues/637) -- an opt-in, in-process Signal engine to drop the signal-cli / JVM dependency, phased behind Cargo features (RFC in [#635](https://github.com/johnsideserf/siggy/issues/635))
 
 Have an idea? [Open an issue](https://github.com/johnsideserf/siggy/issues).

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.12.0                                 │t too                   │
+                     ││[0│  siggy v1.13.0                                 │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

Release housekeeping for v1.13.0, which ships two features merged since v1.12.0:

- **Message triggers** (#615, PR #634) - triggers.toml rules, /triggers reload, headless --watch mode
- **Signal usernames** (#612, PR #636) - @handle contacts, /join @name.123, --send @name.123, Show usernames setting

### Changes

- Cargo.toml version 1.12.0 -> 1.13.0 (+ Cargo.lock)
- About overlay snapshot regenerated
- Docsite changelog entry for v1.13.0
- Docsite roadmap refresh: shipped items checked off; Future section now points at the native backend epic (#637)

No DB migrations since v1.12.0, so the schema table is untouched.

### Checks

- cargo clippy --tests -D warnings: clean
- cargo test: 1,057 passed
- App field ratchet: 66/66

After merge I will tag v1.13.0 to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)