### PR TITLE
feat: U6 incoming-message idempotency (dedup index + replay side-effect gate)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -100,14 +100,27 @@ impl App {
     /// scroll/focus reset) remain at the call sites; see issue #209 for further
     /// unification.
     ///
+    /// The DB insert runs FIRST and is idempotent for incoming rows (#640 U6):
+    /// a replayed envelope (at-least-once delivery, reconnect replay) is
+    /// detected by the dedup index and the entire side-effect chain -- the
+    /// in-memory append, unarchive, read-marker bump, expiring count, and
+    /// sidebar reorder -- is skipped. Outgoing sync-transcript replays are
+    /// caught by an app-level exists-check (they live outside the index
+    /// because #480 rewrites their timestamp).
+    ///
+    /// `entry_seq` numbers the rows of one multi-row message (body plus one
+    /// row per attachment share a timestamp) and is part of the dedup key;
+    /// single-row paths pass 0.
+    ///
     /// Returns the index where the message was placed, or `None` if the
-    /// conversation no longer exists.
+    /// conversation no longer exists or the message was a replayed duplicate.
     pub(crate) fn on_message_added(
         &mut self,
         conv_id: &str,
         msg: DisplayMessage,
         wire_quote: WireQuote,
         ordered_insert: bool,
+        entry_seq: i64,
     ) -> Option<usize> {
         // Snapshot the fields we need for DB persistence before the message moves.
         let ts_rfc3339 = msg.timestamp.to_rfc3339();
@@ -119,6 +132,61 @@ impl App {
         let timestamp_ms = msg.timestamp_ms;
         let expires_in_seconds = msg.expires_in_seconds;
         let expiration_start_ms = msg.expiration_start_ms;
+
+        if !self.store.conversations.contains_key(conv_id) {
+            return None;
+        }
+
+        // Outgoing sync-transcript replay check (#640 U6). Only sync echoes
+        // carry a pre-confirmed status AND the 'you' sender; locally composed
+        // echoes have a fresh unique local timestamp and never match.
+        if !is_system
+            && sender == "you"
+            && self
+                .db
+                .outgoing_message_exists(conv_id, timestamp_ms, &body)
+        {
+            return None;
+        }
+
+        // DB persist first: its conflict result is the "was it new?" gate.
+        let db_result = if is_system {
+            self.db
+                .insert_message(
+                    conv_id,
+                    &sender,
+                    &ts_rfc3339,
+                    &body,
+                    true,
+                    status,
+                    timestamp_ms,
+                )
+                .map(Some)
+        } else {
+            self.db.insert_message_full(
+                conv_id,
+                &sender,
+                &ts_rfc3339,
+                &body,
+                false,
+                status,
+                timestamp_ms,
+                &sender_id,
+                wire_quote.author.as_deref(),
+                wire_quote.body.as_deref(),
+                wire_quote.timestamp,
+                expires_in_seconds,
+                expiration_start_ms,
+                entry_seq,
+            )
+        };
+        let was_duplicate = matches!(db_result, Ok(None));
+        self.db_warn_visible(db_result, "on_message_added");
+        if was_duplicate {
+            // Replayed incoming entry: row already persisted, all side
+            // effects already fired the first time. Do nothing.
+            return None;
+        }
 
         // Insert into the in-memory store.
         let (insert_idx, unarchived) = {
@@ -150,36 +218,6 @@ impl App {
         if expires_in_seconds > 0 {
             self.expiring_msg_count += 1;
         }
-
-        // DB persist.
-        let db_result = if is_system {
-            self.db.insert_message(
-                conv_id,
-                &sender,
-                &ts_rfc3339,
-                &body,
-                true,
-                status,
-                timestamp_ms,
-            )
-        } else {
-            self.db.insert_message_full(
-                conv_id,
-                &sender,
-                &ts_rfc3339,
-                &body,
-                false,
-                status,
-                timestamp_ms,
-                &sender_id,
-                wire_quote.author.as_deref(),
-                wire_quote.body.as_deref(),
-                wire_quote.timestamp,
-                expires_in_seconds,
-                expiration_start_ms,
-            )
-        };
-        self.db_warn_visible(db_result, "on_message_added");
 
         // Sidebar reorder (skip for system messages, which shouldn't bump
         // conversations to the top just because someone changed the group name).

--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -190,11 +190,8 @@ fn no_duplicate_on_repeated_messages(mut app: App) {
 
     for _ in 0..3 {
         let msg = SignalMessage {
-            source: "+1".to_string(),
             source_name: Some("Alice".to_string()),
-            timestamp: chrono::Utc::now(),
-            body: Some("msg".to_string()),
-            ..Default::default()
+            ..make_msg("+1", Some("msg"), None, false)
         };
         app.handle_signal_event(SignalEvent::MessageReceived(msg));
     }
@@ -3274,11 +3271,8 @@ fn unread_bar_clears_on_active_incoming_message(mut app: App) {
 
     // Deliver a message while conversation is NOT active → creates unread
     let msg1 = SignalMessage {
-        source: "+15551234567".to_string(),
         source_name: Some("Alice".to_string()),
-        timestamp: chrono::Utc::now(),
-        body: Some("first".to_string()),
-        ..Default::default()
+        ..make_msg("+15551234567", Some("first"), None, false)
     };
     app.handle_signal_event(SignalEvent::MessageReceived(msg1));
 
@@ -3297,11 +3291,8 @@ fn unread_bar_clears_on_active_incoming_message(mut app: App) {
 
     // Deliver another message while conversation IS active
     let msg2 = SignalMessage {
-        source: "+15551234567".to_string(),
         source_name: Some("Alice".to_string()),
-        timestamp: chrono::Utc::now(),
-        body: Some("second".to_string()),
-        ..Default::default()
+        ..make_msg("+15551234567", Some("second"), None, false)
     };
     app.handle_signal_event(SignalEvent::MessageReceived(msg2));
 
@@ -4797,11 +4788,25 @@ fn make_msg(
     group_id: Option<&str>,
     is_outgoing: bool,
 ) -> SignalMessage {
+    // Distinct, strictly increasing timestamps: Signal message identity is
+    // (sender, timestamp), so two messages from one sender never share a
+    // millisecond on the real wire. Tests that loop make_msg() faster than
+    // the clock ticks would otherwise collide with the U6 dedup index.
+    static NEXT_TS: std::sync::atomic::AtomicI64 = std::sync::atomic::AtomicI64::new(0);
+    let now = chrono::Utc::now().timestamp_millis();
+    let ts_ms = NEXT_TS
+        .fetch_update(
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+            |prev| Some(prev.max(now - 1) + 1),
+        )
+        .map(|prev| prev.max(now - 1) + 1)
+        .unwrap_or(now);
     SignalMessage {
         source: source.to_string(),
         source_name: None,
         source_uuid: None,
-        timestamp: chrono::Utc::now(),
+        timestamp: chrono::DateTime::from_timestamp_millis(ts_ms).expect("valid ts"),
         body: body.map(|s| s.to_string()),
         attachments: vec![],
         group_id: group_id.map(|s| s.to_string()),
@@ -6551,6 +6556,7 @@ fn send_confirm_timestamp_rewrite_survives_reload() {
         outgoing_sending_msg(local_ts, "hello"),
         WireQuote::default(),
         false,
+        0,
     );
     app.pending
         .sends
@@ -6586,6 +6592,7 @@ fn send_failed_status_survives_reload() {
         outgoing_sending_msg(local_ts, "doomed"),
         WireQuote::default(),
         false,
+        0,
     );
     app.pending
         .sends
@@ -6616,7 +6623,7 @@ fn receipt_upgrades_persist_across_reload() {
     let ts = 1_700_000_000_000_i64;
     let mut msg = outgoing_sending_msg(ts, "hello");
     msg.status = Some(MessageStatus::Sent);
-    app.on_message_added(conv_id, msg, WireQuote::default(), false);
+    app.on_message_added(conv_id, msg, WireQuote::default(), false, 0);
 
     app.handle_signal_event(SignalEvent::ReceiptReceived {
         sender: conv_id.to_string(),
@@ -6646,7 +6653,7 @@ fn out_of_order_receipt_does_not_downgrade_after_reload() {
     let ts = 1_700_000_000_000_i64;
     let mut msg = outgoing_sending_msg(ts, "hello");
     msg.status = Some(MessageStatus::Sent);
-    app.on_message_added(conv_id, msg, WireQuote::default(), false);
+    app.on_message_added(conv_id, msg, WireQuote::default(), false, 0);
 
     // Read arrives before Delivery (receipts are not ordered on the wire).
     app.handle_signal_event(SignalEvent::ReceiptReceived {
@@ -6701,4 +6708,125 @@ fn read_marker_and_unread_count_survive_reload() {
     fresh.load_from_db().unwrap();
     assert_eq!(fresh.store.conversations[conv_id].unread, 1);
     assert_eq!(fresh.store.conversations[conv_id].messages.len(), 2);
+}
+
+// --- U6 (#640): incoming replay idempotency ---
+//
+// At-least-once delivery (reconnect replays, the native backend's ack
+// window) must be safe: a replayed envelope may not duplicate rows or
+// re-fire side effects. These lock the behavior end to end through
+// handle_signal_event.
+
+#[rstest]
+fn replayed_incoming_message_is_fully_suppressed(mut app: App) {
+    app.sync.active = false;
+    let msg = make_msg_with_ts("+1", Some("hi"), None, false, 5_000);
+    app.handle_signal_event(SignalEvent::MessageReceived(msg.clone()));
+    assert_eq!(app.store.conversations["+1"].messages.len(), 1);
+    assert_eq!(app.store.conversations["+1"].unread, 1);
+
+    // Archive the conversation and put another on top of the sidebar so the
+    // replay's suppressed side effects are observable.
+    app.store.conversations.get_mut("+1").unwrap().archived = true;
+    let other = make_msg_with_ts("+2", Some("yo"), None, false, 6_000);
+    app.handle_signal_event(SignalEvent::MessageReceived(other));
+    assert_eq!(app.store.conversation_order[0], "+2");
+
+    // Replay the first envelope verbatim.
+    app.handle_signal_event(SignalEvent::MessageReceived(msg));
+
+    let conv = &app.store.conversations["+1"];
+    assert_eq!(conv.messages.len(), 1, "no duplicate in-memory row");
+    assert_eq!(conv.unread, 1, "no unread inflation on replay");
+    assert!(
+        conv.archived,
+        "replay must not unarchive (#611 side effect)"
+    );
+    assert_eq!(
+        app.store.conversation_order[0], "+2",
+        "replay must not bump the conversation in the sidebar"
+    );
+    assert_eq!(
+        app.db.load_messages_page("+1", 50, 0).unwrap().len(),
+        1,
+        "exactly one persisted row"
+    );
+}
+
+#[rstest]
+fn same_timestamp_distinct_senders_in_group_both_survive(mut app: App) {
+    // Sender-chosen client clocks collide across senders routinely in a
+    // group; the dedup key includes sender_id precisely so this is NOT a
+    // duplicate (a wrong dedup is unrecoverable).
+    let m1 = make_msg_with_ts("+1", Some("from alice"), Some("grp"), false, 7_000);
+    let m2 = make_msg_with_ts("+2", Some("from bob"), Some("grp"), false, 7_000);
+    app.handle_signal_event(SignalEvent::MessageReceived(m1));
+    app.handle_signal_event(SignalEvent::MessageReceived(m2));
+    assert_eq!(app.store.conversations["grp"].messages.len(), 2);
+    assert_eq!(app.db.load_messages_page("grp", 50, 0).unwrap().len(), 2);
+}
+
+#[rstest]
+fn attachment_message_rows_survive_and_replay_dedups(mut app: App) {
+    // One incoming message = several rows (body + one per attachment), all
+    // sharing (conv, sender_id, timestamp). entry_seq keeps them distinct
+    // under the dedup index; a replayed envelope re-derives the same seqs
+    // and every row conflict-skips.
+    let mut msg = make_msg_with_ts("+1", Some("look at this"), None, false, 8_000);
+    msg.attachments.push(Attachment {
+        id: "att-1".to_string(),
+        content_type: "application/pdf".to_string(),
+        filename: Some("doc.pdf".to_string()),
+        local_path: None,
+    });
+    app.handle_signal_event(SignalEvent::MessageReceived(msg.clone()));
+    assert_eq!(
+        app.store.conversations["+1"].messages.len(),
+        2,
+        "body row + attachment row"
+    );
+    assert_eq!(app.db.load_messages_page("+1", 50, 0).unwrap().len(), 2);
+
+    app.handle_signal_event(SignalEvent::MessageReceived(msg));
+    assert_eq!(app.store.conversations["+1"].messages.len(), 2);
+    assert_eq!(app.db.load_messages_page("+1", 50, 0).unwrap().len(), 2);
+}
+
+#[rstest]
+fn own_sync_echo_replay_inserts_once(mut app: App) {
+    // The sync transcript of your own send (from another device) is an
+    // outgoing-shaped row OUTSIDE the dedup index (#480 rewrites outgoing
+    // timestamps); the app-level exists-check catches its replay instead.
+    let mut echo = make_msg_with_ts("+10000000000", Some("sent elsewhere"), None, true, 9_000);
+    echo.destination = Some("+2".to_string());
+    app.handle_signal_event(SignalEvent::MessageReceived(echo.clone()));
+    assert_eq!(app.store.conversations["+2"].messages.len(), 1);
+
+    app.handle_signal_event(SignalEvent::MessageReceived(echo));
+    assert_eq!(
+        app.store.conversations["+2"].messages.len(),
+        1,
+        "replayed sync echo must not duplicate"
+    );
+    assert_eq!(app.db.load_messages_page("+2", 50, 0).unwrap().len(), 1);
+}
+
+#[rstest]
+fn replayed_message_does_not_refire_triggers(mut app: App) {
+    // The trigger engine's own rails (cooldown) are per-rule; the U6 newness
+    // gate must stop a replayed envelope from even reaching evaluation.
+    app.triggers = crate::trigger::TriggerEngine::from_toml_str(
+        "[[trigger]]\nmatch = \"ping\"\nreply = \"pong\"\nrate_limit_secs = 0\n",
+        0,
+    );
+    let msg = make_msg_with_ts("+1", Some("ping"), None, false, 10_000);
+    app.handle_signal_event(SignalEvent::MessageReceived(msg.clone()));
+    assert_eq!(app.pending.trigger_sends.len(), 1);
+
+    app.handle_signal_event(SignalEvent::MessageReceived(msg));
+    assert_eq!(
+        app.pending.trigger_sends.len(),
+        1,
+        "replay must not queue a second auto-reply"
+    );
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -221,6 +221,49 @@ const MIGRATIONS: &[Migration] = &[
             COMMIT;
         ",
     },
+    // Incoming-message idempotency (#640 U6, KTD-2): at-least-once delivery
+    // from the backend must be safe, so replayed envelopes may not duplicate
+    // rows or re-fire side effects.
+    //
+    // Key design: one incoming message persists as SEVERAL rows sharing
+    // (conversation_id, sender_id, timestamp_ms) -- the body row plus one row
+    // per attachment -- so that triple alone cannot be unique. `entry_seq`
+    // numbers the rows of one message in insertion order (0 = body/first
+    // entry), which is deterministic across a replayed parse, so the 4-column
+    // key dedups exact replays while multi-entry messages survive.
+    //
+    // The backfill numbers existing rows per key by rowid, which makes the
+    // index build on any populated table without deleting anything: rows that
+    // LOOK like duplicates under the 3-column key are indistinguishable from
+    // legitimate multi-entry messages, and a wrong dedup is unrecoverable
+    // while a missed one is cosmetic. Historical duplicates therefore stay;
+    // only post-migration replays are suppressed.
+    //
+    // Outgoing rows (sender = 'you') are deliberately outside the partial
+    // index: the #480 send-confirm dance rewrites their timestamp_ms, which
+    // a covering unique index would corrupt or reject. They get an app-level
+    // exists-check in on_message_added instead.
+    Migration {
+        version: 16,
+        sql: "
+            BEGIN;
+            ALTER TABLE messages ADD COLUMN entry_seq INTEGER NOT NULL DEFAULT 0;
+            UPDATE messages SET entry_seq = sub.rn - 1
+              FROM (SELECT rowid AS r,
+                           ROW_NUMBER() OVER (
+                               PARTITION BY conversation_id, sender_id, timestamp_ms
+                               ORDER BY rowid
+                           ) AS rn
+                      FROM messages
+                     WHERE sender <> 'you' AND sender_id <> '') AS sub
+             WHERE messages.rowid = sub.r;
+            CREATE UNIQUE INDEX idx_messages_incoming_dedup
+                ON messages(conversation_id, sender_id, timestamp_ms, entry_seq)
+                WHERE sender <> 'you' AND sender_id <> '';
+            UPDATE schema_version SET version = 16;
+            COMMIT;
+        ",
+    },
 ];
 
 pub struct Database {
@@ -238,6 +281,12 @@ impl Database {
         conn.execute_batch("PRAGMA synchronous=NORMAL;")?;
         conn.execute_batch("PRAGMA foreign_keys=ON;")?;
         conn.execute_batch("PRAGMA secure_delete=ON;")?;
+        // Wait for a competing writer instead of failing with SQLITE_BUSY.
+        // WAL allows exactly one writer at a time; the native backend's
+        // adapter connection (#640 U6/U11) inserts from another thread while
+        // the main loop may hold a drain batch, so both sides must queue
+        // rather than error. Drain batches are short; 5s is generous.
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
         let db = Self { conn };
         db.migrate()?;
         Ok(db)
@@ -570,23 +619,36 @@ impl Database {
         status: Option<MessageStatus>,
         timestamp_ms: i64,
     ) -> Result<i64> {
-        self.insert_message_full(
-            conv_id,
-            sender,
-            timestamp,
-            body,
-            is_system,
-            status,
-            timestamp_ms,
-            "",
-            None,
-            None,
-            None,
-            0,
-            0,
-        )
+        // sender_id is '' here, which keeps the row outside the dedup index,
+        // so the insert can never be conflict-skipped (unwrap_or unreachable).
+        Ok(self
+            .insert_message_full(
+                conv_id,
+                sender,
+                timestamp,
+                body,
+                is_system,
+                status,
+                timestamp_ms,
+                "",
+                None,
+                None,
+                None,
+                0,
+                0,
+                0,
+            )?
+            .unwrap_or(-1))
     }
 
+    /// Insert one message row. Returns `Ok(Some(rowid))` for a new row and
+    /// `Ok(None)` when the row was a replay of an already-persisted incoming
+    /// entry (#640 U6): the insert is conflict-targeted at the partial unique
+    /// index on (conversation_id, sender_id, timestamp_ms, entry_seq), so
+    /// only genuine key collisions are skipped -- any other constraint
+    /// violation still surfaces as an error rather than being swallowed.
+    /// Callers must skip the full side-effect chain (in-memory append,
+    /// notification, unarchive, sidebar reorder) on `None`.
     #[allow(clippy::too_many_arguments)]
     pub fn insert_message_full(
         &self,
@@ -603,14 +665,44 @@ impl Database {
         quote_ts_ms: Option<i64>,
         expires_in_seconds: i64,
         expiration_start_ms: i64,
-    ) -> Result<i64> {
+        entry_seq: i64,
+    ) -> Result<Option<i64>> {
         let status_i32 = status.map(|s| s.to_i32()).unwrap_or(0);
-        self.conn.execute(
-            "INSERT INTO messages (conversation_id, sender, timestamp, body, is_system, status, timestamp_ms, sender_id, quote_author, quote_body, quote_ts_ms, expires_in_seconds, expiration_start_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
-            params![conv_id, sender, timestamp, body, is_system as i32, status_i32, timestamp_ms, sender_id, quote_author, quote_body, quote_ts_ms, expires_in_seconds, expiration_start_ms],
+        let changed = self.conn.execute(
+            "INSERT INTO messages (conversation_id, sender, timestamp, body, is_system, status, timestamp_ms, sender_id, quote_author, quote_body, quote_ts_ms, expires_in_seconds, expiration_start_ms, entry_seq)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14)
+             ON CONFLICT (conversation_id, sender_id, timestamp_ms, entry_seq)
+                 WHERE sender <> 'you' AND sender_id <> ''
+                 DO NOTHING",
+            params![conv_id, sender, timestamp, body, is_system as i32, status_i32, timestamp_ms, sender_id, quote_author, quote_body, quote_ts_ms, expires_in_seconds, expiration_start_ms, entry_seq],
         )?;
-        Ok(self.conn.last_insert_rowid())
+        if changed == 0 {
+            return Ok(None);
+        }
+        Ok(Some(self.conn.last_insert_rowid()))
+    }
+
+    /// App-level duplicate check for outgoing rows, which live outside the
+    /// dedup index because the #480 send-confirm dance rewrites their
+    /// timestamp_ms (#640 U6). Matches the sync-transcript replay shape: an
+    /// outgoing row in this conversation with this (server) timestamp and
+    /// this body already exists. Body is included so multi-entry outgoing
+    /// messages (text + attachments, same timestamp) are not misjudged.
+    pub fn outgoing_message_exists(&self, conv_id: &str, timestamp_ms: i64, body: &str) -> bool {
+        use rusqlite::OptionalExtension;
+        self.conn
+            .query_row(
+                "SELECT 1 FROM messages
+                  WHERE conversation_id = ?1 AND timestamp_ms = ?2
+                    AND sender = 'you' AND body = ?3
+                  LIMIT 1",
+                params![conv_id, timestamp_ms, body],
+                |_| Ok(()),
+            )
+            .optional()
+            .ok()
+            .flatten()
+            .is_some()
     }
 
     /// Update delivery status for an outgoing message by its ms epoch timestamp.
@@ -2077,5 +2169,174 @@ mod tests {
         // Most recent first
         assert_eq!(results[0].3, "+2"); // Bob's conversation
         assert_eq!(results[1].3, "+1"); // Alice's conversation
+    }
+
+    // --- U6 (#640): incoming-message dedup index ---
+
+    // Upgrade-day path for the v16 migration: a populated messages table with
+    // a legitimate multi-entry message (body + attachment rows share conv,
+    // sender_id, and timestamp) AND a pre-existing true duplicate. The
+    // migration must build the index without deleting anything: entry_seq
+    // backfills by rowid, making every existing row unique under the new key.
+    #[test]
+    fn upgrade_from_v15_backfills_entry_seq_and_builds_dedup_index() {
+        let db = db_at_version(15);
+        db.conn
+            .execute(
+                "INSERT INTO conversations (id, name, is_group) VALUES ('+1', 'Alice', 0)",
+                [],
+            )
+            .unwrap();
+        for body in ["hello", "[attachment: photo.jpg]", "hello"] {
+            // Third row simulates a historical replay of the body row.
+            db.conn
+                .execute(
+                    "INSERT INTO messages (conversation_id, sender, timestamp, body, sender_id, timestamp_ms)
+                     VALUES ('+1', 'Alice', '2026-01-01T00:00:00Z', ?1, '+1', 1000)",
+                    params![body],
+                )
+                .unwrap();
+        }
+
+        db.migrate().unwrap();
+
+        // All three rows survive (a wrong dedup is unrecoverable; historical
+        // duplicates are only cosmetic), numbered by insertion order.
+        let seqs: Vec<i64> = db
+            .conn
+            .prepare("SELECT entry_seq FROM messages ORDER BY rowid")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .collect::<std::result::Result<_, _>>()
+            .unwrap();
+        assert_eq!(seqs, vec![0, 1, 2]);
+
+        // The index now enforces idempotency: a post-migration replay of the
+        // first entry is conflict-skipped, not inserted and not an error.
+        let replay = db
+            .insert_message_full(
+                "+1",
+                "Alice",
+                "2026-01-01T00:00:00Z",
+                "hello",
+                false,
+                None,
+                1000,
+                "+1",
+                None,
+                None,
+                None,
+                0,
+                0,
+                0,
+            )
+            .unwrap();
+        assert!(replay.is_none(), "replayed entry must be conflict-skipped");
+        // A genuinely new entry_seq still inserts.
+        let new_entry = db
+            .insert_message_full(
+                "+1",
+                "Alice",
+                "2026-01-01T00:00:00Z",
+                "[attachment: second.jpg]",
+                false,
+                None,
+                1000,
+                "+1",
+                None,
+                None,
+                None,
+                0,
+                0,
+                3,
+            )
+            .unwrap();
+        assert!(new_entry.is_some());
+    }
+
+    // Outgoing rows stay OUTSIDE the dedup index so the #480 send-confirm
+    // timestamp rewrite can land on a timestamp an incoming row already
+    // occupies (sender-chosen clocks collide across senders routinely).
+    #[rstest]
+    fn outgoing_rewrite_onto_incoming_timestamp_succeeds(db: Database) {
+        db.upsert_conversation("+1", "Alice", false).unwrap();
+        db.insert_message_full(
+            "+1", "Alice", "t", "incoming", false, None, 5000, "+1", None, None, None, 0, 0, 0,
+        )
+        .unwrap();
+        // Outgoing row at a local timestamp, then rewritten to 5000.
+        db.insert_message(
+            "+1",
+            "you",
+            "t",
+            "mine",
+            false,
+            Some(MessageStatus::Sending),
+            4900,
+        )
+        .unwrap();
+        db.update_message_timestamp_ms("+1", 4900, 5000, MessageStatus::Sent.to_i32())
+            .unwrap();
+        let count: i64 = db
+            .conn
+            .query_row(
+                "SELECT COUNT(*) FROM messages WHERE timestamp_ms = 5000",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2, "incoming and rewritten outgoing rows coexist");
+    }
+
+    // Connection topology settled by U6: a second connection (the future
+    // native adapter's durable-insert path, #640 U11) inserting while the
+    // main connection holds an open drain batch must queue on busy_timeout
+    // and succeed once the batch commits -- never error with SQLITE_BUSY.
+    #[test]
+    fn adapter_connection_insert_queues_behind_main_batch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dedup-test.db");
+        let main_db = Database::open(&path).unwrap();
+        main_db.upsert_conversation("+1", "Alice", false).unwrap();
+        let adapter_db = Database::open(&path).unwrap();
+
+        main_db.begin_batch();
+        main_db
+            .insert_message("+1", "Alice", "t", "from main", false, None, 1000)
+            .unwrap();
+
+        let handle = std::thread::spawn(move || {
+            adapter_db.insert_message_full(
+                "+1",
+                "Bob",
+                "t",
+                "from adapter",
+                false,
+                None,
+                2000,
+                "+2",
+                None,
+                None,
+                None,
+                0,
+                0,
+                0,
+            )
+        });
+        // Let the adapter thread hit the write lock, then release it.
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        main_db.commit_batch();
+
+        let inserted = handle.join().unwrap().unwrap();
+        assert!(
+            inserted.is_some(),
+            "adapter insert must succeed after the batch commits"
+        );
+        let count: i64 = main_db
+            .conn
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 2);
     }
 }

--- a/src/handlers/input.rs
+++ b/src/handlers/input.rs
@@ -327,6 +327,7 @@ fn send_text(app: &mut App, raw_text: String) -> Option<SendRequest> {
             timestamp: quote_timestamp,
         },
         false,
+        0,
     );
     app.scroll.offset = 0;
     app.scroll.focused_index = None;
@@ -873,7 +874,7 @@ fn create_poll(
         preview_image_lines: None,
         preview_image_path: None,
     };
-    app.on_message_added(&conv_id, poll_msg, WireQuote::default(), false);
+    app.on_message_added(&conv_id, poll_msg, WireQuote::default(), false, 0);
     app.db_warn_visible(
         app.db
             .upsert_poll_data(&conv_id, local_ts_ms, &poll_data_for_db),

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -627,19 +627,26 @@ fn resolve_incoming(app: &App, msg: &SignalMessage) -> Option<ResolvedMessage> {
 /// Returns the final accepted-state of the conversation so the caller can pass
 /// the same snapshot to `apply_notification_policy` without re-reading the
 /// store (nothing else mutates `accepted` after this point).
-fn push_resolved(app: &mut App, r: &ResolvedMessage, is_active: bool) -> bool {
-    refresh_sidebar_after_move(app, &r.conv_id);
+/// Returns `(conv_accepted, any_new)`: `any_new` is false when every entry
+/// of the message was a replayed duplicate (#640 U6), in which case all
+/// newness-driven side effects (sidebar reorder, extras persistence, read
+/// state, notification, triggers) are skipped.
+fn push_resolved(app: &mut App, r: &ResolvedMessage, is_active: bool) -> (bool, bool) {
     track_sync_progress(app, r);
     remember_sender_identity(app, r);
 
     let conv_accepted = accept_or_create_conversation(app, r);
-    append_entries(app, r);
+    let any_new = append_entries(app, r);
+    if !any_new {
+        return (conv_accepted, false);
+    }
+    refresh_sidebar_after_move(app, &r.conv_id);
     persist_message_extras(app, r);
 
     if is_active {
         update_active_read_state(app, r, conv_accepted);
     }
-    conv_accepted
+    (conv_accepted, true)
 }
 
 /// Move this conversation to the top of the sidebar order. If the sidebar
@@ -737,14 +744,17 @@ fn accept_or_create_conversation(app: &mut App, r: &ResolvedMessage) -> bool {
 /// - `entry_wire_quote`: the message's quote payload, which historically
 ///   got copy-persisted to every attachment row and produced duplicate
 ///   quote rendering on reload.
-fn append_entries(app: &mut App, r: &ResolvedMessage) {
+///
+/// Returns true when at least one entry was newly persisted (not a replay).
+fn append_entries(app: &mut App, r: &ResolvedMessage) -> bool {
     let mut deferred_poll = app
         .poll_vote
         .pending_polls
         .remove(&(r.conv_id.clone(), r.msg_ts_ms));
     let mut entry_wire_quote = Some(r.wire_quote.clone());
+    let mut any_new = false;
 
-    for entry in &r.entries {
+    for (entry_seq, entry) in r.entries.iter().enumerate() {
         let display = DisplayMessage {
             sender: r.sender_display.clone(),
             timestamp: r.timestamp,
@@ -773,8 +783,14 @@ fn append_entries(app: &mut App, r: &ResolvedMessage) {
             preview_image_path: None,
         };
         let wq = entry_wire_quote.take().unwrap_or_default();
-        app.on_message_added(&r.conv_id, display, wq, true);
+        if app
+            .on_message_added(&r.conv_id, display, wq, true, entry_seq as i64)
+            .is_some()
+        {
+            any_new = true;
+        }
     }
+    any_new
 }
 
 /// Persist the artifacts that hang off a message but live outside the
@@ -923,9 +939,13 @@ fn handle_message(app: &mut App, msg: SignalMessage) {
         .as_ref()
         .map(|a| a == &resolved.conv_id)
         .unwrap_or(false);
-    let conv_accepted = push_resolved(app, &resolved, is_active);
-    apply_notification_policy(app, &resolved, is_active, conv_accepted);
-    evaluate_triggers(app, &msg, &resolved);
+    let (conv_accepted, any_new) = push_resolved(app, &resolved, is_active);
+    // A fully-replayed message (every row already persisted, #640 U6) fires
+    // no notification and no triggers: its side effects ran the first time.
+    if any_new {
+        apply_notification_policy(app, &resolved, is_active, conv_accepted);
+        evaluate_triggers(app, &msg, &resolved);
+    }
 }
 
 /// Run the message through the trigger engine (#615). Replies queue on
@@ -1004,7 +1024,7 @@ fn queue_trigger_reply(app: &mut App, conv_id: String, is_group: bool, text: Str
         preview_image_lines: None,
         preview_image_path: None,
     };
-    app.on_message_added(&conv_id, echo, WireQuote::default(), false);
+    app.on_message_added(&conv_id, echo, WireQuote::default(), false, 0);
     app.pending
         .trigger_sends
         .push(crate::app::SendRequest::Message {
@@ -1070,7 +1090,7 @@ pub(super) fn handle_system_message(
         preview_image_lines: None,
         preview_image_path: None,
     };
-    app.on_message_added(conv_id, msg, WireQuote::default(), true);
+    app.on_message_added(conv_id, msg, WireQuote::default(), true, 0);
 }
 
 fn handle_reaction(


### PR DESCRIPTION
## Summary

Third unit of #640 (Phase 1): make incoming-message insertion idempotent so at-least-once delivery is safe BEFORE any native code exists. Reconnect replays today, and the native backend's acked-before-persisted window later (plan KTD-2), may not duplicate rows or re-fire side effects. The U2 characterization suite (#649) is the regression gate and passes untouched.

## One deliberate deviation from the plan, caught against real data

The plan specified the dedup key as (conversation_id, sender_id, timestamp_ms). That key is wrong in a way the plan itself warns about: one incoming message persists as SEVERAL rows sharing that exact triple - the body row plus one row per attachment. Under the 3-column key, the migration's dedupe-first step would have DELETED users' attachment rows, and the index would have silently dropped attachment entries on arrival. **Verified against a copy of my real siggy.db: it contains 50 legitimate multi-row keys that the planned key would have destroyed.**

Fix: a new entry_seq column numbers the rows of one message in insertion order (deterministic across a replayed parse), and the partial unique index covers (conversation_id, sender_id, timestamp_ms, entry_seq). Exact replays dedup; multi-entry messages survive. Since the plan's own risk table says a wrong dedup is unrecoverable while a missed one is cosmetic, the migration deletes NOTHING: entry_seq backfills per key by rowid, which makes the index build cleanly on any populated table. Historical duplicates stay (cosmetic); only post-migration replays are suppressed.

Real-DB migration check: 2,054 rows in, 2,054 out, integrity_check ok, 5ms.

## What changed

- **Migration v16**: entry_seq column + window-function backfill + partial unique index on incoming rows (sender <> 'you' AND sender_id <> '').
- **insert_message_full**: conflict-targeted upsert (ON CONFLICT (key) WHERE (predicate) DO NOTHING - unrelated constraint violations still error) returning Option<rowid> as the was-it-new signal.
- **on_message_added**: persists FIRST; on replay returns None and skips the full side-effect chain (in-memory append, unarchive #611, read-marker bump, expiring count, sidebar reorder). handle_message additionally skips notification policy and trigger evaluation (#615) when every entry was a replay.
- **Outgoing rows** stay outside the index because the #480 send-confirm dance rewrites their timestamp_ms; replayed sync transcripts of own sends are caught by an app-level exists-check (conv, ts, sender='you', body).
- **Connection topology (settled per plan)**: busy_timeout(5s) on file connections so the future native adapter's durable-insert connection queues behind the main loop's drain batch instead of erroring SQLITE_BUSY. Covered by a two-connection concurrency test.

## Rollback hazard (per plan, stated explicitly)

Revert is only safe BEFORE release. After shipping, a binary downgrade runs the old plain-INSERT code against the still-indexed DB, and legitimate replays start erroring (silent-loss class). Post-release rollback is roll-forward: a new migration dropping the index. Manual escape hatch: DROP INDEX idx_messages_incoming_dedup;

## Tests

+8 tests (1,120 total green): populated-table migration incl. historical duplicates, post-migration replay conflict-skip, outgoing rewrite onto an occupied incoming timestamp, adapter-connection insert behind an open batch, end-to-end replay suppression (rows / unread / archive / sidebar order / DB), same-timestamp distinct senders in a group, attachment multi-row replay, own-sync-echo replay, trigger re-fire suppression. Test fixture make_msg now mints strictly increasing timestamps - Signal message identity IS (sender, timestamp), so same-millisecond messages from one sender cannot exist on the wire, and three tests that relied on that impossibility were fixed.

clippy -D warnings clean, field ratchet 66/66.

Part of #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)