### PR TITLE
chore: U7 backend Cargo features, mutual-exclusion guard, CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
         run: cargo fmt --check
 
       - name: Clippy
-        run: cargo clippy --tests -- -D warnings
+        # --locked: the default lane doubles as the lockfile canary for the
+        # native backend's future [patch.crates-io] entry (#640 U7/U9) -- a
+        # drifted Cargo.lock fails here instead of being silently rewritten.
+        run: cargo clippy --locked --tests -- -D warnings
 
       - name: App field-count ratchet
         run: bash scripts/check-app-field-count.sh
@@ -41,7 +44,32 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Test
-        run: cargo test
+        run: cargo test --locked
+
+  # The native-backend feature lane (#640 U7). Allowed to fail until Phase 3
+  # (#643) per the plan's R11 schedule: pre-U9 the feature intentionally
+  # stops at a compile_error! marker, and during Phases 0-2 upstream churn
+  # may break it without blocking unrelated work. NOT in the required-check
+  # set (branch ruleset 13341653 pins Lint + the three Test jobs by name;
+  # this job is additional and must never rename those).
+  native:
+    name: Native lane (allowed-to-fail until Phase 3)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: native-backend
+
+      - name: Clippy (native-backend)
+        run: cargo clippy --locked --tests --no-default-features --features native-backend -- -D warnings
+
+      - name: Test (native-backend)
+        run: cargo test --locked --no-default-features --features native-backend
 
   fuzz:
     name: Fuzz (${{ matrix.target }})

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,26 @@ Use `--demo` mode to test the UI without a Signal account:
 cargo run -- --demo
 ```
 
+## Backend features
+
+siggy selects its messaging engine at compile time via mutually exclusive
+Cargo features: `signal-cli-backend` (the default) and `native-backend`
+(an in-progress in-process engine, tracked in
+[#637](https://github.com/johnsideserf/siggy/issues/637)). Exactly one must
+be enabled, so **`cargo build --all-features` fails by design** with a
+mutual-exclusion error - this is expected, not a bug.
+
+Build incantations:
+
+```sh
+cargo build                                                  # default engine (signal-cli)
+cargo build --no-default-features --features native-backend  # native engine (not implemented yet)
+```
+
+The native lane also runs in CI (allowed to fail until the epic's Phase 3).
+Once the native engine lands it needs `protoc` installed to build; the
+default build does not.
+
 ## Making changes
 
 1. Create a feature branch from `master`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,22 @@ include = [
     "rust-toolchain.toml",
 ]
 
+# Backend selection (#640 U7, plan R2/KTD-1): exactly one engine per binary,
+# chosen at compile time. The two features are mutually exclusive, enforced
+# by compile_error! guards in main.rs and lib.rs -- `cargo build
+# --all-features` therefore fails BY DESIGN (see CONTRIBUTING.md).
+# `native-backend` is declared ahead of its implementation (#642) so the CI
+# matrix, guards, and lockfile canary are in place before presage merges.
+[features]
+default = ["signal-cli-backend"]
+signal-cli-backend = []
+native-backend = []
+
+[package.metadata.docs.rs]
+# Build with the default backend only; --all-features would hit the
+# mutual-exclusion guard.
+no-default-features = false
+
 [dependencies]
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = "0.29"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,6 +15,11 @@ crossterm = "0.28"
 
 [dependencies.siggy]
 path = ".."
+# Pin the default engine explicitly (#640 U7): fuzz_json_rpc fuzzes the
+# signal-cli JSON-RPC parser, which only exists under this feature. Native
+# parsing gets its own fuzz coverage later if warranted.
+default-features = false
+features = ["signal-cli-backend"]
 
 [[bin]]
 name = "fuzz_json_rpc"

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,6 +15,7 @@
 pub mod demo;
 #[cfg(test)]
 pub mod mock;
+#[cfg(feature = "signal-cli-backend")]
 pub mod signal_cli;
 
 use crate::app::{App, SendRequest};
@@ -22,10 +23,22 @@ use crate::config::Config;
 
 pub use demo::DemoBackend;
 
-/// The concrete backend the binary is built with. U7 turns this into a
-/// cfg-selected alias (`signal-cli-backend` vs `native-backend` features);
-/// until then signal-cli is the only live engine.
+/// The concrete backend the binary is built with, selected at compile time
+/// by the mutually exclusive `signal-cli-backend` / `native-backend`
+/// features (#640 U7, plan KTD-1).
+#[cfg(feature = "signal-cli-backend")]
 pub type ActiveBackend<'a> = signal_cli::SignalCliBackend<'a>;
+
+// The native engine arrives with #642 (U9): pinned presage, store, and the
+// LocalSet runtime shim. The feature exists ahead of it so the CI matrix,
+// mutual-exclusion guard, and lockfile canary are in place before any
+// presage code merges; until U9 lands, a native build stops here with a
+// clear message instead of a wall of missing-type errors. U9 replaces this
+// with `pub mod native;` and the corresponding ActiveBackend alias.
+#[cfg(feature = "native-backend")]
+compile_error!(
+    "the `native-backend` engine is not implemented yet (it lands with #642); build with the default `signal-cli-backend` feature until then"
+);
 
 /// A messaging engine the main loop can drive.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,18 @@
 //! what fuzz harnesses need ([`config`], [`input`], [`keybindings`],
 //! [`signal`], [`theme`]).
 
+// Backend features are mutually exclusive (#640 U7, plan R2/KTD-1). The lib
+// target carries the same guard as the binary so every compilation root
+// rejects an impossible feature set.
+#[cfg(all(feature = "signal-cli-backend", feature = "native-backend"))]
+compile_error!(
+    "features `signal-cli-backend` and `native-backend` are mutually exclusive; enable exactly one"
+);
+#[cfg(not(any(feature = "signal-cli-backend", feature = "native-backend")))]
+compile_error!(
+    "one backend feature is required: `signal-cli-backend` (default) or `native-backend`"
+);
+
 pub mod config;
 #[allow(dead_code)]
 mod debug_log;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,17 @@
 //! Orchestrates the first-run flow: setup wizard -> device linking -> app
 //! startup.
 
+// Backend features are mutually exclusive (#640 U7, plan R2/KTD-1): the
+// boundary is compile-time selected and exactly one engine exists per binary.
+#[cfg(all(feature = "signal-cli-backend", feature = "native-backend"))]
+compile_error!(
+    "features `signal-cli-backend` and `native-backend` are mutually exclusive; enable exactly one"
+);
+#[cfg(not(any(feature = "signal-cli-backend", feature = "native-backend")))]
+compile_error!(
+    "one backend feature is required: `signal-cli-backend` (default) or `native-backend`"
+);
+
 mod app;
 mod audio;
 mod autocomplete;


### PR DESCRIPTION
## Summary

Fifth unit of #640 (Phase 1): the two mutually exclusive backend features exist and are enforced; CI builds both configurations. With this, every Phase 1 unit except U5 (bypass paths) and the U8 soak release is in place.

## What changed

- **Cargo features**: signal-cli-backend (default) and native-backend, declared ahead of the native implementation so the matrix, guards, and lockfile canary exist before any presage code merges (plan sequencing: relicense #648 already landed for the same reason).
- **compile_error! guards** in both compilation roots (main.rs, lib.rs): both features -> 'mutually exclusive; enable exactly one'; neither -> 'one backend feature is required'. cargo build --all-features fails BY DESIGN, documented in CONTRIBUTING.
- **Boundary module gating**: the signal_cli adapter and ActiveBackend alias are cfg-gated to the default feature. A native-backend build stops at a temporary, clearly-marked compile_error pointing at #642 (U9) instead of a wall of missing-type errors; U9 deletes it and adds pub mod native.
- **CI matrix** (.github/workflows/ci.yml):
  - Default lanes gain --locked (clippy + all three Test jobs): the default lane doubles as the lockfile canary that U9's [patch.crates-io] entry depends on.
  - New 'Native lane' job on ubuntu: clippy + test under --no-default-features --features native-backend, continue-on-error: true until Phase 3 per the plan's R11 schedule, with a per-feature rust-cache key.
  - The four required-check job names (Lint, Test (ubuntu-latest), Test (macos-latest), Test (windows-latest)) are byte-identical - the ruleset pins them; the native lane is additional.
- **fuzz crate** pinned explicitly to signal-cli-backend (fuzz_json_rpc fuzzes the signal-cli JSON-RPC parser, which only exists under that feature).
- **docs.rs metadata** pins the default feature set.

## Verification

All four configurations checked locally: default clippy -D warnings clean and 1,139 tests green; both-features, no-features, and native-backend builds each fail with exactly their intended message. Field ratchet 66/66.

Expected CI shape on this PR: all required checks green, the new Native lane amber (its compile_error is the designed pre-U9 behavior).

Part of #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)