### PR TITLE
refactor: U5 route bypass paths through the backend boundary

### DIFF
--- a/src/backend/mock.rs
+++ b/src/backend/mock.rs
@@ -13,6 +13,15 @@ use super::Backend;
 pub struct MockBackend {
     /// Every request routed through [`Backend::dispatch`], in order.
     pub dispatched: Vec<SendRequest>,
+    /// Whether the reconnect supervisor applies (plan U5 supervisor tests).
+    pub reconnectable: bool,
+    /// What [`Backend::try_reconnect`] reports back to the supervisor.
+    pub reconnect_ok: bool,
+    /// How many times [`Backend::try_reconnect`] was called through the
+    /// trait (plan U5: the supervisor must route every attempt here).
+    pub reconnect_calls: u32,
+    /// How many times [`Backend::resync_after_reconnect`] ran.
+    pub resync_calls: u32,
 }
 
 impl Backend for MockBackend {
@@ -31,12 +40,15 @@ impl Backend for MockBackend {
     }
 
     fn supports_reconnect(&self) -> bool {
-        false
+        self.reconnectable
     }
 
     async fn try_reconnect(&mut self, _config: &Config) -> bool {
-        false
+        self.reconnect_calls += 1;
+        self.reconnect_ok
     }
 
-    async fn resync_after_reconnect(&mut self) {}
+    async fn resync_after_reconnect(&mut self) {
+        self.resync_calls += 1;
+    }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -9,14 +9,23 @@
 //! vs array recipients, JSON-RPC correlation) stay inside the adapters and
 //! `signal/`; nothing engine-shaped leaks past this module.
 //!
-//! Linking and connection lifecycle (`link_state`, `link`, `--check`) are not
-//! part of the trait yet; U5 routes those bypass paths through the boundary.
+//! Link-state probing (`--check`, startup registration gating, the wizard's
+//! linking step) goes through each adapter's inherent `link_state()`
+//! associated function rather than a trait method: the probe must run before
+//! any engine instance or connection exists, so tying it to `&mut self` would
+//! misrepresent how it actually works (plan U5, flow gap G1; the choice is
+//! documented on [`Backend`]). The reconnect supervisor's retry policy is
+//! adapter-supplied via [`ReconnectPolicy`] (flow gap G2), and user-facing
+//! engine naming goes through [`Backend::display_name`] or, instance-free,
+//! [`ACTIVE_ENGINE_NAME`] (flow gap G7).
 
 pub mod demo;
 #[cfg(test)]
 pub mod mock;
 #[cfg(feature = "signal-cli-backend")]
 pub mod signal_cli;
+
+use std::time::Duration;
 
 use crate::app::{App, SendRequest};
 use crate::config::Config;
@@ -40,6 +49,19 @@ compile_error!(
     "the `native-backend` engine is not implemented yet (it lands with #642); build with the default `signal-cli-backend` feature until then"
 );
 
+/// User-facing name of the compiled-in engine, for surfaces that run before
+/// any backend instance exists (`--check`'s backend line, spawn-failure
+/// copy). Always matches `ActiveBackend`'s [`Backend::display_name`] (flow
+/// gap G7). Cfg-selected alongside the alias above; U9 adds the native arm.
+#[cfg(feature = "signal-cli-backend")]
+pub const ACTIVE_ENGINE_NAME: &str = signal_cli::ENGINE_NAME;
+
+/// Whether the compiled-in engine drives an external binary the setup wizard
+/// must locate (plan U5 wizard hook, #640). True for signal-cli; U10's
+/// native backend flips this so the wizard skips its binary-detection step.
+#[cfg(feature = "signal-cli-backend")]
+pub const NEEDS_CLI_BINARY: bool = true;
+
 /// A messaging engine the main loop can drive.
 ///
 /// Shaped around siggy's needs (one `dispatch` entry point for the whole
@@ -52,15 +74,21 @@ compile_error!(
 /// - main-loop plumbing carried over from the retired `MessagingBackend`
 ///   enum: [`startup`](Backend::startup), [`drain_events`](Backend::drain_events),
 ///   [`supports_reconnect`](Backend::supports_reconnect),
+///   [`reconnect_policy`](Backend::reconnect_policy),
 ///   [`try_reconnect`](Backend::try_reconnect),
-///   [`resync_after_reconnect`](Backend::resync_after_reconnect). U5 reshapes
-///   this group when linking/connection lifecycle enters the boundary.
+///   [`resync_after_reconnect`](Backend::resync_after_reconnect)
+///
+/// Deliberately *not* a trait method: link-state probing. Every "am I
+/// linked?" call site (`--check`, startup gating in `run_main_flow`, the
+/// wizard's linking step) runs before an engine instance or connection
+/// exists, so each adapter instead exposes an inherent associated function
+/// (`SignalCliBackend::link_state(config)`; U10 adds the native twin with
+/// the same signature). This is the least invasive shape that truthfully
+/// models today's probes (plan U5, KTD-3, flow gap G1).
 pub trait Backend {
-    /// User-facing engine name for status copy (plan flow gap G7).
-    ///
-    /// Not yet threaded into the reconnect/status strings; U5 does that (the
-    /// existing strings stay byte-identical until then).
-    #[allow(dead_code)]
+    /// User-facing engine name for status copy (plan flow gap G7). The
+    /// reconnect supervisor's status strings render through this, keeping
+    /// them byte-identical for signal-cli and truthful for other engines.
     fn display_name(&self) -> &'static str;
 
     /// Capability flag (plan KTD-10): whether group admin operations
@@ -88,8 +116,17 @@ pub trait Backend {
 
     /// Whether the main loop's reconnect supervisor applies to this backend.
     /// Preserves the old `matches!(backend, MessagingBackend::Signal(_))`
-    /// gate; U5 replaces the supervisor with trait-level connection lifecycle.
+    /// gate; the supervisor's cap and backoff come from
+    /// [`reconnect_policy`](Backend::reconnect_policy).
     fn supports_reconnect(&self) -> bool;
+
+    /// Retry policy for [`try_reconnect`](Backend::try_reconnect) (plan U5,
+    /// flow gap G2). Defaults to signal-cli's 6-attempt exponential-backoff
+    /// policy (#497); only consulted when
+    /// [`supports_reconnect`](Backend::supports_reconnect) is true.
+    fn reconnect_policy(&self) -> ReconnectPolicy {
+        ReconnectPolicy::default()
+    }
 
     /// Attempt to re-establish the engine connection. Returns true on
     /// success. See #497 for the signal-cli respawn semantics.
@@ -578,5 +615,33 @@ mod tests {
     fn group_admin_capability_defaults_to_supported() {
         assert!(DemoBackend.supports_group_admin());
         assert!(MockBackend::default().supports_group_admin());
+    }
+
+    // --- Reconnect policy (plan U5, flow gap G2) ---
+
+    /// Moved from main.rs's `reconnect_backoff_is_exponential_and_capped`
+    /// when the backoff became adapter policy (#640 U5). Same assertions:
+    /// signal-cli's schedule must stay byte-identical (#497).
+    #[test]
+    fn reconnect_policy_backoff_is_exponential_and_capped() {
+        let policy = ReconnectPolicy::default();
+        assert_eq!(policy.backoff(1), Duration::from_secs(2));
+        assert_eq!(policy.backoff(2), Duration::from_secs(4));
+        assert_eq!(policy.backoff(3), Duration::from_secs(8));
+        assert_eq!(policy.backoff(4), Duration::from_secs(16));
+        // Capped at 30s, and never overflows the shift for large attempts.
+        assert_eq!(policy.backoff(5), Duration::from_secs(30));
+        assert_eq!(policy.backoff(6), Duration::from_secs(30));
+        assert_eq!(policy.backoff(100), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn reconnect_policy_defaults_to_signal_cli_attempt_cap() {
+        // The old MAX_RECONNECT_ATTEMPTS constant (#497), now trait-supplied.
+        assert_eq!(ReconnectPolicy::default().max_attempts, 6);
+        assert_eq!(
+            MockBackend::default().reconnect_policy(),
+            ReconnectPolicy::default()
+        );
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -62,6 +62,36 @@ pub const ACTIVE_ENGINE_NAME: &str = signal_cli::ENGINE_NAME;
 #[cfg(feature = "signal-cli-backend")]
 pub const NEEDS_CLI_BINARY: bool = true;
 
+/// Retry policy for the main loop's reconnect supervisor (plan U5, flow gap
+/// G2, #640). Adapters expose it via [`Backend::reconnect_policy`] so the
+/// policy is an engine property, not a main-loop constant: U11 lets the
+/// native adapter retry network-class errors indefinitely while signal-cli
+/// keeps its 6-attempt respawn cap (#497).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ReconnectPolicy {
+    /// How many attempts before giving up and leaving the disconnect error
+    /// on screen.
+    pub max_attempts: u32,
+}
+
+impl Default for ReconnectPolicy {
+    /// signal-cli's policy (#497): 6 respawn attempts, exponential backoff.
+    fn default() -> Self {
+        Self { max_attempts: 6 }
+    }
+}
+
+impl ReconnectPolicy {
+    /// Exponential backoff before the next attempt, capped at 30s. `attempt`
+    /// is 1-based (the delay applied *after* attempt N fails, before attempt
+    /// N+1). The first attempt fires immediately on disconnect, so this is
+    /// only consulted after a failure. Byte-identical to the old
+    /// `reconnect_backoff` in `main.rs`.
+    pub fn backoff(&self, attempt: u32) -> Duration {
+        Duration::from_secs((1u64 << attempt.min(6)).min(30))
+    }
+}
+
 /// A messaging engine the main loop can drive.
 ///
 /// Shaped around siggy's needs (one `dispatch` entry point for the whole

--- a/src/backend/signal_cli.rs
+++ b/src/backend/signal_cli.rs
@@ -15,9 +15,16 @@ use crate::config::Config;
 use crate::debug_log;
 use crate::handlers;
 use crate::input;
+use crate::link;
 use crate::signal::client::SignalClient;
+use crate::signal::types::LinkState;
 
 use super::Backend;
+
+/// User-facing engine name (flow gap G7). Also exposed instance-free as
+/// [`super::ACTIVE_ENGINE_NAME`] for surfaces that run before any backend
+/// exists (`--check`).
+pub const ENGINE_NAME: &str = "signal-cli";
 
 pub struct SignalCliBackend<'a> {
     client: &'a mut SignalClient,
@@ -27,11 +34,56 @@ impl<'a> SignalCliBackend<'a> {
     pub fn new(client: &'a mut SignalClient) -> Self {
         Self { client }
     }
+
+    /// Probe whether the configured account is registered as a linked device
+    /// (plan U5, flow gap G1, #640). Spawns a one-shot `signal-cli
+    /// listContacts` and reads its exit code - the same probe the wizard's
+    /// linking step has always used. An associated fn rather than a trait
+    /// method because every caller (`--check`, the setup wizard) runs before
+    /// any engine instance or connection exists; see the [`Backend`] docs for
+    /// the convention. U10 adds the native twin (open store, inspect
+    /// registration state).
+    pub async fn link_state(config: &Config) -> LinkState {
+        link_state_from_probe(link::check_account_registered(config).await)
+    }
+
+    /// Registration sniff on a freshly spawned jsonRpc child (plan U5, flow
+    /// gap G1, #640): signal-cli exits within milliseconds when the account
+    /// is not registered, so a child still alive after 500ms is treated as
+    /// linked. Byte-identical relocation of `run_main_flow`'s old inline
+    /// `wait_for_ready` + stderr debug log; only the *inference* moved here -
+    /// the raw process plumbing (`wait_for_ready`, stderr capture) stays on
+    /// [`SignalClient`]. This sniff can only distinguish "exited early" from
+    /// "still running", so it never reports [`LinkState::Corrupt`].
+    pub async fn startup_link_state(client: &mut SignalClient) -> LinkState {
+        if client.wait_for_ready(Duration::from_millis(500)).await {
+            LinkState::Linked
+        } else {
+            let stderr = client.stderr_output();
+            debug_log::logf(format_args!(
+                "signal-cli exited early during startup, stderr: {stderr}"
+            ));
+            LinkState::Unlinked
+        }
+    }
+}
+
+/// Map the registration probe's outcome to a [`LinkState`]. Free function so
+/// tests can inject probe results without spawning signal-cli (plan U5 test
+/// scenarios). A probe that could not run cannot prove a link, so a spawn
+/// failure maps to `Unlinked` - matching the wizard's old
+/// `check_account_registered(..).unwrap_or(false)` exactly; `--check` reports
+/// a missing binary separately before this is consulted.
+pub(crate) fn link_state_from_probe(registered: anyhow::Result<bool>) -> LinkState {
+    match registered {
+        Ok(true) => LinkState::Linked,
+        Ok(false) | Err(_) => LinkState::Unlinked,
+    }
 }
 
 impl Backend for SignalCliBackend<'_> {
     fn display_name(&self) -> &'static str {
-        "signal-cli"
+        ENGINE_NAME
     }
 
     /// Dispatch a SendRequest to signal-cli.
@@ -581,5 +633,25 @@ impl Backend for SignalCliBackend<'_> {
         let _ = self.client.list_contacts().await;
         let _ = self.client.list_groups().await;
         let _ = self.client.list_identities().await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Mocked-probe mapping (plan U5 test scenarios): `link_state()`
+    /// delegates to this, so these pin `--check`'s registration input
+    /// without spawning signal-cli.
+    #[test]
+    fn link_state_from_probe_maps_registration_outcomes() {
+        assert_eq!(link_state_from_probe(Ok(true)), LinkState::Linked);
+        assert_eq!(link_state_from_probe(Ok(false)), LinkState::Unlinked);
+        // A probe that could not run cannot prove a link (fails toward
+        // relinking, like the wizard's old unwrap_or(false)).
+        assert_eq!(
+            link_state_from_probe(Err(anyhow::anyhow!("spawn failed"))),
+            LinkState::Unlinked
+        );
     }
 }

--- a/src/link.rs
+++ b/src/link.rs
@@ -1,9 +1,14 @@
 //! Device linking against an existing Signal account.
 //!
-//! Spawns `signal-cli link`, parses the linking URI from stdout, renders a
-//! QR code in the terminal, and waits for the user to scan it from their
-//! primary device. On success, polls account registration until signal-cli
-//! reports the new device is provisioned.
+//! Split along the backend boundary (plan U5, #640): the engine-specific
+//! provisioning steps - obtain a linking URI ([`start_link_session`]), await
+//! completion ([`LinkSession::poll`]), and check registration
+//! ([`check_account_registered`], which the signal-cli adapter's
+//! `link_state()` wraps) - are signal-cli-shaped, spawning `signal-cli link`
+//! and reading its stdout/exit code. The QR rendering and screen flow
+//! ([`render_qr_lines`], `show_qr_and_wait`) are backend-agnostic and stay
+//! unchanged; U10 implements the same three-step seam natively via presage's
+//! `link_secondary_device` and reuses the rendering as-is.
 
 use std::io;
 use std::time::Duration;
@@ -33,6 +38,10 @@ pub enum LinkResult {
 
 /// Check whether the configured account is registered with signal-cli.
 /// Returns `Ok(true)` if registered, `Ok(false)` if not.
+///
+/// signal-cli-specific probe (a one-shot `listContacts` exit-code read);
+/// callers outside this module go through the signal-cli adapter's
+/// `link_state()` instead of calling this directly (#640 U5, flow gap G1).
 pub async fn check_account_registered(config: &Config) -> Result<bool> {
     let result = tokio::time::timeout(Duration::from_secs(10), async {
         let output = Command::new(&config.signal_cli_path)
@@ -63,21 +72,65 @@ pub async fn check_account_registered(config: &Config) -> Result<bool> {
     }
 }
 
-/// Run the interactive device-linking flow: spawn `signal-cli link`, capture the
-/// linking URI, display a QR code in the TUI, and wait for completion or cancellation.
-pub async fn run_linking_flow(
-    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    config: &Config,
-) -> Result<LinkResult> {
-    // Show initial status
-    terminal.draw(|frame| {
-        let msg = Paragraph::new("Starting device linking...")
-            .alignment(Alignment::Center)
-            .style(Style::default().fg(Color::Yellow));
-        let area = centered_rect(50, 3, frame.area());
-        frame.render_widget(msg, area);
-    })?;
+/// An in-flight signal-cli provisioning session (plan U5, #640): owns the
+/// `signal-cli link` child between "URI obtained" and "handshake complete".
+/// Engine-specific step 2 of the linking seam; U10's native backend replaces
+/// this with presage's provisioning future behind the same poll shape.
+struct LinkSession {
+    child: tokio::process::Child,
+}
 
+/// What one non-blocking [`LinkSession::poll`] observed.
+enum LinkPoll {
+    /// Handshake still in progress; keep showing the QR.
+    Pending,
+    /// The device was linked successfully.
+    Completed,
+}
+
+impl LinkSession {
+    /// Non-blocking completion check. Failure errors carry signal-cli's
+    /// stderr detail, byte-identical to the old inline `try_wait` handling
+    /// in `show_qr_and_wait`.
+    async fn poll(&mut self) -> Result<LinkPoll> {
+        match self.child.try_wait() {
+            Ok(Some(status)) => {
+                if status.success() {
+                    Ok(LinkPoll::Completed)
+                } else {
+                    // signal-cli writes the real reason (timeout, rate limit,
+                    // stale account state) to stderr. Surface it instead of just
+                    // the numeric exit code, which is opaque on its own.
+                    let mut stderr_output = String::new();
+                    if let Some(mut stderr) = self.child.stderr.take() {
+                        let _ = stderr.read_to_string(&mut stderr_output).await;
+                    }
+                    let detail = stderr_output.trim();
+                    if detail.is_empty() {
+                        anyhow::bail!("signal-cli link failed (exit code: {:?})", status.code());
+                    } else {
+                        anyhow::bail!(
+                            "signal-cli link failed (exit code: {:?}): {detail}",
+                            status.code()
+                        );
+                    }
+                }
+            }
+            Ok(None) => Ok(LinkPoll::Pending),
+            Err(e) => anyhow::bail!("Error checking signal-cli link status: {e}"),
+        }
+    }
+
+    /// Abort the session (user cancelled). Best-effort kill of the child.
+    async fn cancel(&mut self) {
+        let _ = self.child.kill().await;
+    }
+}
+
+/// Obtain a provisioning URI by spawning `signal-cli link` (plan U5, #640):
+/// engine-specific step 1 of the linking seam. Returns the URI (for the
+/// backend-agnostic QR renderer) plus the session to poll for completion.
+async fn start_link_session(config: &Config) -> Result<(String, LinkSession)> {
     // Spawn signal-cli link
     let mut child = Command::new(&config.signal_cli_path)
         .arg("link")
@@ -114,7 +167,7 @@ pub async fn run_linking_flow(
                 }
             }
             Ok(Ok(None)) => {
-                // stdout closed without URI — read stderr for details
+                // stdout closed without URI - read stderr for details
                 let mut stderr_output = String::new();
                 if let Some(mut stderr) = child.stderr.take() {
                     let _ = stderr.read_to_string(&mut stderr_output).await;
@@ -136,12 +189,33 @@ pub async fn run_linking_flow(
         }
     };
 
+    Ok((uri, LinkSession { child }))
+}
+
+/// Run the interactive device-linking flow: obtain a linking URI from the
+/// engine ([`start_link_session`]), display a QR code in the TUI, and wait
+/// for completion or cancellation.
+pub async fn run_linking_flow(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    config: &Config,
+) -> Result<LinkResult> {
+    // Show initial status
+    terminal.draw(|frame| {
+        let msg = Paragraph::new("Starting device linking...")
+            .alignment(Alignment::Center)
+            .style(Style::default().fg(Color::Yellow));
+        let area = centered_rect(50, 3, frame.area());
+        frame.render_widget(msg, area);
+    })?;
+
+    let (uri, mut session) = start_link_session(config).await?;
+
     // Generate QR code
     let qr = qrcode::QrCode::new(uri.as_bytes()).context("Failed to generate QR code")?;
     let qr_lines = render_qr_lines(&qr);
 
     // Show QR and wait for linking to complete or user to cancel
-    show_qr_and_wait(terminal, &qr_lines, &mut child).await
+    show_qr_and_wait(terminal, &qr_lines, &mut session).await
 }
 
 /// Convert a QR code matrix into half-block text lines.
@@ -191,52 +265,34 @@ fn render_qr_lines(qr: &qrcode::QrCode) -> Vec<Line<'static>> {
     lines
 }
 
-/// Display the QR code screen and wait for the child process to finish (link success)
-/// or for the user to press Esc/Ctrl+C to cancel.
+/// Display the QR code screen and wait for the provisioning session to
+/// complete (link success) or for the user to press Esc/Ctrl+C to cancel.
+/// Backend-agnostic: everything engine-specific happens inside the session.
 async fn show_qr_and_wait(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     qr_lines: &[Line<'static>],
-    child: &mut tokio::process::Child,
+    session: &mut LinkSession,
 ) -> Result<LinkResult> {
     loop {
         // Draw
         terminal.draw(|frame| draw_qr_screen(frame, qr_lines))?;
 
-        // Check if the child process finished (non-blocking)
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                if status.success() {
-                    // Show success briefly
-                    terminal.draw(|frame| {
-                        let msg = Paragraph::new("Device linked successfully!")
-                            .alignment(Alignment::Center)
-                            .style(Style::default().fg(Color::Green));
-                        let area = centered_rect(50, 3, frame.area());
-                        frame.render_widget(msg, area);
-                    })?;
-                    tokio::time::sleep(Duration::from_secs(2)).await;
-                    return Ok(LinkResult::Success);
-                } else {
-                    // signal-cli writes the real reason (timeout, rate limit,
-                    // stale account state) to stderr. Surface it instead of just
-                    // the numeric exit code, which is opaque on its own.
-                    let mut stderr_output = String::new();
-                    if let Some(mut stderr) = child.stderr.take() {
-                        let _ = stderr.read_to_string(&mut stderr_output).await;
-                    }
-                    let detail = stderr_output.trim();
-                    if detail.is_empty() {
-                        anyhow::bail!("signal-cli link failed (exit code: {:?})", status.code());
-                    } else {
-                        anyhow::bail!(
-                            "signal-cli link failed (exit code: {:?}): {detail}",
-                            status.code()
-                        );
-                    }
-                }
+        // Check if the handshake finished (non-blocking); failure details
+        // propagate as errors from the session poll.
+        match session.poll().await? {
+            LinkPoll::Completed => {
+                // Show success briefly
+                terminal.draw(|frame| {
+                    let msg = Paragraph::new("Device linked successfully!")
+                        .alignment(Alignment::Center)
+                        .style(Style::default().fg(Color::Green));
+                    let area = centered_rect(50, 3, frame.area());
+                    frame.render_widget(msg, area);
+                })?;
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                return Ok(LinkResult::Success);
             }
-            Ok(None) => {} // Still running
-            Err(e) => anyhow::bail!("Error checking signal-cli link status: {e}"),
+            LinkPoll::Pending => {} // Still running
         }
 
         // Poll for keyboard input
@@ -248,7 +304,7 @@ async fn show_qr_and_wait(
             }
             match (key.modifiers, key.code) {
                 (_, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
-                    let _ = child.kill().await;
+                    session.cancel().await;
                     return Ok(LinkResult::Cancelled);
                 }
                 _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1891,16 +1891,25 @@ mod tests {
     #[test]
     fn check_verdict_requires_a_verified_link_for_ready() {
         // Fully configured and registered: ready, exit 0, no hint.
-        assert_eq!(check_verdict(true, true, Some(LinkState::Linked)), (0, None));
+        assert_eq!(
+            check_verdict(true, true, Some(LinkState::Linked)),
+            (0, None)
+        );
         // Unlinked account: nonzero with the actionable relink instruction.
         let (code, hint) = check_verdict(true, true, Some(LinkState::Unlinked));
         assert_eq!(code, 1);
         let hint = hint.expect("unlinked must carry an actionable hint");
-        assert!(hint.contains("--setup"), "hint should say how to relink: {hint}");
+        assert!(
+            hint.contains("--setup"),
+            "hint should say how to relink: {hint}"
+        );
         // Corrupt local data: nonzero with reset guidance.
         let (code, hint) = check_verdict(true, true, Some(LinkState::Corrupt));
         assert_eq!(code, 1);
-        assert!(hint.expect("corrupt must carry a hint").contains("--reset-account"));
+        assert!(
+            hint.expect("corrupt must carry a hint")
+                .contains("--reset-account")
+        );
         // Probe skipped (missing binary or no account): not ready, as before.
         assert_eq!(check_verdict(false, true, None).0, 1);
         assert_eq!(check_verdict(true, false, None).0, 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,7 @@ use app::{App, InputMode, OverlayKind, SendRequest};
 use config::Config;
 use setup::SetupResult;
 use signal::client::SignalClient;
+use signal::types::LinkState;
 
 /// Keyboard polling interval for the main event loop.
 const POLL_TIMEOUT: Duration = Duration::from_millis(50);
@@ -86,18 +87,6 @@ const POLL_TIMEOUT: Duration = Duration::from_millis(50);
 /// diagnostic hint, and let the user reach the rest of the app. Generous enough
 /// not to fire on a slow-but-healthy first sync.
 const STARTUP_SYNC_TIMEOUT: Duration = Duration::from_secs(20);
-
-/// How many times to retry spawning signal-cli after the child dies before
-/// giving up and leaving the disconnect error on screen (#497).
-const MAX_RECONNECT_ATTEMPTS: u32 = 6;
-
-/// Exponential backoff before the next signal-cli reconnect attempt, capped at
-/// 30s. `attempt` is 1-based (the delay applied *after* attempt N fails, before
-/// attempt N+1). The first attempt fires immediately on disconnect, so this is
-/// only consulted after a failure.
-fn reconnect_backoff(attempt: u32) -> Duration {
-    Duration::from_secs((1u64 << attempt.min(6)).min(30))
-}
 
 /// Translate signal-cli stderr into a clearer message for the non-interactive
 /// CLI commands when it indicates a well-known fatal condition. signal-cli
@@ -137,6 +126,12 @@ fn oneshot_target(recipient: &str) -> (String, bool) {
 /// Send a single message non-interactively, await confirmation, and return
 /// whether it was accepted (#257). Spawns signal-cli, sends, then waits up to
 /// 30s for the correlated `SendTimestamp` (ok) or `SendFailed`.
+///
+/// Drives the signal-cli client directly rather than the [`backend::Backend`]
+/// trait: the headless modes need raw send/event access without an [`App`],
+/// which the trait deliberately does not expose. They stay engine-specific
+/// until the native backend implements them (#640; R8's native half lands
+/// with U17). Same applies to `run_receive_stream` and `run_watch`.
 async fn run_send_oneshot(config: &Config, recipient: &str, body: &str) -> Result<bool> {
     let mut client = SignalClient::spawn(config).await?;
     let (target, is_group) = oneshot_target(recipient);
@@ -305,6 +300,89 @@ async fn run_watch(config: &Config) -> Result<()> {
         Some(hint) => Err(anyhow::anyhow!("{hint}")),
         None => Ok(()),
     }
+}
+
+/// Pure core of the `--check` verdict (plan U5, #640): exit code plus the
+/// actionable stderr hint, from the probe results. `link_state` is `None`
+/// when the registration probe was skipped because it could not succeed
+/// (missing binary or no account configured). Ready requires an actual
+/// [`LinkState::Linked`] answer - `--check` used to report "ready" without
+/// verifying registration at all (flow gap G1).
+fn check_verdict(
+    found: bool,
+    account_ok: bool,
+    link_state: Option<LinkState>,
+) -> (i32, Option<&'static str>) {
+    let ready = found && account_ok && link_state == Some(LinkState::Linked);
+    let hint = match link_state {
+        // Same phrasing as cli_stderr_hint's unregistered case, so every
+        // surface gives the same recovery instruction.
+        Some(LinkState::Unlinked) => {
+            Some("this account is not registered - run `siggy --setup` to link a device")
+        }
+        Some(LinkState::Corrupt) => Some(
+            "local account data is unusable - run `siggy --reset-account`, then `siggy --setup`",
+        ),
+        _ => None,
+    };
+    (if ready { 0 } else { 1 }, hint)
+}
+
+/// Non-interactive setup health report for scripts/CI (#257; rewritten on the
+/// adapter's link-state probe in #640 U5). Plain stdout, no TUI. Reports the
+/// active engine and, when it can be probed, the account's actual link
+/// state; exit 0 only when the binary is found, an account is set, and that
+/// account is registered. Note: the registration probe spawns a one-shot
+/// signal-cli, so it shares `--send`'s caveat - while the siggy TUI holds the
+/// account lock the probe times out and reports unlinked.
+async fn run_check(config: &Config, resolved_config_path: &std::path::Path) -> i32 {
+    let (found, location, _resolved) = setup::check_signal_cli(&config.signal_cli_path).await;
+    let account_ok = !config.account.is_empty();
+    println!("siggy {}", env!("CARGO_PKG_VERSION"));
+    println!("backend:      {}", backend::ACTIVE_ENGINE_NAME);
+    println!("config:       {}", resolved_config_path.display());
+    println!(
+        "account:      {}",
+        if account_ok {
+            config.account.as_str()
+        } else {
+            "(not set)"
+        }
+    );
+    println!(
+        "signal-cli:   {}",
+        if found {
+            location
+        } else {
+            format!("NOT FOUND (configured: {})", config.signal_cli_path)
+        }
+    );
+    println!("download dir: {}", config.download_dir.display());
+    // Probe registration only when the probe can succeed: it needs the
+    // binary and an account. Otherwise the report is already "not ready".
+    let link_state = if found && account_ok {
+        let state = backend::signal_cli::SignalCliBackend::link_state(config).await;
+        println!(
+            "link:         {}",
+            match state {
+                LinkState::Linked => "linked",
+                LinkState::Unlinked => "NOT LINKED",
+                LinkState::Corrupt => "CORRUPT",
+            }
+        );
+        Some(state)
+    } else {
+        None
+    };
+    let (exit_code, hint) = check_verdict(found, account_ok, link_state);
+    println!(
+        "status:       {}",
+        if exit_code == 0 { "ready" } else { "not ready" }
+    );
+    if let Some(hint) = hint {
+        eprintln!("{hint}");
+    }
+    exit_code
 }
 
 /// Whether the session should auto-lock now (#438). `timeout_mins == 0` disables
@@ -550,36 +628,11 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Non-interactive setup health report for scripts/CI (#257). Plain stdout,
-    // no TUI; exit 0 only when signal-cli is detected and an account is set.
+    // Non-interactive setup health report for scripts/CI (#257). Exit 0 only
+    // when signal-cli is detected, an account is set, and the account is
+    // actually registered (#640 U5 - the old report never checked the link).
     if check {
-        let (found, location, _resolved) = setup::check_signal_cli(&config.signal_cli_path).await;
-        let account_ok = !config.account.is_empty();
-        println!("siggy {}", env!("CARGO_PKG_VERSION"));
-        println!("config:       {}", resolved_config_path.display());
-        println!(
-            "account:      {}",
-            if account_ok {
-                config.account.as_str()
-            } else {
-                "(not set)"
-            }
-        );
-        println!(
-            "signal-cli:   {}",
-            if found {
-                location
-            } else {
-                format!("NOT FOUND (configured: {})", config.signal_cli_path)
-            }
-        );
-        println!("download dir: {}", config.download_dir.display());
-        let ready = found && account_ok;
-        println!(
-            "status:       {}",
-            if ready { "ready" } else { "not ready" }
-        );
-        std::process::exit(if ready { 0 } else { 1 });
+        std::process::exit(run_check(&config, &resolved_config_path).await);
     }
 
     // Non-interactive conversation list for scripts (#257). Reads the cached DB
@@ -796,22 +849,25 @@ async fn run_main_flow(
         Ok(client) => client,
         Err(e) => {
             let msg = format!("{e}");
-            show_error_screen(terminal, "Failed to Start signal-cli", &msg).await?;
+            show_error_screen(
+                terminal,
+                &format!("Failed to Start {}", backend::ACTIVE_ENGINE_NAME),
+                &msg,
+            )
+            .await?;
             return Ok(());
         }
     };
 
-    // Give signal-cli a brief window to fail if the account is unregistered.
-    // If the process exits early, check stderr and fall back to linking.
+    // Registration gating goes through the adapter's link-state sniff
+    // (#640 U5, flow gap G1): the 500ms child-exit window and stderr read
+    // live in backend::signal_cli now, so main no longer interprets process
+    // behavior. Anything short of Linked falls back to the linking flow,
+    // exactly as the old inline wait_for_ready check did.
     if !setup_handled_linking
-        && !signal_client
-            .wait_for_ready(std::time::Duration::from_millis(500))
-            .await
+        && backend::signal_cli::SignalCliBackend::startup_link_state(&mut signal_client).await
+            != LinkState::Linked
     {
-        let stderr = signal_client.stderr_output();
-        debug_log::logf(format_args!(
-            "signal-cli exited early during startup, stderr: {stderr}"
-        ));
         signal_client.shutdown().await?;
 
         match link::run_linking_flow(terminal, config).await {
@@ -831,7 +887,12 @@ async fn run_main_flow(
             Ok(client) => client,
             Err(e) => {
                 let msg = format!("{e}");
-                show_error_screen(terminal, "Failed to Start signal-cli", &msg).await?;
+                show_error_screen(
+                    terminal,
+                    &format!("Failed to Start {}", backend::ACTIVE_ENGINE_NAME),
+                    &msg,
+                )
+                .await?;
                 return Ok(());
             }
         };
@@ -1237,6 +1298,65 @@ fn emit_native_images(backend: &mut CrosstermBackend<io::Stdout>, app: &mut App)
     Ok(())
 }
 
+/// One pass of the supervised-reconnect state machine (#497; routed through
+/// the [`backend::Backend`] trait with an adapter-supplied retry policy in
+/// #640 U5, flow gaps G2/G7). Runs only while disconnected, only for
+/// backends that support reconnecting, and only up to the policy's attempt
+/// cap; the first attempt fires immediately, later ones wait out the
+/// policy's backoff. Status copy renders the engine via `display_name()`,
+/// which keeps the strings byte-identical for signal-cli ("Reconnecting to
+/// signal-cli (attempt 1/6)..."). Returns true when it did anything (the
+/// caller schedules a redraw).
+async fn reconnect_tick<B: backend::Backend>(
+    backend: &mut B,
+    app: &mut App,
+    config: &Config,
+    attempts: &mut u32,
+    next_attempt_at: &mut Option<Instant>,
+) -> bool {
+    let policy = backend.reconnect_policy();
+    if app.connection_error.is_none()
+        || !backend.supports_reconnect()
+        || *attempts >= policy.max_attempts
+    {
+        return false;
+    }
+    let now = Instant::now();
+    let due = next_attempt_at.map(|t| now >= t).unwrap_or(true);
+    if !due {
+        return false;
+    }
+    *attempts += 1;
+    app.status_message = format!(
+        "Reconnecting to {} (attempt {}/{})...",
+        backend.display_name(),
+        attempts,
+        policy.max_attempts
+    );
+    if backend.try_reconnect(config).await {
+        *attempts = 0;
+        *next_attempt_at = None;
+        app.connection_error = None;
+        app.set_connected();
+        // Re-run the startup sync against the fresh connection (best-effort).
+        backend.resync_after_reconnect().await;
+    } else if *attempts >= policy.max_attempts {
+        app.status_message = format!(
+            "{} disconnected; reconnect failed. Restart siggy.",
+            backend.display_name()
+        );
+    } else {
+        let delay = policy.backoff(*attempts);
+        *next_attempt_at = Some(now + delay);
+        app.status_message = format!(
+            "{} reconnect failed; retrying in {}s",
+            backend.display_name(),
+            delay.as_secs()
+        );
+    }
+    true
+}
+
 async fn run_app<B: backend::Backend>(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     mut backend: B,
@@ -1306,8 +1426,9 @@ async fn run_app<B: backend::Backend>(
         .unwrap_or_else(Instant::now);
     let mut needs_redraw = true;
     let mut last_title: Option<String> = None;
-    // Supervised signal-cli reconnect state (#497). `next_reconnect_at` is the
-    // earliest time the next spawn attempt may run; None means "try now".
+    // Supervised reconnect state (#497, adapter policy per #640 U5).
+    // `next_reconnect_at` is the earliest time the next attempt may run;
+    // None means "try now".
     let mut reconnect_attempts: u32 = 0;
     let mut next_reconnect_at: Option<Instant> = None;
     // Auto-lock idle tracking (#438): reset on every keypress (not mouse).
@@ -1551,40 +1672,19 @@ async fn run_app<B: backend::Backend>(
             }
         }
 
-        // Supervised reconnect: only while disconnected, only for the Signal
-        // backend, and only up to the attempt cap. The first attempt fires
-        // immediately; subsequent ones wait for the backoff (#497).
-        if app.connection_error.is_some()
-            && backend.supports_reconnect()
-            && reconnect_attempts < MAX_RECONNECT_ATTEMPTS
+        // Supervised reconnect (#497), one tick per loop iteration. The
+        // attempt cap, backoff, and engine naming all come from the backend
+        // (#640 U5, flow gaps G2/G7).
+        if reconnect_tick(
+            &mut backend,
+            &mut app,
+            config,
+            &mut reconnect_attempts,
+            &mut next_reconnect_at,
+        )
+        .await
         {
-            let now = Instant::now();
-            let due = next_reconnect_at.map(|t| now >= t).unwrap_or(true);
-            if due {
-                reconnect_attempts += 1;
-                app.status_message = format!(
-                    "Reconnecting to signal-cli (attempt {reconnect_attempts}/{MAX_RECONNECT_ATTEMPTS})..."
-                );
-                needs_redraw = true;
-                if backend.try_reconnect(config).await {
-                    reconnect_attempts = 0;
-                    next_reconnect_at = None;
-                    app.connection_error = None;
-                    app.set_connected();
-                    // Re-run the startup sync against the fresh child (best-effort).
-                    backend.resync_after_reconnect().await;
-                } else if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
-                    app.status_message =
-                        "signal-cli disconnected; reconnect failed. Restart siggy.".to_string();
-                } else {
-                    let delay = reconnect_backoff(reconnect_attempts);
-                    next_reconnect_at = Some(now + delay);
-                    app.status_message = format!(
-                        "signal-cli reconnect failed; retrying in {}s",
-                        delay.as_secs()
-                    );
-                }
-            }
+            needs_redraw = true;
         }
 
         // Check if initial sync burst has ended
@@ -1782,15 +1882,121 @@ mod tests {
         assert!(startup_sync_timed_out(true, STARTUP_SYNC_TIMEOUT * 2));
     }
 
+    // The reconnect backoff test moved to src/backend/mod.rs
+    // (reconnect_policy_backoff_is_exponential_and_capped) when the schedule
+    // became adapter policy (#640 U5).
+
+    // --- --check verdict (plan U5: fix the "reports OK without checking" lie) ---
+
     #[test]
-    fn reconnect_backoff_is_exponential_and_capped() {
-        assert_eq!(reconnect_backoff(1), Duration::from_secs(2));
-        assert_eq!(reconnect_backoff(2), Duration::from_secs(4));
-        assert_eq!(reconnect_backoff(3), Duration::from_secs(8));
-        assert_eq!(reconnect_backoff(4), Duration::from_secs(16));
-        // Capped at 30s, and never overflows the shift for large attempts.
-        assert_eq!(reconnect_backoff(5), Duration::from_secs(30));
-        assert_eq!(reconnect_backoff(6), Duration::from_secs(30));
-        assert_eq!(reconnect_backoff(100), Duration::from_secs(30));
+    fn check_verdict_requires_a_verified_link_for_ready() {
+        // Fully configured and registered: ready, exit 0, no hint.
+        assert_eq!(check_verdict(true, true, Some(LinkState::Linked)), (0, None));
+        // Unlinked account: nonzero with the actionable relink instruction.
+        let (code, hint) = check_verdict(true, true, Some(LinkState::Unlinked));
+        assert_eq!(code, 1);
+        let hint = hint.expect("unlinked must carry an actionable hint");
+        assert!(hint.contains("--setup"), "hint should say how to relink: {hint}");
+        // Corrupt local data: nonzero with reset guidance.
+        let (code, hint) = check_verdict(true, true, Some(LinkState::Corrupt));
+        assert_eq!(code, 1);
+        assert!(hint.expect("corrupt must carry a hint").contains("--reset-account"));
+        // Probe skipped (missing binary or no account): not ready, as before.
+        assert_eq!(check_verdict(false, true, None).0, 1);
+        assert_eq!(check_verdict(true, false, None).0, 1);
+    }
+
+    // --- Reconnect supervisor through the trait (plan U5, flow gap G2) ---
+
+    fn test_app() -> App {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let config_path = dir.path().join("config.toml");
+        // Leak the tempdir so it lives as long as the test process, matching
+        // the app_tests fixture. The OS reclaims temp dirs on exit.
+        std::mem::forget(dir);
+        let db = db::Database::open_in_memory().unwrap();
+        App::new("+10000000000".to_string(), db, &config_path)
+    }
+
+    #[tokio::test]
+    async fn reconnect_supervisor_counts_attempts_through_the_trait() {
+        use backend::Backend as _;
+        let mut app = test_app();
+        let mut mock = backend::mock::MockBackend {
+            reconnectable: true,
+            ..Default::default()
+        };
+        let cap = mock.reconnect_policy().max_attempts;
+        let config = Config::default();
+        let mut attempts = 0u32;
+        let mut next_at: Option<Instant> = None;
+
+        // Connected: the supervisor must not fire at all.
+        assert!(!reconnect_tick(&mut mock, &mut app, &config, &mut attempts, &mut next_at).await);
+        assert_eq!(mock.reconnect_calls, 0);
+
+        // Disconnected: every attempt goes through Backend::try_reconnect,
+        // with the backoff schedule applied between failures.
+        app.connection_error = Some("gone".to_string());
+        for expected in 1..=cap {
+            assert!(
+                reconnect_tick(&mut mock, &mut app, &config, &mut attempts, &mut next_at).await
+            );
+            assert_eq!(mock.reconnect_calls, expected);
+            if expected < cap {
+                assert!(next_at.is_some(), "a failed attempt schedules a backoff");
+                assert_eq!(
+                    app.status_message,
+                    format!(
+                        "mock reconnect failed; retrying in {}s",
+                        mock.reconnect_policy().backoff(expected).as_secs()
+                    )
+                );
+                next_at = None; // simulate the backoff having elapsed
+            }
+        }
+        assert_eq!(
+            app.status_message,
+            "mock disconnected; reconnect failed. Restart siggy."
+        );
+
+        // Cap reached: no further attempts reach the trait.
+        assert!(!reconnect_tick(&mut mock, &mut app, &config, &mut attempts, &mut next_at).await);
+        assert_eq!(mock.reconnect_calls, cap);
+    }
+
+    #[tokio::test]
+    async fn reconnect_success_resets_supervisor_and_resyncs() {
+        let mut app = test_app();
+        let mut mock = backend::mock::MockBackend {
+            reconnectable: true,
+            reconnect_ok: true,
+            ..Default::default()
+        };
+        let config = Config::default();
+        let mut attempts = 0u32;
+        let mut next_at: Option<Instant> = None;
+        app.connection_error = Some("gone".to_string());
+
+        assert!(reconnect_tick(&mut mock, &mut app, &config, &mut attempts, &mut next_at).await);
+        assert_eq!(mock.reconnect_calls, 1);
+        assert_eq!(mock.resync_calls, 1, "success re-runs the startup sync");
+        assert_eq!(attempts, 0, "attempt counter resets on success");
+        assert!(next_at.is_none());
+        assert!(app.connection_error.is_none());
+        assert!(app.connected);
+    }
+
+    #[tokio::test]
+    async fn reconnect_supervisor_skips_backends_without_reconnect() {
+        let mut app = test_app();
+        let mut mock = backend::mock::MockBackend::default(); // reconnectable: false
+        let config = Config::default();
+        let mut attempts = 0u32;
+        let mut next_at: Option<Instant> = None;
+        app.connection_error = Some("gone".to_string());
+
+        assert!(!reconnect_tick(&mut mock, &mut app, &config, &mut attempts, &mut next_at).await);
+        assert_eq!(mock.reconnect_calls, 0);
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -20,8 +20,10 @@ use ratatui::{
 };
 use tokio::process::Command;
 
+use crate::backend;
 use crate::config::Config;
 use crate::link;
+use crate::signal::types::LinkState;
 
 pub enum SetupResult {
     /// Wizard finished successfully, use this config.
@@ -32,13 +34,28 @@ pub enum SetupResult {
     Cancelled,
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum Step {
     SignalCli,
     Account,
     Linking,
     Preferences,
     Done,
+}
+
+/// Ordered wizard steps for the compiled-in backend (plan U5 gating hook,
+/// #640). The binary-detection step exists only for engines that drive an
+/// external binary (`needs_binary` = [`backend::NEEDS_CLI_BINARY`]); U10's
+/// native backend flips that flag and the wizard starts at the account step.
+/// Today only the first step feeds the imperative loop below - the in-loop
+/// transitions stay hardcoded until a second backend actually exists.
+fn wizard_steps(needs_binary: bool) -> Vec<Step> {
+    let mut steps = Vec::with_capacity(5);
+    if needs_binary {
+        steps.push(Step::SignalCli);
+    }
+    steps.extend([Step::Account, Step::Linking, Step::Preferences, Step::Done]);
+    steps
 }
 
 pub async fn run_setup(
@@ -51,7 +68,9 @@ pub async fn run_setup(
     }
 
     let mut working_config = config.clone();
-    let mut step = Step::SignalCli;
+    let mut step = *wizard_steps(backend::NEEDS_CLI_BINARY)
+        .first()
+        .expect("wizard step list is never empty");
     let mut signal_cli_path = working_config.signal_cli_path.clone();
     let mut phone_input = String::new();
     let mut phone_cursor: usize = 0;
@@ -176,10 +195,13 @@ pub async fn run_setup(
             }
 
             Step::Linking => {
-                // Check if already registered
-                let registered = link::check_account_registered(&working_config)
-                    .await
-                    .unwrap_or(false);
+                // Check if already registered - through the adapter's
+                // link-state probe (#640 U5, flow gap G1) rather than a raw
+                // listContacts exit-code read. Same probe, same semantics
+                // (a failed probe reads as unlinked).
+                let registered =
+                    backend::signal_cli::SignalCliBackend::link_state(&working_config).await
+                        == LinkState::Linked;
                 if registered {
                     // Already registered, skip linking
                     terminal.draw(|frame| {
@@ -1186,6 +1208,34 @@ fn draw_done_screen(frame: &mut ratatui::Frame) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- wizard_steps (plan U5 gating hook, #640) ---
+
+    #[test]
+    fn wizard_steps_gate_binary_detection_per_backend() {
+        // signal-cli drives an external binary, so detection is the first
+        // step - behavior unchanged today.
+        assert_eq!(
+            wizard_steps(true),
+            vec![
+                Step::SignalCli,
+                Step::Account,
+                Step::Linking,
+                Step::Preferences,
+                Step::Done,
+            ]
+        );
+        // An in-process engine (native, #640 U10) skips straight to the
+        // account step; every other step survives.
+        let native = wizard_steps(false);
+        assert!(!native.contains(&Step::SignalCli));
+        assert_eq!(native.first(), Some(&Step::Account));
+        assert_eq!(native.len(), 4);
+        // The compiled-in backend today starts at binary detection: the
+        // list run_setup actually uses must lead with it.
+        let compiled = wizard_steps(backend::NEEDS_CLI_BINARY);
+        assert_eq!(compiled.first(), Some(&Step::SignalCli));
+    }
 
     #[tokio::test]
     async fn check_signal_cli_detects_known_command() {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -199,9 +199,9 @@ pub async fn run_setup(
                 // link-state probe (#640 U5, flow gap G1) rather than a raw
                 // listContacts exit-code read. Same probe, same semantics
                 // (a failed probe reads as unlinked).
-                let registered =
-                    backend::signal_cli::SignalCliBackend::link_state(&working_config).await
-                        == LinkState::Linked;
+                let registered = backend::signal_cli::SignalCliBackend::link_state(&working_config)
+                    .await
+                    == LinkState::Linked;
                 if registered {
                     // Already registered, skip linking
                     terminal.draw(|frame| {


### PR DESCRIPTION
## Summary

Final code unit of #640 Phase 1: the four flows that bypassed the backend seam (headless startup sniffing, --check, reconnect supervision, linking) now go through it, eliminating the app layer's process-behavior inferences (plan flow gaps G1/G2/G7, KTD-3). After this, Phase 1 is code-complete and U8 (the soak release) is next.

## Shape choices

- **link_state is an inherent associated fn per adapter**, not a trait method: every 'am I linked?' call site (--check, run_main_flow startup gating, the wizard's linking step) runs before an engine instance or connection exists, and the signal-cli probe spawns its own one-shot process. A &mut self trait method would misrepresent that. The convention is documented on the trait; U10 adds the native twin with the same signature. Probe results map through a pure link_state_from_probe() so tests inject outcomes (Ok(true) -> Linked, Ok(false) | Err -> Unlinked, matching the wizard's old unwrap_or(false) exactly).
- **Startup sniffing moved, not changed**: the 500ms child-exit window, stderr read, and debug log line relocated byte-identical into SignalCliBackend::startup_link_state(); main.rs now compares a LinkState.
- **Reconnect policy is an engine property**: Backend::reconnect_policy() returns { max_attempts: 6 } with the byte-identical backoff formula; U11 lets the native adapter retry network-class errors indefinitely. Supervisor extracted into a testable reconnect_tick(); status strings render through display_name() (byte-identical for signal-cli).
- **link.rs split**: start_link_session() / LinkSession::poll()/cancel() are signal-cli-specific and private; show_qr_and_wait and render_qr_lines are backend-agnostic. All error strings byte-identical.
- **Wizard hook**: wizard_steps(backend::NEEDS_CLI_BINARY) builds the step list; behavior unchanged today, U10 flips the const for native.

## The one sanctioned behavior change: --check stops lying

Before, --check reported ready without verifying registration. Now it prints the backend engine and a link line (linked / NOT LINKED / CORRUPT), requires Linked for ready, and exits 1 with 'this account is not registered - run siggy --setup to link a device' when unlinked. Caveat: the probe spawns a one-shot signal-cli, so running --check while the TUI holds the account lock takes ~10s and reports NOT LINKED (documented in run_check; previously --check did not probe at all).

Headless send/receive/watch still drive SignalClient directly by design: they need raw event access without an App, and R8's native half belongs to U17 (documented in code).

## Tests

+9 (1,146 total green): probe mapping, policy backoff + cap, check_verdict exit codes and hints, reconnect supervisor through MockBackend (attempt counting to cap, success reset + resync, non-reconnectable skip), wizard step-list gating. U2 characterization suite untouched. clippy -D warnings clean both lanes (native lane still stops at its designed pre-U9 marker), field ratchet 66/66.

Part of #640

🤖 Generated with [Claude Code](https://claude.com/claude-code)