### PR TITLE
chore(release): bump version to 1.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.13.0"
+version = "1.14.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.13.0"
+version = "1.14.0"
 edition = "2024"
 license = "AGPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,47 @@
 # Changelog
 
+## v1.14.0
+
+The foundation release for the native backend epic
+([#637](https://github.com/johnsideserf/siggy/issues/637)): an internal
+backend-boundary refactor with no intended user-facing changes beyond the
+items below. This release soaks before any native engine code merges, so
+anything odd is worth [reporting](https://github.com/johnsideserf/siggy/issues).
+
+### Changed
+
+- **License: GPL-3.0 to AGPL-3.0-only.** The planned native Signal engine
+  builds on presage and Signal's libsignal (both AGPL), and the relicense
+  lands ahead of that code. AGPL keeps every GPL obligation and adds the
+  network-source clause.
+- **`siggy --check` now actually checks.** It previously reported ready
+  without verifying registration; it now probes the account's link state,
+  prints the backend engine and a `link:` line, and exits nonzero with a
+  pointer to `siggy --setup` when the account is not linked.
+- **Replay protection.** Incoming messages are deduplicated at the
+  database level (new `entry_seq` schema column and unique index), so
+  replayed envelopes after a reconnect can no longer duplicate messages,
+  inflate unread counts, unarchive conversations, or re-fire
+  notifications and message triggers.
+
+### Internal
+
+- The messaging engine now lives behind a `Backend` trait in
+  `src/backend/` (signal-cli adapter, demo adapter, test mock), selected
+  at compile time by mutually exclusive Cargo features
+  (`signal-cli-backend`, the default, and the not-yet-implemented
+  `native-backend`).
+- Send correlation, link state, connection events, and sync completion
+  are backend-neutral vocabulary types; linking, startup registration
+  checks, and reconnect supervision route through the boundary.
+- 30 characterization tests lock the signal-cli backend's observable
+  behavior as the refactor's regression gate.
+- Schema migration to v16 (entry_seq backfill + dedup index), verified
+  against a real database copy before shipping.
+- +89 tests since v1.13.0 (1,146 total).
+
+---
+
 ## v1.13.0
 
 The automation and identity release: scriptable message triggers with a

--- a/docs/src/dev-guide/database.md
+++ b/docs/src/dev-guide/database.md
@@ -63,12 +63,23 @@ CREATE TABLE messages (
     poll_data            TEXT,                           -- serialized poll JSON (v11)
     link_preview         TEXT,                           -- serialized preview JSON (v12)
     body_raw             TEXT,                           -- body with mention placeholders (v13)
-    mentions_json        TEXT                            -- serialized mention ranges (v13)
+    mentions_json        TEXT,                           -- serialized mention ranges (v13)
+    entry_seq            INTEGER NOT NULL DEFAULT 0     -- row number within one message (v16)
 );
 
 CREATE INDEX idx_messages_conv_ts ON messages(conversation_id, timestamp);
 CREATE INDEX idx_messages_conv_ts_ms ON messages(conversation_id, timestamp_ms);
+CREATE UNIQUE INDEX idx_messages_incoming_dedup                    -- replay dedup (v16)
+    ON messages(conversation_id, sender_id, timestamp_ms, entry_seq)
+    WHERE sender <> 'you' AND sender_id <> '';
 ```
+
+One incoming message persists as several rows (the body plus one row per
+attachment) sharing `(conversation_id, sender_id, timestamp_ms)`;
+`entry_seq` numbers them in insertion order. The partial unique index makes
+replayed envelopes (reconnect redelivery) conflict-skip instead of
+duplicating, while outgoing rows stay outside it because the send-confirm
+flow rewrites their `timestamp_ms`.
 
 System messages (`is_system = 1`) are used for join/leave notifications and
 are excluded from unread counts.
@@ -144,6 +155,7 @@ Migrations are version-based and run sequentially in `Database::migrate()`:
 | 13 | Add `body_raw` and `mentions_json` columns to `messages` (mention re-resolution) |
 | 14 | Add `mute_expires_at` column to `conversations` (timed mutes) |
 | 15 | Add `archived` column to `conversations` (archive) |
+| 16 | Add `entry_seq` column to `messages` (backfilled per message key) and a partial unique index on incoming rows `(conversation_id, sender_id, timestamp_ms, entry_seq)` for replay deduplication |
 
 Each migration is wrapped in a transaction. The `schema_version` table tracks
 the current version.

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.13.0                                 │t too                   │
+                     ││[0│  siggy v1.14.0                                 │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

The U8 soak release for #640 Phase 1 (plan: ship the boundary refactor alone, as a normal release, so regressions are attributable before any native code merges). Master since v1.13.0 contains the AGPL relicense (#648) and Phase 1 units U2-U7 (#649, #650, #651, #652, #653, #654).

### Changes

- Cargo.toml version 1.13.0 -> 1.14.0 (+ Cargo.lock)
- About overlay snapshot regenerated
- Docsite changelog entry for v1.14.0 (relicense, --check fix, replay protection as the user-visible items; boundary refactor summarized under Internal)
- Docsite database page: messages table sketch + migration table gain v16 (entry_seq + dedup index) with the multi-row-message explanation

### Checks

- 1,146 tests green, clippy -D warnings clean, field ratchet 66/66

After merge I will tag v1.14.0. Per the plan's U8, this release should soak (roughly one release cycle of dogfooding) before Phase 2 (#642) merges any native code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)