### PR TITLE
chore(release): bump version to 1.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,7 +2574,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.14.0"
+version = "1.14.1"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "siggy"
-version = "1.14.0"
+version = "1.14.1"
 edition = "2024"
 license = "AGPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## v1.14.1
+
+Patch release for the broken proxy config
+([#656](https://github.com/johnsideserf/siggy/issues/656)).
+
+### Fixed
+
+- **Removed the `proxy` config field; siggy now refuses to start while it
+  is set.** The field was passed to signal-cli as `--proxy`, a flag that
+  does not exist in any signal-cli version, so it never worked: with a
+  proxy configured the message process died at startup (no messages,
+  spurious relink prompts), while linking and `--check` probes connected
+  to Signal directly, unproxied. signal-cli has no proxy support of any
+  kind, so the field is gone; if you had it set, siggy exits with an
+  explanation and pointers to OS-level alternatives (JVM proxy properties
+  via `JAVA_TOOL_OPTIONS`, proxychains). If you relied on this setting
+  for privacy, be aware your traffic was never proxied.
+
 ## v1.14.0
 
 The foundation release for the native backend epic

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.14.0                                 │t too                   │
+                     ││[0│  siggy v1.14.1                                 │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

Patch release for #656 (broken proxy config, fixed in #657):

- `Cargo.toml` + `Cargo.lock`: 1.14.0 -> 1.14.1
- About overlay snapshot refreshed for the new version string
- Docsite changelog entry for v1.14.1, including the privacy note that traffic was never proxied

After merge: tag `v1.14.1`, push the tag (release workflow builds the four binaries), then `cargo publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)