### PR TITLE
feat(native): U10 device linking + store-backed link_state

### DIFF
--- a/src/backend/native/linking.rs
+++ b/src/backend/native/linking.rs
@@ -1,0 +1,219 @@
+//! Native device linking + link-state probe (#642 U10, plan R4/R5/R8).
+//!
+//! The provisioning flow is the spike's link leg (#639 findings) as
+//! production code: `Manager::link_secondary_device` runs on a dedicated
+//! [`EngineThread`] (its store futures are `!Send`), the provisioning URL
+//! crosses back over presage's oneshot, and the caller renders it with the
+//! backend-agnostic QR path in `crate::link`. Device name is "siggy",
+//! matching the signal-cli convention in `link.rs`.
+//!
+//! The link-state probe reads the store's registration row directly
+//! (`StateStore::is_registered`), replacing U9's always-Unlinked stub: every
+//! "am I linked?" surface (`--check`, startup gating, the wizard) now
+//! answers from the same store the engine will use.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use presage::libsignal_service::configuration::SignalServers;
+use presage::manager::Manager;
+use presage::model::identity::OnNewIdentity;
+use presage::store::StateStore;
+use presage_store_sqlite::SqliteStore;
+
+use crate::config::Config;
+use crate::signal::types::LinkState;
+
+use super::runtime::EngineThread;
+use super::store;
+
+/// Device name shown in the phone's Linked Devices list. Same value the
+/// signal-cli flow passes via `link -n` (see `link.rs`).
+const DEVICE_NAME: &str = "siggy";
+
+/// An in-flight native provisioning session: owns the engine thread running
+/// `link_secondary_device` between "URI obtained" and "handshake complete".
+/// The `LinkSession` twin for the native engine (plan U5 seam, step 2).
+pub struct NativeLinkSession {
+    engine: Option<EngineThread<Result<(), String>>>,
+}
+
+/// What one non-blocking [`NativeLinkSession::poll`] observed. Mirrors the
+/// signal-cli session's poll vocabulary in `link.rs`.
+pub enum NativeLinkPoll {
+    /// Handshake still in progress; keep showing the QR.
+    Pending,
+    /// The device was linked successfully.
+    Completed,
+}
+
+impl NativeLinkSession {
+    /// Non-blocking completion check. Errors carry presage's failure detail
+    /// (timeout, rate limit, rejected handshake) the way the signal-cli
+    /// session surfaces stderr.
+    pub async fn poll(&mut self) -> Result<NativeLinkPoll> {
+        let finished = self
+            .engine
+            .as_ref()
+            .is_some_and(|engine| engine.is_finished());
+        if !finished {
+            return Ok(NativeLinkPoll::Pending);
+        }
+        let engine = self
+            .engine
+            .take()
+            .context("link session polled after completion")?;
+        // is_finished() was true, so this join returns without blocking.
+        match engine.join() {
+            Ok(Ok(())) => Ok(NativeLinkPoll::Completed),
+            Ok(Err(e)) => anyhow::bail!("device linking failed: {e}"),
+            Err(_) => anyhow::bail!("device linking thread panicked"),
+        }
+    }
+
+    /// Abort the session (user cancelled). presage's provisioning future has
+    /// no cancellation handle, so the engine thread is detached: it exits on
+    /// its own when the provisioning window times out (~1 min). Safe because
+    /// an interrupted handshake leaves the store unregistered (spike finding:
+    /// a failed attempt does not corrupt the store, and `clear_registration`
+    /// runs at the start of the next attempt).
+    pub async fn cancel(&mut self) {
+        self.engine = None;
+    }
+}
+
+/// Obtain a provisioning URI by starting `link_secondary_device` on an
+/// engine thread (plan U5 seam, step 1). Returns the URI for the
+/// backend-agnostic QR renderer plus the session to poll for completion.
+pub async fn start_link_session(config: &Config) -> Result<(String, NativeLinkSession)> {
+    store::ensure_store_dir(&config.account)?;
+    let store_file = store::store_file(&config.account);
+    let (tx, rx) = futures::channel::oneshot::channel();
+
+    let engine = EngineThread::spawn("siggy-native-link", move || async move {
+        let store = match open_store(&store_file).await {
+            Ok(store) => store,
+            Err(e) => return Err(format!("{e:#}")),
+        };
+        match Manager::link_secondary_device(
+            store,
+            SignalServers::Production,
+            DEVICE_NAME.to_string(),
+            tx,
+        )
+        .await
+        {
+            // The manager drops here by design: U10 only proves the link and
+            // persists registration to the store. U11's receive supervisor
+            // owns a long-lived Manager.
+            Ok(_manager) => Ok(()),
+            Err(e) => Err(e.to_string()),
+        }
+    })
+    .context("Failed to spawn native link thread")?;
+
+    match rx.await {
+        Ok(url) => Ok((
+            url.to_string(),
+            NativeLinkSession {
+                engine: Some(engine),
+            },
+        )),
+        Err(_) => {
+            // The sender dropped without a URL: the engine future failed
+            // before provisioning started. Join for the real error.
+            let detail = match engine.join() {
+                Ok(Err(e)) => e,
+                Ok(Ok(())) => "engine exited before producing a provisioning URL".to_string(),
+                Err(_) => "engine thread panicked".to_string(),
+            };
+            anyhow::bail!("Failed to start device linking: {detail}")
+        }
+    }
+}
+
+/// Real link-state probe (replaces U9's always-Unlinked stub): open the
+/// account's store and read its registration row. Runs on an engine thread
+/// because the store futures are `!Send`; the join is wrapped in
+/// `spawn_blocking` so the probe never blocks the caller's runtime.
+pub async fn link_state(config: &Config) -> LinkState {
+    link_state_of_store(store::store_file(&config.account)).await
+}
+
+/// Testable core of [`link_state`], keyed by store file path.
+///
+/// Mapping: no store file → Unlinked (nothing was ever linked); store opens
+/// and `is_registered` → Linked / Unlinked accordingly; store file exists
+/// but cannot be opened → Corrupt (the `--reset-account` recovery path).
+async fn link_state_of_store(store_file: PathBuf) -> LinkState {
+    if !store_file.exists() {
+        return LinkState::Unlinked;
+    }
+    let probe = EngineThread::spawn("siggy-native-linkstate", move || async move {
+        match open_store(&store_file).await {
+            Ok(store) => {
+                if store.is_registered().await {
+                    LinkState::Linked
+                } else {
+                    LinkState::Unlinked
+                }
+            }
+            Err(_) => LinkState::Corrupt,
+        }
+    });
+    let Ok(probe) = probe else {
+        // Cannot even spawn a thread; report the unusable-store state so
+        // `--check` fails loudly rather than pretending to be unlinked.
+        return LinkState::Corrupt;
+    };
+    tokio::task::spawn_blocking(move || probe.join())
+        .await
+        .ok()
+        .and_then(|joined| joined.ok())
+        .unwrap_or(LinkState::Corrupt)
+}
+
+async fn open_store(store_file: &std::path::Path) -> Result<SqliteStore> {
+    let path = store_file
+        .to_str()
+        .context("native store path is not valid UTF-8")?;
+    SqliteStore::open(path, OnNewIdentity::Trust)
+        .await
+        .with_context(|| format!("Failed to open native store at {}", store_file.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn link_state_missing_store_is_unlinked() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = link_state_of_store(dir.path().join("nope.sqlite")).await;
+        assert_eq!(state, LinkState::Unlinked);
+    }
+
+    #[tokio::test]
+    async fn link_state_fresh_store_is_unlinked() {
+        // A store presage created but never linked (e.g. cancelled QR):
+        // opens fine, no registration row.
+        let dir = tempfile::tempdir().unwrap();
+        let store_file = dir.path().join("store.sqlite");
+        open_store(&store_file).await.expect("create fresh store");
+        let state = link_state_of_store(store_file).await;
+        assert_eq!(state, LinkState::Unlinked);
+    }
+
+    #[tokio::test]
+    async fn link_state_garbage_store_is_corrupt() {
+        let dir = tempfile::tempdir().unwrap();
+        let store_file = dir.path().join("store.sqlite");
+        std::fs::write(&store_file, b"this is not a sqlite database").unwrap();
+        let state = link_state_of_store(store_file).await;
+        assert_eq!(state, LinkState::Corrupt);
+    }
+
+    // Linked requires real registration data from a completed provisioning
+    // handshake; that is the Tier-3 manual checklist run (plan U10), not a
+    // unit test.
+}

--- a/src/backend/native/mod.rs
+++ b/src/backend/native/mod.rs
@@ -1,11 +1,12 @@
 //! Native in-process Signal engine (#642, plan U9-U12).
 //!
-//! U9 skeleton: the pinned presage dependency tree compiles, the per-account
-//! store path resolves ([`store`]), and the `!Send` runtime shim exists
-//! ([`runtime`]). The [`Backend`] impl is an honest stub: a native build
-//! launches, says so in the status line, and does nothing else. Linking
-//! lands with U10, receive with U11, send with U12.
+//! U9 landed the skeleton (pinned presage tree, per-account store paths in
+//! [`store`], the `!Send` runtime shim in [`runtime`]); U10 adds device
+//! linking and the real store-backed link-state probe ([`linking`]). The
+//! [`Backend`] impl remains an honest stub for receive/send: those land
+//! with U11/U12.
 
+pub mod linking;
 pub mod runtime;
 pub mod store;
 
@@ -29,14 +30,13 @@ impl NativeBackend {
     }
 
     /// Instance-free link-state probe, same signature as
-    /// `SignalCliBackend::link_state` (plan U5, flow gap G1).
-    ///
-    /// U9 stub: always [`LinkState::Unlinked`]. Truthful for the skeleton
-    /// (nothing can have linked through it), but it does NOT yet inspect the
-    /// store; U10 replaces this with a real registration read so relinked /
-    /// pre-existing stores answer correctly.
-    pub async fn link_state(_config: &Config) -> LinkState {
-        LinkState::Unlinked
+    /// `SignalCliBackend::link_state` (plan U5, flow gap G1). Reads the
+    /// account's store registration row (#642 U10); note this reflects
+    /// LOCAL state - a device unlinked from the phone still reads Linked
+    /// until the engine's next connection attempt fails (same caveat as
+    /// signal-cli's probe).
+    pub async fn link_state(config: &Config) -> LinkState {
+        linking::link_state(config).await
     }
 }
 

--- a/src/backend/native/runtime.rs
+++ b/src/backend/native/runtime.rs
@@ -47,6 +47,13 @@ impl<T: Send + 'static> EngineThread<T> {
     pub fn join(self) -> thread::Result<T> {
         self.handle.join()
     }
+
+    /// Non-blocking completion check, for callers that poll from an event
+    /// loop (U10's linking session). True once the engine future has
+    /// finished; [`join`](EngineThread::join) then returns without blocking.
+    pub fn is_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
 }
 
 #[cfg(test)]

--- a/src/link.rs
+++ b/src/link.rs
@@ -7,8 +7,11 @@
 //! `link_state()` wraps) - are signal-cli-shaped, spawning `signal-cli link`
 //! and reading its stdout/exit code. The QR rendering and screen flow
 //! ([`render_qr_lines`], `show_qr_and_wait`) are backend-agnostic and stay
-//! unchanged; U10 implements the same three-step seam natively via presage's
-//! `link_secondary_device` and reuses the rendering as-is.
+//! unchanged. U10 (#642) implements the same three-step seam natively via
+//! presage's `link_secondary_device` (`backend::native::linking`); the
+//! cfg-selected `ActiveLinkSession` / `ActivePoll` aliases pick the
+//! compiled-in engine's session, and everything downstream of the URI is
+//! shared.
 
 use std::io;
 use std::time::Duration;
@@ -23,10 +26,24 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
 };
+#[cfg(feature = "signal-cli-backend")]
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+#[cfg(feature = "signal-cli-backend")]
 use tokio::process::Command;
 
 use crate::config::Config;
+
+/// The compiled-in engine's provisioning session and poll vocabulary. Both
+/// sessions expose the same `poll`/`cancel` shape, so `show_qr_and_wait`
+/// compiles against whichever the feature selects.
+#[cfg(feature = "signal-cli-backend")]
+type ActiveLinkSession = LinkSession;
+#[cfg(feature = "signal-cli-backend")]
+use LinkPoll as ActivePoll;
+#[cfg(feature = "native-backend")]
+type ActiveLinkSession = crate::backend::native::linking::NativeLinkSession;
+#[cfg(feature = "native-backend")]
+use crate::backend::native::linking::NativeLinkPoll as ActivePoll;
 
 /// Result of a device-linking flow.
 pub enum LinkResult {
@@ -76,13 +93,15 @@ pub async fn check_account_registered(config: &Config) -> Result<bool> {
 
 /// An in-flight signal-cli provisioning session (plan U5, #640): owns the
 /// `signal-cli link` child between "URI obtained" and "handshake complete".
-/// Engine-specific step 2 of the linking seam; U10's native backend replaces
-/// this with presage's provisioning future behind the same poll shape.
+/// Engine-specific step 2 of the linking seam; the native twin is
+/// `backend::native::linking::NativeLinkSession` (#642 U10).
+#[cfg(feature = "signal-cli-backend")]
 struct LinkSession {
     child: tokio::process::Child,
 }
 
 /// What one non-blocking [`LinkSession::poll`] observed.
+#[cfg(feature = "signal-cli-backend")]
 enum LinkPoll {
     /// Handshake still in progress; keep showing the QR.
     Pending,
@@ -90,6 +109,7 @@ enum LinkPoll {
     Completed,
 }
 
+#[cfg(feature = "signal-cli-backend")]
 impl LinkSession {
     /// Non-blocking completion check. Failure errors carry signal-cli's
     /// stderr detail, byte-identical to the old inline `try_wait` handling
@@ -129,9 +149,17 @@ impl LinkSession {
     }
 }
 
+/// Obtain a provisioning URI from the compiled-in engine (plan U5, #640):
+/// engine-specific step 1 of the linking seam, native arm (#642 U10).
+#[cfg(feature = "native-backend")]
+async fn start_link_session(config: &Config) -> Result<(String, ActiveLinkSession)> {
+    crate::backend::native::linking::start_link_session(config).await
+}
+
 /// Obtain a provisioning URI by spawning `signal-cli link` (plan U5, #640):
 /// engine-specific step 1 of the linking seam. Returns the URI (for the
 /// backend-agnostic QR renderer) plus the session to poll for completion.
+#[cfg(feature = "signal-cli-backend")]
 async fn start_link_session(config: &Config) -> Result<(String, LinkSession)> {
     // Spawn signal-cli link
     let mut child = Command::new(&config.signal_cli_path)
@@ -273,7 +301,7 @@ fn render_qr_lines(qr: &qrcode::QrCode) -> Vec<Line<'static>> {
 async fn show_qr_and_wait(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     qr_lines: &[Line<'static>],
-    session: &mut LinkSession,
+    session: &mut ActiveLinkSession,
 ) -> Result<LinkResult> {
     loop {
         // Draw
@@ -282,7 +310,7 @@ async fn show_qr_and_wait(
         // Check if the handshake finished (non-blocking); failure details
         // propagate as errors from the session poll.
         match session.poll().await? {
-            LinkPoll::Completed => {
+            ActivePoll::Completed => {
                 // Show success briefly
                 terminal.draw(|frame| {
                     let msg = Paragraph::new("Device linked successfully!")
@@ -294,7 +322,7 @@ async fn show_qr_and_wait(
                 tokio::time::sleep(Duration::from_secs(2)).await;
                 return Ok(LinkResult::Success);
             }
-            LinkPoll::Pending => {} // Still running
+            ActivePoll::Pending => {} // Still running
         }
 
         // Poll for keyboard input

--- a/src/main.rs
+++ b/src/main.rs
@@ -962,10 +962,11 @@ async fn run_with_engine(
     result
 }
 
-/// Native engine lifecycle, U9 skeleton (#642): no engine to spawn and no
-/// linking flow yet (U10), so run the UI on the stub adapter. Exists so a
-/// native build is a launchable, inspectable binary rather than a compile
-/// artifact; the status line says exactly what is missing.
+/// Native engine lifecycle (#642): registration gating through the store
+/// probe, fall back to the native linking flow when unlinked (U10), then
+/// run the UI. Still the receive/send stub adapter until U11/U12; there is
+/// no engine process to spawn or shut down - the linking session owns its
+/// own thread and the store is the only persistent artifact.
 #[cfg(feature = "native-backend")]
 async fn run_with_engine(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
@@ -973,8 +974,29 @@ async fn run_with_engine(
     database: db::Database,
     incognito: bool,
     config_path: &std::path::Path,
-    _setup_handled_linking: bool,
+    setup_handled_linking: bool,
 ) -> Result<()> {
+    // Same gate order as the signal-cli arm: anything short of Linked falls
+    // back to the linking flow. Corrupt also lands here - the flow's
+    // provisioning restart clears the registration row (presage calls
+    // clear_registration at session start), which is the native equivalent
+    // of the #603 relink path.
+    if !setup_handled_linking
+        && backend::native::NativeBackend::link_state(config).await != LinkState::Linked
+    {
+        match link::run_linking_flow(terminal, config).await {
+            Ok(link::LinkResult::Success) => {}
+            Ok(link::LinkResult::Cancelled) => {
+                return Ok(());
+            }
+            Err(e) => {
+                let msg = format!("{e}");
+                show_error_screen(terminal, "Device Linking Failed", &msg).await?;
+                return Ok(());
+            }
+        }
+    }
+
     run_app(
         terminal,
         backend::ActiveBackend::new(),
@@ -987,9 +1009,6 @@ async fn run_with_engine(
 }
 
 /// Show a full-screen error in the TUI instead of crashing to stderr.
-// Unused under the U9 native skeleton (its run_with_engine has no failure
-// paths yet); U10's native linking flow starts calling this again.
-#[cfg_attr(feature = "native-backend", allow(dead_code))]
 async fn show_error_screen(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     title: &str,


### PR DESCRIPTION
## Summary

Part of #642 (Phase 2), second unit. A native-build user can now link as a secondary device end-to-end through the existing wizard/QR UX, and every "am I linked?" surface answers from the store.

### Linking (`backend/native/linking.rs`)

- `start_link_session` runs `Manager::link_secondary_device` on a dedicated `EngineThread` (store futures are !Send), delivers the provisioning URI over presage's oneshot, and exposes the same poll/cancel shape as the signal-cli `LinkSession`
- Device name "siggy", matching the signal-cli convention
- Cancel detaches the engine thread: presage has no provisioning abort handle, and the spike proved an interrupted handshake leaves the store unregistered (next attempt runs `clear_registration` first)
- Manager is dropped after linking by design; U11's receive supervisor owns a long-lived Manager

### Real link-state probe

Opens the account's store and reads `StateStore::is_registered`:

| Store state | Result |
|---|---|
| no file | Unlinked |
| opens, no registration row | Unlinked |
| file exists, cannot open | Corrupt |

Replaces U9's always-Unlinked stub. Same local-state caveat as the signal-cli probe: a device unlinked from the phone reads Linked until the next connection attempt fails.

### Flow integration

- `link.rs`: cfg-selected `ActiveLinkSession`/`ActivePoll` aliases pick the compiled-in engine; QR rendering and the wait screen are shared verbatim (zero changes to the rendering path)
- `main.rs`: the native `run_with_engine` gains the same registration gate as the signal-cli arm - probe, fall back to the linking flow, then run the app. Corrupt lands in the same flow (the native #603 relink equivalent)

## Testing

- Both lanes clippy `-D warnings` clean
- Native: 900 + 261 tests pass (new: `link_state` on missing / fresh-but-unregistered / garbage stores, `EngineThread::is_finished`)
- Default: 893 + 261 unchanged
- **Tier-3 live link is pending**: one manual wizard run against production Signal on a native build (takes a device slot; same routine as the spike). Happy to do this before or after merge per the maintainer's preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)