### PR TITLE
fix: MSRV declaration + crates.io publish path for the git-dep tree (closes #668)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,37 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+  # MSRV canary (#668): Cargo.toml declares rust-version so users on an old
+  # toolchain get a clean "requires rustc X" error instead of an E0658 deep
+  # inside a dependency; this lane proves the declared floor still compiles
+  # the default tree. Plain `cargo check`, no -D warnings: older rustc's
+  # dead-code analysis differs from the pinned toolchain's, and lint drift
+  # is not an MSRV break. Not in the required-check set (see note on the
+  # native lane below).
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: echo "msrv=$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.msrv }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: msrv
+
+      - name: Check (default features)
+        env:
+          # override rust-toolchain.toml's pin for this job only
+          RUSTUP_TOOLCHAIN: ${{ steps.msrv.outputs.msrv }}
+        run: cargo check --locked
+
   # The native-backend feature lane (#640 U7). Informational until Phase 3
   # (#643) per the plan's R11 schedule: pre-U9 the feature intentionally
   # stops at a compile_error! marker, and during Phases 0-2 upstream churn

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4283,7 +4283,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "siggy"
-version = "1.14.1"
+version = "1.14.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "siggy"
-version = "1.14.1"
+version = "1.14.2"
 edition = "2024"
+# Verified floor of the default (signal-cli-backend) dependency tree, enforced
+# by the CI msrv job. Without this, users on older toolchains get an opaque
+# compile error deep inside a dependency instead of a clean cargo error (#668).
+rust-version = "1.90"
 license = "AGPL-3.0-only"
 description = "Terminal-based Signal messenger client with vim keybindings"
 repository = "https://github.com/johnsideserf/siggy"
@@ -29,7 +33,11 @@ include = [
 [features]
 default = ["signal-cli-backend"]
 signal-cli-backend = []
+# BEGIN CRATES-IO-STRIP (scripts/publish-crate.sh removes marked blocks: git
+# dependencies cannot be published to crates.io, so the crates.io artifact is
+# signal-cli-backend only, which is the only supported engine there anyway)
 native-backend = ["dep:presage", "dep:presage-store-sqlite", "dep:futures"]
+# END CRATES-IO-STRIP
 
 [package.metadata.docs.rs]
 # Build with the default backend only; --all-features would hit the
@@ -64,6 +72,7 @@ emojis = "0.9"
 icy_sixel = "0.5"
 ureq = "3.3.0"
 
+# BEGIN CRATES-IO-STRIP
 # Native engine deps (#642 U9), active only under `native-backend`. Pinned to
 # the spike-validated rev (#639 findings): main HEAD of 2026-07-07 (63482efd),
 # the first rev with the merged linking fix (upstream presage PR #421,
@@ -84,15 +93,18 @@ optional = true
 [dependencies.futures]
 version = "0.3"
 optional = true
+# END CRATES-IO-STRIP
 
 [dev-dependencies]
 insta = "1"
 rstest = "0.26"
 tempfile = "3"
 
+# BEGIN CRATES-IO-STRIP
 # Required by the libsignal dependency tree whenever presage is in the graph
 # (presage README documents this for all downstream consumers). Inert for
 # default builds: the patched crate only enters the graph under
 # `native-backend`. Spike finding, #639.
 [patch.crates-io]
 curve25519-dalek = { git = "https://github.com/signalapp/curve25519-dalek", tag = "signal-curve25519-4.1.3" }
+# END CRATES-IO-STRIP

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v1.14.2
+
+Patch release for `cargo install siggy` failing on Rust toolchains older
+than 1.95 ([#668](https://github.com/johnsideserf/siggy/issues/668)).
+
+### Fixed
+
+- **`cargo install siggy` no longer requires a bleeding-edge Rust
+  toolchain.** v1.14.1 depended on rusqlite 0.40, whose libsqlite3-sys
+  0.38.1 build script uses the `cfg_select!` macro stabilized only in
+  Rust 1.95 (April 2026), failing on older toolchains with an opaque
+  `E0658` error. siggy now builds against rusqlite 0.38 / libsqlite3-sys
+  0.36, and declares an explicit `rust-version = "1.90"` (verified in CI)
+  so a too-old toolchain gets a clear, actionable error from cargo
+  instead.
+
 ## v1.14.1
 
 Patch release for the broken proxy config

--- a/scripts/publish-crate.sh
+++ b/scripts/publish-crate.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Publish siggy to crates.io with the native-backend git dependencies
+# stripped (#668 follow-up).
+#
+# crates.io rejects manifests with git dependencies, and presage is not
+# published there, so the crates.io artifact ships the signal-cli backend
+# only. That matches reality: the native backend cannot be built from a
+# crates.io install regardless (its deps only exist as a pinned git tree).
+#
+# The script works on a throwaway git worktree of HEAD, deletes every
+# block in Cargo.toml between "BEGIN CRATES-IO-STRIP" and
+# "END CRATES-IO-STRIP" markers, and publishes from there. The repo tree
+# is never modified.
+#
+# Usage:
+#   scripts/publish-crate.sh          # dry run (verify build, no upload)
+#   scripts/publish-crate.sh --live   # actually publish
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree is dirty; publish from a clean release commit" >&2
+    exit 1
+fi
+
+live=0
+if [[ "${1:-}" == "--live" ]]; then
+    live=1
+elif [[ $# -gt 0 ]]; then
+    echo "usage: $0 [--live]" >&2
+    exit 1
+fi
+
+worktree=$(mktemp -d "${TMPDIR:-/tmp}/siggy-publish.XXXXXX")
+cleanup() {
+    git worktree remove --force "$worktree" 2>/dev/null || true
+    rm -rf "$worktree"
+}
+trap cleanup EXIT
+
+git worktree add --detach "$worktree" HEAD >/dev/null
+
+sed -i '/BEGIN CRATES-IO-STRIP/,/END CRATES-IO-STRIP/d' "$worktree/Cargo.toml"
+
+if grep -qE '^\s*git = |^\[patch\.' "$worktree/Cargo.toml"; then
+    echo "error: strip markers did not cover every git dependency; check Cargo.toml" >&2
+    exit 1
+fi
+
+# The stripped manifest no longer matches the committed lockfile (the
+# presage tree drops out). Let cargo prune it in the worktree copy.
+(cd "$worktree" && cargo update --workspace --offline >/dev/null 2>&1 || cargo update --workspace >/dev/null)
+
+echo "== stripped manifest diff =="
+diff Cargo.toml "$worktree/Cargo.toml" || true
+echo "============================"
+
+if [[ $live -eq 1 ]]; then
+    (cd "$worktree" && cargo publish --allow-dirty)
+else
+    (cd "$worktree" && cargo publish --dry-run --allow-dirty)
+    echo
+    echo "Dry run complete. Re-run with --live to upload to crates.io."
+fi

--- a/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
+++ b/src/ui/snapshots/siggy__ui__snapshot_tests__about_overlay.snap
@@ -13,7 +13,7 @@ expression: output
                      ││● [08:25] <you> That's what everyone says...                                │
                      ││[0╭ About ─────────────────────────────────────────╮tomatic                 │
                      ││  │                                                │                        │
-                     ││[0│  siggy v1.14.1                                 │t too                   │
+                     ││[0│  siggy v1.14.2                                 │t too                   │
                      ││✓ │                                                │                        │
                      ││[0│  A terminal Signal messenger client            │                        │
                      ││[0│                                                │/localmarket.example.com│


### PR DESCRIPTION
## Summary

`cargo install siggy` (v1.14.1) fails on Rust toolchains older than 1.95 (#668). Root cause: rusqlite 0.40 pulls libsqlite3-sys 0.38.1, whose build script uses the `cfg_select!` macro stabilized only in Rust 1.95. Neither crate declares an MSRV, so older toolchains die with a raw E0658 deep in a dependency.

This PR fixes the class of problem and unblocks the v1.14.2 patch release:

- **Declare `rust-version = "1.90"`** in Cargo.toml, the verified floor of the default dependency tree (wide 0.8.3 requires 1.89, quantette 0.5.1 requires 1.90; 1.85 and 1.89 fail, 1.90 compiles the full default build). Too-old toolchains now get a clean, actionable cargo error.
- **New CI `msrv` lane** that checks the declared floor actually compiles (plain `cargo check --locked`, no `-D warnings` since old rustc's dead-code analysis differs from the 1.95 pin). Reads the MSRV from Cargo.toml so there is one source of truth. Additive job, required-check names untouched.
- **`scripts/publish-crate.sh`**: crates.io rejects git dependencies, so master has been unpublishable since the U9 presage deps landed (verified with `cargo package`; presage-store-sqlite has no registry release at all). The script publishes from a throwaway worktree with the marker-delimited native-backend blocks stripped from Cargo.toml. The crates.io artifact is signal-cli-backend only, which matches reality: the native engine can only build from the pinned git tree. Dry-run by default, `--live` to upload.
- **Version bump to 1.14.2** (about overlay snapshot + docsite changelog included). Publishing from this tree also drops the effective dependency floor back below `cfg_select`, since master already carries the U9 rusqlite 0.40 -> 0.38 downgrade.

## Testing

- `cargo +1.85.0` / `+1.89.0` check fail with the expected dep MSRV errors; `cargo +1.90.0 check --locked` compiles clean
- Strip logic verified against the current manifest: no `git =` or `[patch.*]` lines survive, and the script hard-fails if any do
- `cargo clippy --locked --tests -- -D warnings` clean, 893 + 261 tests pass

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)