### PR TITLE
feat(native): U11 stage 2 - receive supervisor with durable journal (part of #642)

### DIFF
--- a/src/backend/native/journal.rs
+++ b/src/backend/native/journal.rs
@@ -1,0 +1,449 @@
+//! Durable receive journal (#642 U11, plan KTD-2).
+//!
+//! libsignal-service acks each envelope on the websocket *before* yielding
+//! it to the stream, so anything the process has pulled but not persisted
+//! is gone if it crashes. The contract: the engine thread appends each
+//! mapped event here, on its own connection, before pulling the next
+//! stream item; the main thread deletes the row after committing the
+//! event's effects; startup replays leftovers, and the v16 entry_seq dedup
+//! index makes replays silent.
+//!
+//! PLAN DEVIATION (documented for the U19 gate): plan U6 had the adapter
+//! writing finished rows straight into `messages` from its own connection.
+//! That is not implementable - `messages` rows store app-resolved display
+//! data (contact names, conversation upserts, unread counts) that only the
+//! main thread's state can produce. The journal keeps U6's durability
+//! ordering (persist-before-next-pull, second connection, busy_timeout)
+//! while leaving row production where the data lives. Same crash windows,
+//! same dedup discipline.
+//!
+//! Payload rows are JSON of [`JournalEvent`], a mirror of the
+//! persistent-effect subset of [`SignalEvent`]. Rows normally live
+//! milliseconds; a row that survives a crash *and* a version upgrade whose
+//! payload no longer parses is logged and dropped (the envelope was acked
+//! either way - this is the documented residual window, not a new one).
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use rusqlite::{Connection, params};
+use serde::{Deserialize, Serialize};
+
+use crate::signal::types::{ReceiptKind, SignalEvent, SignalMessage};
+
+/// The journaled subset of [`SignalEvent`]: exactly the variants whose loss
+/// at a crash would be user-visible data loss. Transient events (typing,
+/// sync lifecycle, directory refreshes) are deliberately absent - they are
+/// re-derivable or harmless to drop.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum JournalEvent {
+    Message(SignalMessage),
+    Receipt {
+        sender: String,
+        receipt_type: ReceiptKind,
+        timestamps: Vec<i64>,
+    },
+    Reaction {
+        conv_id: String,
+        emoji: String,
+        sender: String,
+        sender_name: Option<String>,
+        target_author: String,
+        target_timestamp: i64,
+        is_remove: bool,
+    },
+    Edit {
+        conv_id: String,
+        sender: String,
+        sender_name: Option<String>,
+        target_timestamp: i64,
+        new_body: String,
+        new_timestamp: i64,
+        is_outgoing: bool,
+    },
+    RemoteDelete {
+        conv_id: String,
+        sender: String,
+        target_timestamp: i64,
+    },
+    TimerChange {
+        conv_id: String,
+        seconds: i64,
+        body: String,
+        timestamp_ms: i64,
+    },
+    System {
+        conv_id: String,
+        body: String,
+        timestamp_ms: i64,
+    },
+    ReadSync {
+        read_messages: Vec<(String, i64)>,
+    },
+}
+
+/// Millisecond timestamp → the `DateTime<Utc>` twin the event variants
+/// carry. Out-of-range values clamp to epoch, matching the mapper's own
+/// fallback behavior.
+fn ts_utc(ms: i64) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::from_timestamp_millis(ms).unwrap_or_default()
+}
+
+impl JournalEvent {
+    /// The journal twin of a boundary event, `None` when the event is
+    /// transient and not worth a durable row.
+    pub fn from_signal(event: &SignalEvent) -> Option<Self> {
+        match event {
+            SignalEvent::MessageReceived(msg) => Some(Self::Message(msg.clone())),
+            SignalEvent::ReceiptReceived {
+                sender,
+                receipt_type,
+                timestamps,
+            } => Some(Self::Receipt {
+                sender: sender.clone(),
+                receipt_type: *receipt_type,
+                timestamps: timestamps.clone(),
+            }),
+            SignalEvent::ReactionReceived {
+                conv_id,
+                emoji,
+                sender,
+                sender_name,
+                target_author,
+                target_timestamp,
+                is_remove,
+            } => Some(Self::Reaction {
+                conv_id: conv_id.clone(),
+                emoji: emoji.clone(),
+                sender: sender.clone(),
+                sender_name: sender_name.clone(),
+                target_author: target_author.clone(),
+                target_timestamp: *target_timestamp,
+                is_remove: *is_remove,
+            }),
+            SignalEvent::EditReceived {
+                conv_id,
+                sender,
+                sender_name,
+                target_timestamp,
+                new_body,
+                new_timestamp,
+                is_outgoing,
+            } => Some(Self::Edit {
+                conv_id: conv_id.clone(),
+                sender: sender.clone(),
+                sender_name: sender_name.clone(),
+                target_timestamp: *target_timestamp,
+                new_body: new_body.clone(),
+                new_timestamp: *new_timestamp,
+                is_outgoing: *is_outgoing,
+            }),
+            SignalEvent::RemoteDeleteReceived {
+                conv_id,
+                sender,
+                target_timestamp,
+            } => Some(Self::RemoteDelete {
+                conv_id: conv_id.clone(),
+                sender: sender.clone(),
+                target_timestamp: *target_timestamp,
+            }),
+            SignalEvent::ExpirationTimerChanged {
+                conv_id,
+                seconds,
+                body,
+                timestamp_ms,
+                ..
+            } => Some(Self::TimerChange {
+                conv_id: conv_id.clone(),
+                seconds: *seconds,
+                body: body.clone(),
+                timestamp_ms: *timestamp_ms,
+            }),
+            SignalEvent::SystemMessage {
+                conv_id,
+                body,
+                timestamp_ms,
+                ..
+            } => Some(Self::System {
+                conv_id: conv_id.clone(),
+                body: body.clone(),
+                timestamp_ms: *timestamp_ms,
+            }),
+            SignalEvent::ReadSyncReceived { read_messages } => Some(Self::ReadSync {
+                read_messages: read_messages.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// Back to the boundary vocabulary for replay through
+    /// `App::handle_signal_event`.
+    pub fn into_signal(self) -> SignalEvent {
+        match self {
+            Self::Message(msg) => SignalEvent::MessageReceived(msg),
+            Self::Receipt {
+                sender,
+                receipt_type,
+                timestamps,
+            } => SignalEvent::ReceiptReceived {
+                sender,
+                receipt_type,
+                timestamps,
+            },
+            Self::Reaction {
+                conv_id,
+                emoji,
+                sender,
+                sender_name,
+                target_author,
+                target_timestamp,
+                is_remove,
+            } => SignalEvent::ReactionReceived {
+                conv_id,
+                emoji,
+                sender,
+                sender_name,
+                target_author,
+                target_timestamp,
+                is_remove,
+            },
+            Self::Edit {
+                conv_id,
+                sender,
+                sender_name,
+                target_timestamp,
+                new_body,
+                new_timestamp,
+                is_outgoing,
+            } => SignalEvent::EditReceived {
+                conv_id,
+                sender,
+                sender_name,
+                target_timestamp,
+                new_body,
+                new_timestamp,
+                is_outgoing,
+            },
+            Self::RemoteDelete {
+                conv_id,
+                sender,
+                target_timestamp,
+            } => SignalEvent::RemoteDeleteReceived {
+                conv_id,
+                sender,
+                target_timestamp,
+            },
+            Self::TimerChange {
+                conv_id,
+                seconds,
+                body,
+                timestamp_ms,
+            } => SignalEvent::ExpirationTimerChanged {
+                conv_id,
+                seconds,
+                body,
+                timestamp: ts_utc(timestamp_ms),
+                timestamp_ms,
+            },
+            Self::System {
+                conv_id,
+                body,
+                timestamp_ms,
+            } => SignalEvent::SystemMessage {
+                conv_id,
+                body,
+                timestamp: ts_utc(timestamp_ms),
+                timestamp_ms,
+            },
+            Self::ReadSync { read_messages } => SignalEvent::ReadSyncReceived { read_messages },
+        }
+    }
+}
+
+/// The engine thread's own connection to siggy.db, used exclusively for
+/// journal appends (plan U6 topology: second connection, busy_timeout on
+/// both sides, so adapter writes queue behind a busy main thread instead of
+/// erroring). WAL is a database-level property already set by the main
+/// connection; `synchronous=NORMAL` matches it - commits survive app
+/// crash (the KTD-2 bar), not power loss.
+pub struct JournalWriter {
+    conn: Connection,
+}
+
+impl JournalWriter {
+    pub fn open(db_path: &Path) -> Result<Self> {
+        let conn = Connection::open(db_path)
+            .with_context(|| format!("open journal connection to {}", db_path.display()))?;
+        conn.execute_batch("PRAGMA synchronous=NORMAL;")?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        Ok(Self { conn })
+    }
+
+    /// Durably append one event; returns the row id the main thread deletes
+    /// after processing. The INSERT autocommits, so when this returns the
+    /// row survives an app crash - the caller may then (and only then) pull
+    /// the next stream item (KTD-2 ordering).
+    pub fn append(&self, event: &JournalEvent) -> Result<i64> {
+        let payload = serde_json::to_string(event).context("serialize journal event")?;
+        self.conn.execute(
+            "INSERT INTO native_journal (payload) VALUES (?1)",
+            params![payload],
+        )?;
+        Ok(self.conn.last_insert_rowid())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signal::types::StyleType;
+
+    fn sample_message() -> SignalMessage {
+        SignalMessage {
+            source: "+15550001111".into(),
+            source_name: Some("Ada".into()),
+            source_uuid: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into()),
+            timestamp: ts_utc(1_700_000_000_123),
+            body: Some("hello *world*".into()),
+            group_id: Some("Z3JvdXBpZA==".into()),
+            quote: Some((5, "+15552223333".into(), "quoted".into())),
+            expires_in_seconds: 3600,
+            text_styles: vec![crate::signal::types::TextStyle {
+                start: 6,
+                length: 5,
+                style: StyleType::Bold,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn roundtrip(event: &SignalEvent) -> SignalEvent {
+        let journaled = JournalEvent::from_signal(event).expect("journalable");
+        let json = serde_json::to_string(&journaled).unwrap();
+        let parsed: JournalEvent = serde_json::from_str(&json).unwrap();
+        parsed.into_signal()
+    }
+
+    #[test]
+    fn message_roundtrips_with_full_fidelity() {
+        let event = SignalEvent::MessageReceived(sample_message());
+        match roundtrip(&event) {
+            SignalEvent::MessageReceived(msg) => {
+                let original = sample_message();
+                assert_eq!(msg.source, original.source);
+                assert_eq!(msg.source_name, original.source_name);
+                assert_eq!(msg.timestamp, original.timestamp);
+                assert_eq!(msg.body, original.body);
+                assert_eq!(msg.group_id, original.group_id);
+                assert_eq!(msg.quote, original.quote);
+                assert_eq!(msg.expires_in_seconds, original.expires_in_seconds);
+                assert_eq!(msg.text_styles.len(), 1);
+            }
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn every_persistent_variant_roundtrips() {
+        let events = vec![
+            SignalEvent::ReceiptReceived {
+                sender: "+15550001111".into(),
+                receipt_type: ReceiptKind::Read,
+                timestamps: vec![1, 2],
+            },
+            SignalEvent::ReactionReceived {
+                conv_id: "+15550001111".into(),
+                emoji: "👍".into(),
+                sender: "+15550001111".into(),
+                sender_name: None,
+                target_author: "+15552223333".into(),
+                target_timestamp: 42,
+                is_remove: false,
+            },
+            SignalEvent::EditReceived {
+                conv_id: "+15550001111".into(),
+                sender: "+15550001111".into(),
+                sender_name: None,
+                target_timestamp: 42,
+                new_body: "edited".into(),
+                new_timestamp: 43,
+                is_outgoing: false,
+            },
+            SignalEvent::RemoteDeleteReceived {
+                conv_id: "+15550001111".into(),
+                sender: "+15550001111".into(),
+                target_timestamp: 42,
+            },
+            SignalEvent::ExpirationTimerChanged {
+                conv_id: "+15550001111".into(),
+                seconds: 3600,
+                body: "Disappearing messages set to 1 hour".into(),
+                timestamp: ts_utc(9),
+                timestamp_ms: 9,
+            },
+            SignalEvent::SystemMessage {
+                conv_id: "+15550001111".into(),
+                body: "sys".into(),
+                timestamp: ts_utc(9),
+                timestamp_ms: 9,
+            },
+            SignalEvent::ReadSyncReceived {
+                read_messages: vec![("+15550001111".into(), 42)],
+            },
+        ];
+        for event in &events {
+            // Round-trips without panicking and lands on the same variant.
+            let back = roundtrip(event);
+            assert_eq!(
+                std::mem::discriminant(event),
+                std::mem::discriminant(&back),
+                "variant changed across journal roundtrip: {event:?} -> {back:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn transient_events_are_not_journaled() {
+        for event in [
+            SignalEvent::SyncComplete,
+            SignalEvent::Disconnected,
+            SignalEvent::Error("x".into()),
+            SignalEvent::TypingIndicator {
+                sender: "+15550001111".into(),
+                sender_name: None,
+                is_typing: true,
+                group_id: None,
+            },
+            SignalEvent::ContactList(vec![]),
+            SignalEvent::GroupList(vec![]),
+        ] {
+            assert!(
+                JournalEvent::from_signal(&event).is_none(),
+                "unexpectedly journaled: {event:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn writer_appends_rows_the_main_connection_sees() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("t.db");
+        // Main connection creates the schema (migration 17)...
+        let db = crate::db::Database::open(&file).unwrap();
+        // ...and the adapter connection appends through its own handle.
+        let writer = JournalWriter::open(&file).unwrap();
+        let id = writer
+            .append(
+                &JournalEvent::from_signal(&SignalEvent::MessageReceived(sample_message()))
+                    .unwrap(),
+            )
+            .unwrap();
+        let rows = db.journal_pending().unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].0, id);
+        let parsed: JournalEvent = serde_json::from_str(&rows[0].1).unwrap();
+        assert!(matches!(parsed, JournalEvent::Message(_)));
+        db.journal_delete(id).unwrap();
+        assert!(db.journal_pending().unwrap().is_empty());
+    }
+}

--- a/src/backend/native/mod.rs
+++ b/src/backend/native/mod.rs
@@ -1,33 +1,40 @@
 //! Native in-process Signal engine (#642, plan U9-U12).
 //!
 //! U9 landed the skeleton (pinned presage tree, per-account store paths in
-//! [`store`], the `!Send` runtime shim in [`runtime`]); U10 adds device
-//! linking and the real store-backed link-state probe ([`linking`]). The
-//! [`Backend`] impl remains an honest stub for receive/send: those land
-//! with U11/U12.
+//! [`store`], the `!Send` runtime shim in [`runtime`]); U10 added device
+//! linking and the store-backed link-state probe ([`linking`]); U11 adds
+//! the receive path: the pure mapping layer ([`receive`]), the durable
+//! journal ([`journal`], KTD-2), and the stream supervisor
+//! ([`supervisor`]). Sending remains an honest stub until U12.
 
+pub mod journal;
 pub mod linking;
 pub mod receive;
 pub mod runtime;
 pub mod store;
+pub mod supervisor;
 
 use crate::app::{App, SendRequest};
 use crate::config::Config;
+use crate::debug_log;
 use crate::signal::types::LinkState;
 
 use super::Backend;
+use supervisor::{EngineStatus, ReceiveEngine};
 
 /// User-facing engine name (flow gap G7).
 pub const ENGINE_NAME: &str = "native";
 
-/// The native engine adapter. U9 holds no state; U10-U12 add the
-/// [`runtime::EngineThread`] handle and the mpsc pair the trait methods
-/// drive.
-pub struct NativeBackend;
+/// The native engine adapter: owns the receive supervisor's engine thread
+/// once [`Backend::startup`] spawns it. Send routing (U12) will reuse the
+/// same thread.
+pub struct NativeBackend {
+    engine: Option<ReceiveEngine>,
+}
 
 impl NativeBackend {
     pub fn new() -> Self {
-        Self
+        Self { engine: None }
     }
 
     /// Instance-free link-state probe, same signature as
@@ -47,6 +54,62 @@ impl Default for NativeBackend {
     }
 }
 
+/// KTD-2 crash recovery: replay journal rows the previous process
+/// persisted but never confirmed, through the same pipeline live events
+/// use. The v16 entry_seq dedup index makes rows whose effects already
+/// committed silent, so replaying after any crash point is safe.
+fn replay_journal(app: &mut App) {
+    let rows = match app.db.journal_pending() {
+        Ok(rows) => rows,
+        Err(e) => {
+            debug_log::logf(format_args!("journal replay: read failed: {e}"));
+            return;
+        }
+    };
+    if rows.is_empty() {
+        return;
+    }
+    debug_log::logf(format_args!(
+        "journal replay: {} event(s) from previous session",
+        rows.len()
+    ));
+    for (id, payload) in rows {
+        match serde_json::from_str::<journal::JournalEvent>(&payload) {
+            Ok(event) => app.handle_signal_event(event.into_signal()),
+            // A row that survived a crash AND a version upgrade whose
+            // schema drifted: log and drop (see journal.rs module docs for
+            // why this residual window is accepted).
+            Err(e) => debug_log::logf(format_args!(
+                "journal replay: row {id} unparseable, dropping: {e}"
+            )),
+        }
+        if let Err(e) = app.db.journal_delete(id) {
+            debug_log::logf(format_args!("journal replay: delete {id} failed: {e}"));
+        }
+    }
+}
+
+/// Reflect the supervisor's latest connection status into app state.
+fn apply_status(app: &mut App, status: &EngineStatus) {
+    match status {
+        EngineStatus::Connecting => {
+            app.startup_status = "Connecting to Signal...".to_string();
+        }
+        EngineStatus::Connected => {
+            app.set_connected();
+            app.connection_error = None;
+        }
+        EngineStatus::Reconnecting { attempt } => {
+            app.connected = false;
+            app.status_message = format!("native engine: reconnecting (attempt {attempt})...");
+        }
+        EngineStatus::Terminal(msg) => {
+            app.connected = false;
+            app.connection_error = Some(msg.clone());
+        }
+    }
+}
+
 impl Backend for NativeBackend {
     fn display_name(&self) -> &'static str {
         ENGINE_NAME
@@ -61,21 +124,109 @@ impl Backend for NativeBackend {
     /// U12 routes the send vocabulary through the engine thread. Until
     /// then, surface the truth instead of silently dropping the request.
     async fn dispatch(&mut self, app: &mut App, _req: SendRequest) {
-        app.status_message = "native engine: sending not implemented yet (#642)".to_string();
+        app.status_message = "native engine: sending not implemented yet (#642 U12)".to_string();
     }
 
     async fn startup(&mut self, app: &mut App) {
-        app.connected = false;
+        // Replay before the supervisor spawns so recovered rows cannot
+        // interleave with fresh appends.
+        replay_journal(app);
+
+        app.sweep_expired_messages();
+
+        // G5: loading ends with the store load - the DB read (before
+        // startup) plus the replay above. There is no RPC round-trip to
+        // wait for; the notification-suppressing sync window still runs
+        // until QueueEmpty maps to SyncComplete (KTD-5).
         app.loading = false;
-        app.status_message =
-            "native engine skeleton (#642): linking/receive/send not implemented yet".to_string();
+
+        if !store::account_data_exists(&app.account) {
+            // Unreachable in the normal flow (the linking gate in main.rs
+            // runs first); honest copy instead of a phantom engine if a
+            // store vanishes between the gate and here.
+            app.connected = false;
+            app.connection_error =
+                Some("native engine: no linked account store; restart siggy to link".to_string());
+            return;
+        }
+
+        let journal_db = app.db.path();
+        if journal_db.is_none() {
+            // In-memory DBs exist only in tests; production siggy.db is
+            // always file-backed.
+            debug_log::logf(format_args!(
+                "native startup: in-memory DB, journaling disabled"
+            ));
+        }
+        match supervisor::spawn(store::store_file(&app.account), journal_db) {
+            Ok(engine) => {
+                self.engine = Some(engine);
+                app.startup_status = "Connecting to Signal...".to_string();
+            }
+            Err(e) => {
+                app.connected = false;
+                app.connection_error = Some(format!("native engine failed to start: {e}"));
+            }
+        }
     }
 
-    fn drain_events(&mut self, _app: &mut App) -> bool {
-        false
+    fn drain_events(&mut self, app: &mut App) -> bool {
+        let Some(engine) = self.engine.as_mut() else {
+            return false;
+        };
+        let mut changed = false;
+
+        // Newest connection status wins; the watch channel coalesces.
+        // has_changed errors once the supervisor exits - the Terminal
+        // status it sent beforehand was already consumed, and the closed
+        // event channel below covers unexpected deaths.
+        if engine.status.has_changed().unwrap_or(false) {
+            let status = engine.status.borrow_and_update().clone();
+            apply_status(app, &status);
+            changed = true;
+        }
+
+        // Deliberately NO begin_batch here (plan U6 topology): the engine
+        // thread commits a journal append between every stream pull, and a
+        // long-held main-thread batch transaction would stall those appends
+        // exactly when traffic is heaviest. Native drains autocommit per
+        // event; the batching optimization (#489) stays signal-cli-internal.
+        loop {
+            match engine.events.try_recv() {
+                Ok(engine_event) => {
+                    let journal_id = engine_event.journal_id;
+                    app.handle_signal_event(engine_event.event);
+                    if let Some(id) = journal_id {
+                        // Effects are committed (autocommit above); the
+                        // journal row has served its purpose. A crash
+                        // between the two lines replays one event, which
+                        // dedup silences.
+                        if let Err(e) = app.db.journal_delete(id) {
+                            debug_log::logf(format_args!("journal delete {id} failed: {e}"));
+                        }
+                    }
+                    changed = true;
+                }
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    // Supervisor gone without a Terminal status (panic):
+                    // report honestly. Normal terminations already set
+                    // connection_error via apply_status.
+                    if app.connection_error.is_none() {
+                        app.connected = false;
+                        app.connection_error =
+                            Some("native engine stopped unexpectedly".to_string());
+                    }
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+        changed
     }
 
-    /// No connection exists to lose; U11's stream supervisor flips this.
+    /// The supervisor self-heals on its own thread (indefinite capped
+    /// backoff for network-class errors, plan Q4); the main loop's
+    /// reconnect machinery belongs to signal-cli's child-process model.
     fn supports_reconnect(&self) -> bool {
         false
     }
@@ -85,4 +236,199 @@ impl Backend for NativeBackend {
     }
 
     async fn resync_after_reconnect(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::journal::{JournalEvent, JournalWriter};
+    use super::supervisor::{EngineEvent, EngineStatus, ReceiveEngine};
+    use super::*;
+    use crate::db::Database;
+    use crate::signal::types::{SignalEvent, SignalMessage};
+    use tokio::sync::{mpsc, watch};
+
+    fn file_backed_app(dir: &std::path::Path) -> App {
+        let db = Database::open(&dir.join("siggy-test.db")).unwrap();
+        App::new("+10000000000".to_string(), db, &dir.join("config.toml"))
+    }
+
+    fn incoming_message() -> SignalMessage {
+        SignalMessage {
+            source: "+15550001111".into(),
+            source_name: Some("Ada".into()),
+            source_uuid: Some("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".into()),
+            timestamp: chrono::DateTime::from_timestamp_millis(1_700_000_000_123).unwrap(),
+            body: Some("hello".into()),
+            ..Default::default()
+        }
+    }
+
+    fn message_count(app: &App, conv_id: &str) -> usize {
+        app.store
+            .conversations
+            .get(conv_id)
+            .map(|c| c.messages.len())
+            .unwrap_or(0)
+    }
+
+    /// The KTD-2 recovery leg: journaled rows replay through the normal
+    /// pipeline on startup, and a replayed row whose effects already
+    /// committed is silenced by the v16 dedup index.
+    #[tokio::test]
+    async fn startup_replays_journal_and_dedups_double_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let db_path = app.db.path().unwrap();
+
+        // The same message journaled twice = the crash-between-commit-and-
+        // delete window plus the redelivered envelope, worst case.
+        let writer = JournalWriter::open(&db_path).unwrap();
+        let event = SignalEvent::MessageReceived(incoming_message());
+        let journaled = JournalEvent::from_signal(&event).unwrap();
+        writer.append(&journaled).unwrap();
+        writer.append(&journaled).unwrap();
+
+        let mut backend = NativeBackend::new();
+        backend.startup(&mut app).await;
+
+        assert_eq!(
+            message_count(&app, "+15550001111"),
+            1,
+            "duplicate journal rows must collapse to one message"
+        );
+        assert!(
+            app.db.journal_pending().unwrap().is_empty(),
+            "replayed rows are deleted"
+        );
+        assert!(!app.loading, "G5: loading clears on store load");
+        // No native store for this account: honest terminal copy, no engine.
+        assert!(app.connection_error.is_some());
+        assert!(backend.engine.is_none());
+    }
+
+    #[tokio::test]
+    async fn startup_with_unparseable_journal_row_drops_it_and_continues() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let db_path = app.db.path().unwrap();
+
+        let writer = JournalWriter::open(&db_path).unwrap();
+        writer
+            .append(
+                &JournalEvent::from_signal(&SignalEvent::MessageReceived(incoming_message()))
+                    .unwrap(),
+            )
+            .unwrap();
+        // Simulate version skew: a second row whose payload no current
+        // variant matches (as if written by a different build).
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute(
+            "INSERT INTO native_journal (payload) VALUES ('{\"FutureVariant\":{}}')",
+            [],
+        )
+        .unwrap();
+        drop(conn);
+
+        let mut backend = NativeBackend::new();
+        backend.startup(&mut app).await;
+
+        assert_eq!(message_count(&app, "+15550001111"), 1);
+        assert!(
+            app.db.journal_pending().unwrap().is_empty(),
+            "unparseable rows are dropped, not wedged"
+        );
+    }
+
+    /// Live drain: handle the event, then delete its journal row - and no
+    /// batching wraps the loop (autocommit visibility is what the engine
+    /// thread's busy_timeout relies on).
+    #[tokio::test]
+    async fn drain_handles_event_then_deletes_journal_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let db_path = app.db.path().unwrap();
+
+        let writer = JournalWriter::open(&db_path).unwrap();
+        let event = SignalEvent::MessageReceived(incoming_message());
+        let id = writer
+            .append(&JournalEvent::from_signal(&event).unwrap())
+            .unwrap();
+
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (_status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+        let mut backend = NativeBackend::new();
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx));
+
+        event_tx
+            .send(EngineEvent {
+                journal_id: Some(id),
+                event,
+            })
+            .unwrap();
+
+        assert!(backend.drain_events(&mut app));
+        assert_eq!(message_count(&app, "+15550001111"), 1);
+        assert!(
+            app.db.journal_pending().unwrap().is_empty(),
+            "journal row deleted after the event was handled"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_reflects_engine_status_transitions() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+
+        let (_event_tx, event_rx) = mpsc::unbounded_channel();
+        let (status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+        let mut backend = NativeBackend::new();
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx));
+
+        status_tx.send(EngineStatus::Connected).unwrap();
+        assert!(backend.drain_events(&mut app));
+        assert!(app.connected);
+        assert!(app.connection_error.is_none());
+
+        status_tx
+            .send(EngineStatus::Reconnecting { attempt: 3 })
+            .unwrap();
+        backend.drain_events(&mut app);
+        assert!(!app.connected);
+        assert!(app.status_message.contains("attempt 3"));
+
+        status_tx
+            .send(EngineStatus::Terminal("relink needed".into()))
+            .unwrap();
+        backend.drain_events(&mut app);
+        assert!(!app.connected);
+        assert_eq!(app.connection_error.as_deref(), Some("relink needed"));
+    }
+
+    #[tokio::test]
+    async fn drain_reports_supervisor_death_without_terminal_status() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        app.connected = true;
+
+        let (event_tx, event_rx) = mpsc::unbounded_channel::<EngineEvent>();
+        let (_status_tx, status_rx) = watch::channel(EngineStatus::Connected);
+        let mut backend = NativeBackend::new();
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx));
+        drop(event_tx); // supervisor panicked: channel closes with no Terminal
+
+        backend.drain_events(&mut app);
+        assert!(!app.connected);
+        assert_eq!(
+            app.connection_error.as_deref(),
+            Some("native engine stopped unexpectedly")
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_without_engine_is_a_quiet_noop() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let mut backend = NativeBackend::new();
+        assert!(!backend.drain_events(&mut app));
+    }
 }

--- a/src/backend/native/supervisor.rs
+++ b/src/backend/native/supervisor.rs
@@ -1,0 +1,443 @@
+//! Receive supervisor (#642 U11 stage 2, plan KTD-2/KTD-5/KTD-6).
+//!
+//! Owns the long-lived engine thread: opens the account store, loads the
+//! registered [`Manager`], emits the store's contact/group directory, then
+//! consumes `receive_messages()` item by item - map, journal (KTD-2),
+//! emit, and only then pull the next item. `QueueEmpty` maps to
+//! [`SignalEvent::SyncComplete`] (KTD-5); the wall-clock sync heuristic
+//! never runs natively.
+//!
+//! Reconnect policy (plan flow question Q4 default): network-class errors
+//! retry indefinitely with capped exponential backoff - a laptop that
+//! slept through the night reconnects on wake without ceremony. Auth and
+//! store errors terminate with actionable copy instead; retrying those
+//! would loop forever against a server that already said no.
+//!
+//! Everything here runs on the [`EngineThread`]'s current-thread runtime
+//! because the store futures are partially `!Send` (KTD-8); the main
+//! thread sees only the mpsc event stream and the watch status.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use futures::StreamExt;
+use presage::manager::Manager;
+use presage::model::identity::OnNewIdentity;
+use presage::model::messages::Received;
+use presage::store::ContentsStore;
+use presage_store_sqlite::SqliteStore;
+use tokio::sync::{mpsc, watch};
+
+use crate::debug_log;
+use crate::signal::types::{Contact, Group, SignalEvent};
+
+use super::journal::{JournalEvent, JournalWriter};
+use super::receive::{self, IdentityResolver};
+use super::runtime::EngineThread;
+
+/// Connection lifecycle as the main loop sees it, published over a watch
+/// channel so `drain_events` reflects the latest state without queueing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EngineStatus {
+    /// Opening the store / websocket (initial state).
+    Connecting,
+    /// Receive stream is live.
+    Connected,
+    /// Stream lost; retrying with capped backoff (1-based attempt count).
+    Reconnecting { attempt: u32 },
+    /// Unrecoverable: auth revoked or store unusable. The copy is
+    /// user-facing (rendered via `app.connection_error`).
+    Terminal(String),
+}
+
+/// One boundary event plus the journal row that guarantees it survives a
+/// crash. `journal_id` is `None` for transient events and when journaling
+/// is unavailable (in-memory DB in tests).
+pub struct EngineEvent {
+    pub journal_id: Option<i64>,
+    pub event: SignalEvent,
+}
+
+/// Handle the adapter holds: the event queue, the status watch, and the
+/// engine thread keeping both alive.
+pub struct ReceiveEngine {
+    pub events: mpsc::UnboundedReceiver<EngineEvent>,
+    pub status: watch::Receiver<EngineStatus>,
+    /// `None` only in tests that fake the channels; production always
+    /// carries the thread handle so the supervisor outlives frames.
+    #[allow(dead_code)]
+    thread: Option<EngineThread<()>>,
+}
+
+impl ReceiveEngine {
+    /// Test seam: a ReceiveEngine around hand-fed channels, no thread.
+    #[cfg(test)]
+    pub fn for_test(
+        events: mpsc::UnboundedReceiver<EngineEvent>,
+        status: watch::Receiver<EngineStatus>,
+    ) -> Self {
+        Self {
+            events,
+            status,
+            thread: None,
+        }
+    }
+}
+
+/// Spawn the supervisor on its engine thread. `journal_db` is siggy.db's
+/// path (None disables journaling - in-memory test DBs only; production
+/// callers always pass it, this is not a soft-degrade switch).
+pub fn spawn(store_file: PathBuf, journal_db: Option<PathBuf>) -> Result<ReceiveEngine> {
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let (status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+    let thread = EngineThread::spawn("siggy-native-receive", move || async move {
+        run_supervisor(store_file, journal_db, event_tx, status_tx).await;
+    })?;
+    Ok(ReceiveEngine {
+        events: event_rx,
+        status: status_rx,
+        thread: Some(thread),
+    })
+}
+
+/// Same schedule as `ReconnectPolicy::backoff` (2s, 4s, ... capped 30s)
+/// but with no attempt cap: the native engine self-heals indefinitely for
+/// network-class failures instead of using the main loop's supervisor.
+fn backoff(attempt: u32) -> Duration {
+    Duration::from_secs((1u64 << attempt.min(6)).min(30))
+}
+
+enum SessionEnd {
+    /// Retry after backoff (network-class, or the stream simply ended).
+    Retry(String),
+    /// Stop the engine and surface the message (auth/store class).
+    Terminal(String),
+}
+
+async fn run_supervisor(
+    store_file: PathBuf,
+    journal_db: Option<PathBuf>,
+    event_tx: mpsc::UnboundedSender<EngineEvent>,
+    status_tx: watch::Sender<EngineStatus>,
+) {
+    let journal = match &journal_db {
+        Some(path) => match JournalWriter::open(path) {
+            Ok(writer) => Some(writer),
+            Err(e) => {
+                // Without a journal the KTD-2 contract is void; running
+                // anyway would silently downgrade durability.
+                let _ = status_tx.send(EngineStatus::Terminal(format!(
+                    "native engine: cannot open receive journal: {e}"
+                )));
+                return;
+            }
+        },
+        None => None,
+    };
+
+    let mut attempt: u32 = 0;
+    loop {
+        let end = run_session(
+            &store_file,
+            journal.as_ref(),
+            &event_tx,
+            &status_tx,
+            &mut attempt,
+        )
+        .await;
+        if event_tx.is_closed() {
+            // The adapter (and with it the app) is gone; nobody is
+            // listening. Exit quietly.
+            return;
+        }
+        match end {
+            SessionEnd::Terminal(msg) => {
+                debug_log::logf(format_args!("native receive terminal: {msg}"));
+                let _ = status_tx.send(EngineStatus::Terminal(msg));
+                return;
+            }
+            SessionEnd::Retry(detail) => {
+                attempt += 1;
+                debug_log::logf(format_args!(
+                    "native receive retry (attempt {attempt}): {detail}"
+                ));
+                let _ = status_tx.send(EngineStatus::Reconnecting { attempt });
+                tokio::time::sleep(backoff(attempt)).await;
+            }
+        }
+    }
+}
+
+/// One stream lifetime: store open → manager → directory emission →
+/// receive loop. Returns how it ended so the supervisor can decide
+/// between backoff and termination.
+async fn run_session(
+    store_file: &std::path::Path,
+    journal: Option<&JournalWriter>,
+    event_tx: &mpsc::UnboundedSender<EngineEvent>,
+    status_tx: &watch::Sender<EngineStatus>,
+    attempt: &mut u32,
+) -> SessionEnd {
+    let Some(path) = store_file.to_str() else {
+        return SessionEnd::Terminal("native store path is not valid UTF-8".into());
+    };
+    // Store-open failures are terminal: the file is local, retrying cannot
+    // fix corruption, and `--check` / `--reset-account` own the recovery
+    // copy (same classification as linking.rs's Corrupt).
+    let store = match SqliteStore::open(path, OnNewIdentity::Trust).await {
+        Ok(store) => store,
+        Err(e) => {
+            return SessionEnd::Terminal(format!(
+                "native engine: cannot open account store (run --check; --reset-account recovers): {e}"
+            ));
+        }
+    };
+    let mut manager = match Manager::load_registered(store).await {
+        Ok(manager) => manager,
+        Err(e) => return classify_manager_error(e),
+    };
+    let own_aci = manager.registration_data().service_ids.aci.to_string();
+
+    // A cloned store handle for directory reads after `receive_messages`
+    // mutably borrows the manager.
+    let store_handle = manager.store().clone();
+    let mut resolver = load_resolver(&store_handle).await;
+
+    // Spike finding: contact sync is NOT automatic on a linked device. On
+    // a fresh store, ask the primary for it (best-effort; the payload
+    // arrives as Received::Contacts below).
+    if resolver.by_aci.is_empty() {
+        if let Err(e) = manager.request_contacts().await {
+            debug_log::logf(format_args!("request_contacts failed: {e}"));
+        }
+    }
+
+    // Directory snapshot so conversations render with names immediately
+    // (native twin of the startup listContacts/listGroups round-trip).
+    emit_directory(&store_handle, &resolver, event_tx).await;
+
+    let stream = match manager.receive_messages().await {
+        Ok(stream) => stream,
+        Err(e) => return classify_manager_error(e),
+    };
+    tokio::pin!(stream);
+    *attempt = 0;
+    let _ = status_tx.send(EngineStatus::Connected);
+
+    while let Some(item) = stream.next().await {
+        if matches!(item, Received::Contacts) {
+            // Payload landed in the store; refresh the resolver and
+            // re-emit the directory so late contact sync names existing
+            // conversations (KTD-6; the uuid→E164 re-key is stage 3).
+            resolver = load_resolver(&store_handle).await;
+            emit_directory(&store_handle, &resolver, event_tx).await;
+            continue;
+        }
+        for event in receive::map_received(&item, &own_aci, &resolver) {
+            // KTD-2 ordering: the journal append commits before this
+            // iteration ends, i.e. before the next stream pull can ack
+            // anything further.
+            let journal_id = match (journal, JournalEvent::from_signal(&event)) {
+                (Some(writer), Some(journaled)) => match writer.append(&journaled) {
+                    Ok(id) => Some(id),
+                    Err(e) => {
+                        // A failed append re-opens the ack window for this
+                        // one event; log loudly and still deliver rather
+                        // than dropping it on the floor.
+                        debug_log::logf(format_args!("journal append failed: {e}"));
+                        None
+                    }
+                },
+                _ => None,
+            };
+            if event_tx.send(EngineEvent { journal_id, event }).is_err() {
+                return SessionEnd::Terminal("event channel closed".into());
+            }
+        }
+    }
+    SessionEnd::Retry("receive stream ended".into())
+}
+
+/// Q4 default: auth/registration problems terminate with actionable copy;
+/// everything else (websocket, IO, timeouts) is network-class and retries
+/// forever.
+fn classify_manager_error(e: presage::Error<presage_store_sqlite::SqliteStoreError>) -> SessionEnd {
+    use presage::Error;
+    match &e {
+        Error::NotYetRegisteredError | Error::RelinkNecessary => SessionEnd::Terminal(format!(
+            "native engine: this device is no longer linked ({e}); relink from the phone"
+        )),
+        Error::MissingKeyError(_) | Error::Store(_) => SessionEnd::Terminal(format!(
+            "native engine: account store is unusable ({e}); --reset-account recovers"
+        )),
+        _ => SessionEnd::Retry(e.to_string()),
+    }
+}
+
+/// Store-backed KTD-6 identity data: ACI uuid → (E.164, display name).
+#[derive(Default)]
+pub(super) struct StoreResolver {
+    by_aci: HashMap<String, (Option<String>, Option<String>)>,
+}
+
+impl IdentityResolver for StoreResolver {
+    fn number_for_aci(&self, aci: &str) -> Option<String> {
+        self.by_aci.get(aci).and_then(|(number, _)| number.clone())
+    }
+
+    fn name_for_aci(&self, aci: &str) -> Option<String> {
+        self.by_aci.get(aci).and_then(|(_, name)| name.clone())
+    }
+}
+
+async fn load_resolver(store: &SqliteStore) -> StoreResolver {
+    let mut by_aci = HashMap::new();
+    match store.contacts().await {
+        Ok(contacts) => {
+            for contact in contacts {
+                let Ok(contact) = contact else { continue };
+                by_aci.insert(
+                    contact.uuid.to_string(),
+                    (e164(&contact), non_empty(&contact.name)),
+                );
+            }
+        }
+        Err(e) => debug_log::logf(format_args!("store contacts read failed: {e}")),
+    }
+    StoreResolver { by_aci }
+}
+
+/// KTD-6 format lock: numbers cross the boundary in E.164 exactly as
+/// signal-cli renders them, never phonenumber's display formats.
+fn e164(contact: &presage::model::contacts::Contact) -> Option<String> {
+    use presage::libsignal_service::prelude::phonenumber::Mode;
+    contact
+        .phone_number
+        .as_ref()
+        .map(|p| p.format().mode(Mode::E164).to_string())
+}
+
+fn non_empty(s: &str) -> Option<String> {
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Emit ContactList + GroupList from the store so `App` names
+/// conversations and populates mention maps. Not journaled: re-emitted at
+/// every session start and on every Contacts sync.
+async fn emit_directory(
+    store: &SqliteStore,
+    resolver: &StoreResolver,
+    event_tx: &mpsc::UnboundedSender<EngineEvent>,
+) {
+    let mut contacts_out = Vec::new();
+    if let Ok(contacts) = store.contacts().await {
+        for contact in contacts.flatten() {
+            contacts_out.push(Contact {
+                number: e164(&contact),
+                name: non_empty(&contact.name),
+                uuid: Some(contact.uuid.to_string()),
+                // presage's contact model has no username field at the
+                // pinned rev; username resolution stays a U12 send-path
+                // concern (#612 lookup_username).
+                username: None,
+            });
+        }
+    }
+    if !contacts_out.is_empty() {
+        let _ = event_tx.send(EngineEvent {
+            journal_id: None,
+            event: SignalEvent::ContactList(contacts_out),
+        });
+    }
+
+    let mut groups_out = Vec::new();
+    match store.groups().await {
+        Ok(groups) => {
+            for entry in groups {
+                let Ok((master_key, group)) = entry else {
+                    continue;
+                };
+                let Some(id) = receive::derive_group_id(&master_key) else {
+                    continue;
+                };
+                let mut members = Vec::new();
+                let mut member_uuids = Vec::new();
+                for member in &group.members {
+                    let aci = member.aci.service_id_string();
+                    // KTD-6 selection rule for the member roster too:
+                    // E.164 when known, else the uuid string.
+                    let key = resolver.number_for_aci(&aci).unwrap_or_else(|| aci.clone());
+                    members.push(key.clone());
+                    member_uuids.push((key, aci));
+                }
+                groups_out.push(Group {
+                    id,
+                    name: group.title.clone(),
+                    members,
+                    member_uuids,
+                });
+            }
+        }
+        Err(e) => debug_log::logf(format_args!("store groups read failed: {e}")),
+    }
+    if !groups_out.is_empty() {
+        let _ = event_tx.send(EngineEvent {
+            journal_id: None,
+            event: SignalEvent::GroupList(groups_out),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_matches_reconnect_policy_schedule_without_a_cap() {
+        assert_eq!(backoff(1), Duration::from_secs(2));
+        assert_eq!(backoff(2), Duration::from_secs(4));
+        assert_eq!(backoff(4), Duration::from_secs(16));
+        assert_eq!(backoff(5), Duration::from_secs(30));
+        // No attempt cap: hour-1000 still retries at the 30s ceiling.
+        assert_eq!(backoff(100_000), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn resolver_applies_the_ktd6_selection_rule() {
+        let mut by_aci = HashMap::new();
+        by_aci.insert(
+            "aaaa".to_string(),
+            (Some("+15550001111".to_string()), Some("Ada".to_string())),
+        );
+        by_aci.insert("bbbb".to_string(), (None, None));
+        let resolver = StoreResolver { by_aci };
+        assert_eq!(
+            resolver.number_for_aci("aaaa").as_deref(),
+            Some("+15550001111")
+        );
+        assert_eq!(resolver.name_for_aci("aaaa").as_deref(), Some("Ada"));
+        assert_eq!(resolver.number_for_aci("bbbb"), None);
+        assert_eq!(resolver.number_for_aci("unknown"), None);
+    }
+
+    #[tokio::test]
+    async fn terminal_manager_errors_are_classified_as_terminal() {
+        let end = classify_manager_error(presage::Error::NotYetRegisteredError);
+        assert!(matches!(end, SessionEnd::Terminal(msg) if msg.contains("relink")));
+        let end = classify_manager_error(presage::Error::RelinkNecessary);
+        assert!(matches!(end, SessionEnd::Terminal(_)));
+    }
+
+    #[tokio::test]
+    async fn other_manager_errors_retry() {
+        let io = std::io::Error::new(std::io::ErrorKind::ConnectionReset, "socket died");
+        let end = classify_manager_error(presage::Error::IoError(io));
+        assert!(matches!(end, SessionEnd::Retry(_)));
+    }
+}

--- a/src/db.rs
+++ b/src/db.rs
@@ -264,6 +264,26 @@ const MIGRATIONS: &[Migration] = &[
             COMMIT;
         ",
     },
+    // Native receive journal (#642 U11, plan KTD-2). The native adapter's
+    // engine thread appends each mapped incoming event here (own
+    // connection) BEFORE pulling the next stream item, because
+    // libsignal-service acks envelopes before yielding them: this table is
+    // what makes an acked-but-unprocessed envelope survive a crash. The
+    // main thread deletes a row after committing the event's effects;
+    // startup replays whatever is left and the entry_seq dedup (v16) makes
+    // replays silent. Empty and unused under the signal-cli backend.
+    Migration {
+        version: 17,
+        sql: "
+            BEGIN;
+            CREATE TABLE native_journal (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                payload TEXT NOT NULL
+            );
+            UPDATE schema_version SET version = 17;
+            COMMIT;
+        ",
+    },
 ];
 
 pub struct Database {
@@ -315,6 +335,37 @@ impl Database {
         if let Err(e) = self.conn.execute_batch("COMMIT;") {
             crate::debug_log::logf(format_args!("commit_batch failed: {e}"));
         }
+    }
+
+    /// Filesystem path of the open database, `None` for in-memory DBs.
+    /// The native adapter's engine thread opens its own journal connection
+    /// to the same file (#642 U11, KTD-2).
+    pub fn path(&self) -> Option<std::path::PathBuf> {
+        self.conn
+            .path()
+            .filter(|p| !p.is_empty())
+            .map(std::path::PathBuf::from)
+    }
+
+    // --- Native receive journal (#642 U11, KTD-2) ---
+
+    /// Journal rows the native adapter persisted but the main thread has not
+    /// yet confirmed processed: `(id, payload)` in insertion order. Appends
+    /// happen on the adapter's own connection (`backend::native::journal`);
+    /// this side only replays and deletes.
+    pub fn journal_pending(&self) -> Result<Vec<(i64, String)>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, payload FROM native_journal ORDER BY id")?;
+        let rows = stmt.query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?;
+        Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+    }
+
+    /// Drop one journal row after its event's effects are committed.
+    pub fn journal_delete(&self, id: i64) -> Result<()> {
+        self.conn
+            .execute("DELETE FROM native_journal WHERE id = ?1", params![id])?;
+        Ok(())
     }
 
     fn migrate(&self) -> Result<()> {
@@ -1297,6 +1348,57 @@ mod tests {
     #[fixture]
     fn db() -> Database {
         Database::open_in_memory().unwrap()
+    }
+
+    // --- Native receive journal (#642 U11, KTD-2) ---
+
+    /// Simulate the adapter side (a second connection appending) with a
+    /// direct insert; the Database API only replays and deletes.
+    fn journal_append(db: &Database, payload: &str) -> i64 {
+        db.conn
+            .execute(
+                "INSERT INTO native_journal (payload) VALUES (?1)",
+                params![payload],
+            )
+            .unwrap();
+        db.conn.last_insert_rowid()
+    }
+
+    #[rstest]
+    fn journal_pending_returns_rows_in_insertion_order(db: Database) {
+        assert!(db.journal_pending().unwrap().is_empty());
+        let first = journal_append(&db, "a");
+        let second = journal_append(&db, "b");
+        let rows = db.journal_pending().unwrap();
+        assert_eq!(
+            rows,
+            vec![(first, "a".to_string()), (second, "b".to_string())]
+        );
+    }
+
+    #[rstest]
+    fn journal_delete_removes_exactly_one_row(db: Database) {
+        let first = journal_append(&db, "a");
+        let second = journal_append(&db, "b");
+        db.journal_delete(first).unwrap();
+        let rows = db.journal_pending().unwrap();
+        assert_eq!(rows, vec![(second, "b".to_string())]);
+        // Deleting an already-gone row is a no-op, not an error (replay
+        // after a crash between delete and commit hits this).
+        db.journal_delete(first).unwrap();
+    }
+
+    #[rstest]
+    fn path_is_none_for_in_memory(db: Database) {
+        assert_eq!(db.path(), None);
+    }
+
+    #[test]
+    fn path_reports_file_backed_location() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("t.db");
+        let db = Database::open(&file).unwrap();
+        assert_eq!(db.path(), Some(file));
     }
 
     /// Build an in-memory database migrated only up to schema version `k`, to

--- a/src/db.rs
+++ b/src/db.rs
@@ -1398,7 +1398,13 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let file = dir.path().join("t.db");
         let db = Database::open(&file).unwrap();
-        assert_eq!(db.path(), Some(file));
+        // SQLite reports the symlink-resolved absolute path; on macOS the
+        // temp dir crosses the /var -> /private/var symlink, so compare
+        // canonicalized forms rather than raw strings.
+        assert_eq!(
+            db.path().map(|p| p.canonicalize().unwrap()),
+            Some(file.canonicalize().unwrap())
+        );
     }
 
     /// Build an in-memory database migrated only up to schema version `k`, to

--- a/src/signal/types.rs
+++ b/src/signal/types.rs
@@ -51,7 +51,8 @@ impl MessageStatus {
 /// `_ => return` for any unrecognized value (#500): a casing or spelling drift
 /// between the parser and the handler dropped receipts silently. The mapping to
 /// `MessageStatus` is now total.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// Serde: journaled by the native receive path (#642 U11, KTD-2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ReceiptKind {
     Delivery,
     Read,
@@ -453,7 +454,8 @@ impl SignalEvent {
 }
 
 /// A message from Signal
-#[derive(Debug, Clone)]
+// Serde: journaled by the native receive path (#642 U11, KTD-2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SignalMessage {
     pub source: String,
     pub source_name: Option<String>,
@@ -513,7 +515,8 @@ pub struct LinkPreview {
 }
 
 /// An attachment on a message
-#[derive(Debug, Clone)]
+// Serde: journaled by the native receive path (#642 U11, KTD-2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Attachment {
     #[allow(dead_code)]
     pub id: String,
@@ -560,7 +563,8 @@ pub struct Mention {
 }
 
 /// A text style range from signal-cli's textStyles/bodyRanges array.
-#[derive(Debug, Clone)]
+// Serde: journaled by the native receive path (#642 U11, KTD-2).
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TextStyle {
     pub start: usize,  // UTF-16 offset in body
     pub length: usize, // UTF-16 length
@@ -568,7 +572,8 @@ pub struct TextStyle {
 }
 
 /// Type of text styling applied to a range.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+// Serde: journaled by the native receive path (#642 U11, KTD-2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StyleType {
     Bold,
     Italic,


### PR DESCRIPTION
## Summary

The native engine now has a live receive path. A supervisor on the dedicated engine thread opens the account store, loads the registered presage Manager, emits the store's contact/group directory, then consumes `receive_messages()` one item at a time: map (stage 1's pure layer) -> journal -> emit -> only then pull the next item.

## The KTD-2 durability contract

libsignal-service acks each envelope on the websocket **before** yielding it to the stream, so anything pulled but not persisted dies with a crash. The contract implemented here:

1. Engine thread appends each mapped event to a `native_journal` table (migration 17) on its own connection, autocommitted, **before** the next stream pull
2. Main thread handles the event through the normal pipeline, then deletes the journal row
3. Startup replays any leftover rows; the v16 `entry_seq` dedup index makes rows whose effects already committed completely silent

Crash at any point between those steps loses at most the one acked in-flight envelope (the documented residual window from the spike).

## PLAN DEVIATION (flagged for the U19 gate)

Plan U6 specified the adapter writing finished rows straight into `messages` from its own connection. That turned out not implementable: message rows carry app-resolved display state (contact names, conversation upserts, unread counts) that only the main thread produces. The journal table keeps U6's durability *ordering* (persist-before-next-pull, second connection, busy_timeout on both sides) while leaving row production where the data lives. Full rationale in `journal.rs` module docs.

## Also in here

- **KTD-5**: `QueueEmpty` -> `SyncComplete`; the native path never runs the wall-clock sync heuristic
- **KTD-6**: store-backed resolver (E.164-when-known-else-uuid), phone numbers locked to E.164 format via phonenumber's E164 mode; directory re-emitted on every `Contacts` sync so late contact sync names conversations (the uuid->E164 conversation re-key/merge is stage 3)
- **Spike follow-up**: `request_contacts()` fired on fresh stores since contact sync is not automatic on linked devices
- **Reconnect (plan Q4 default)**: network-class errors retry indefinitely at the familiar 2s/4s/.../30s-cap schedule on the engine thread; auth-revoked and store-corrupt errors terminate with actionable copy. `supports_reconnect()` stays false: the supervisor self-heals, the main loop's respawn machinery is signal-cli's
- **Flow gap G5**: `app.loading` clears on store load + journal replay; no RPC round-trip to wait for
- **Plan U6 topology**: native drain does NOT wrap in `begin_batch` - a long-held main-thread transaction would stall engine-side journal appends exactly when traffic is heaviest

## Tests

18 new: journal round-trip per variant + transient-exclusion + cross-connection visibility (journal.rs), backoff schedule / resolver selection rule / error classification (supervisor.rs), startup replay with double-delivery dedup, unparseable-row drop, drain-deletes-after-handle, status reflection, supervisor-death reporting (mod.rs), journal table + path methods (db.rs).

- Native lane: 937 + 261 green, clippy `-D warnings` clean
- Default lane: 897 + 261 green, clippy `-D warnings` clean (journal table exists but is unused there)

## Remaining for U11 (stage 3)

- uuid->E164 conversation re-key/merge on late contact sync + the KTD-6 race test
- env-var crash-injection hook (abort-after-N-inserts) + the data-loss torture test per the Verification Contract
- Tier-3 live verification (link a real device, receive from a phone) - folds in the deferred U10 Tier-3 leg

Part of #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)