### PR TITLE
feat(native): U11 stage 3 - KTD-6 late-sync re-key + crash-injection torture test (part of #642)

### DIFF
--- a/src/app_tests.rs
+++ b/src/app_tests.rs
@@ -6830,3 +6830,127 @@ fn replayed_message_does_not_refire_triggers(mut app: App) {
         "replay must not queue a second auto-reply"
     );
 }
+
+// --- KTD-6 late-contact-sync re-key (#642 U11 stage 3) ---
+// A message can arrive before contact sync supplies the sender's number
+// (the native engine hits this on every freshly linked device). The
+// conversation keys by ACI uuid at that point; when the ContactList later
+// maps that uuid to an E.164, the uuid conversation must fold into the
+// number-keyed one or history splits across two sidebar entries.
+
+const RACE_UUID: &str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+const RACE_NUMBER: &str = "+15551234567";
+
+fn uuid_keyed_message(ts_ms: i64, body: &str) -> SignalMessage {
+    SignalMessage {
+        source: RACE_UUID.to_string(),
+        source_uuid: Some(RACE_UUID.to_string()),
+        timestamp: chrono::DateTime::from_timestamp_millis(ts_ms).unwrap(),
+        body: Some(body.to_string()),
+        ..Default::default()
+    }
+}
+
+fn race_contact() -> Contact {
+    Contact {
+        number: Some(RACE_NUMBER.to_string()),
+        name: Some("Ada".to_string()),
+        uuid: Some(RACE_UUID.to_string()),
+        username: None,
+    }
+}
+
+#[rstest]
+fn late_contact_sync_rekeys_uuid_conversation_to_e164() {
+    let (mut app, db_path) = app_with_file_db();
+    app.handle_signal_event(SignalEvent::MessageReceived(uuid_keyed_message(
+        1_700_000_000_000,
+        "arrived before sync",
+    )));
+    assert!(app.store.conversations.contains_key(RACE_UUID));
+    let unread_before = app.store.conversations[RACE_UUID].unread;
+
+    app.handle_signal_event(SignalEvent::ContactList(vec![race_contact()]));
+
+    assert!(
+        !app.store.conversations.contains_key(RACE_UUID),
+        "uuid-keyed conversation must be retired"
+    );
+    let conv = &app.store.conversations[RACE_NUMBER];
+    assert_eq!(conv.name, "Ada");
+    assert_eq!(conv.messages.len(), 1);
+    assert_eq!(conv.unread, unread_before, "unread survives the re-key");
+    assert!(
+        !app.store
+            .conversation_order
+            .iter()
+            .any(|id| id == RACE_UUID),
+        "sidebar order drops the retired key"
+    );
+    // What a restart would load: rows live under the E.164 key only.
+    assert_eq!(reload_messages(&db_path, RACE_NUMBER).len(), 1);
+    assert!(reload_messages(&db_path, RACE_UUID).is_empty());
+}
+
+#[rstest]
+fn rekey_merges_into_existing_number_conversation_in_order() {
+    let (mut app, db_path) = app_with_file_db();
+    // The number-keyed conversation already exists (e.g. the user messaged
+    // them on another device after sync partially landed)...
+    let number_msg = SignalMessage {
+        source: RACE_NUMBER.to_string(),
+        timestamp: chrono::DateTime::from_timestamp_millis(1_700_000_000_500).unwrap(),
+        body: Some("later, number-keyed".to_string()),
+        ..Default::default()
+    };
+    app.handle_signal_event(SignalEvent::MessageReceived(number_msg));
+    // ...and an EARLIER message had landed under the uuid key.
+    app.handle_signal_event(SignalEvent::MessageReceived(uuid_keyed_message(
+        1_700_000_000_000,
+        "earlier, uuid-keyed",
+    )));
+    assert_eq!(
+        app.store.conversations.len(),
+        2,
+        "history is split pre-sync"
+    );
+
+    app.handle_signal_event(SignalEvent::ContactList(vec![race_contact()]));
+
+    assert_eq!(app.store.conversations.len(), 1, "split healed");
+    let conv = &app.store.conversations[RACE_NUMBER];
+    assert_eq!(conv.messages.len(), 2);
+    assert_eq!(
+        conv.messages[0].body, "earlier, uuid-keyed",
+        "merged messages interleave chronologically"
+    );
+    assert_eq!(conv.messages[1].body, "later, number-keyed");
+    assert_eq!(reload_messages(&db_path, RACE_NUMBER).len(), 2);
+}
+
+#[rstest]
+fn rekey_follows_the_active_conversation() {
+    let (mut app, _db_path) = app_with_file_db();
+    app.handle_signal_event(SignalEvent::MessageReceived(uuid_keyed_message(
+        1_700_000_000_000,
+        "hi",
+    )));
+    app.active_conversation = Some(RACE_UUID.to_string());
+
+    app.handle_signal_event(SignalEvent::ContactList(vec![race_contact()]));
+
+    assert_eq!(
+        app.active_conversation.as_deref(),
+        Some(RACE_NUMBER),
+        "the open chat must not dangle on a retired key"
+    );
+}
+
+#[rstest]
+fn contact_sync_without_prior_uuid_conversation_rekeys_nothing(mut app: App) {
+    app.handle_signal_event(SignalEvent::ContactList(vec![race_contact()]));
+    assert!(
+        app.store.conversations.is_empty(),
+        "re-key never conjures conversations from nothing"
+    );
+}

--- a/src/backend/native/journal.rs
+++ b/src/backend/native/journal.rs
@@ -35,6 +35,9 @@ use crate::signal::types::{ReceiptKind, SignalEvent, SignalMessage};
 /// at a crash would be user-visible data loss. Transient events (typing,
 /// sync lifecycle, directory refreshes) are deliberately absent - they are
 /// re-derivable or harmless to drop.
+// large_enum_variant: mirrors SignalEvent's own allow - journal events are
+// short-lived single values, not bulk-stored collections.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum JournalEvent {
     Message(SignalMessage),
@@ -266,8 +269,18 @@ impl JournalEvent {
 /// erroring). WAL is a database-level property already set by the main
 /// connection; `synchronous=NORMAL` matches it - commits survive app
 /// crash (the KTD-2 bar), not power loss.
+/// Crash-injection env var for the KTD-2 torture test (#642 U11 stage 3):
+/// when set to N, the process aborts immediately after the Nth successful
+/// journal append - deterministically landing on the
+/// committed-but-unprocessed boundary the replay leg must survive. Read
+/// once at `open`; absent in production.
+pub const ABORT_AFTER_ENV: &str = "SIGGY_TEST_JOURNAL_ABORT_AFTER";
+
 pub struct JournalWriter {
     conn: Connection,
+    /// Crash-injection budget from [`ABORT_AFTER_ENV`], `None` normally.
+    abort_after: Option<u64>,
+    appended: std::cell::Cell<u64>,
 }
 
 impl JournalWriter {
@@ -276,7 +289,14 @@ impl JournalWriter {
             .with_context(|| format!("open journal connection to {}", db_path.display()))?;
         conn.execute_batch("PRAGMA synchronous=NORMAL;")?;
         conn.busy_timeout(std::time::Duration::from_secs(5))?;
-        Ok(Self { conn })
+        let abort_after = std::env::var(ABORT_AFTER_ENV)
+            .ok()
+            .and_then(|n| n.parse().ok());
+        Ok(Self {
+            conn,
+            abort_after,
+            appended: std::cell::Cell::new(0),
+        })
     }
 
     /// Durably append one event; returns the row id the main thread deletes
@@ -289,7 +309,18 @@ impl JournalWriter {
             "INSERT INTO native_journal (payload) VALUES (?1)",
             params![payload],
         )?;
-        Ok(self.conn.last_insert_rowid())
+        let id = self.conn.last_insert_rowid();
+        if let Some(limit) = self.abort_after {
+            let count = self.appended.get() + 1;
+            self.appended.set(count);
+            if count >= limit {
+                // Torture-test crash point: the row above is committed,
+                // nothing downstream has seen it. abort(), not panic - no
+                // unwinding, no destructors, the honest kill -9 analog.
+                std::process::abort();
+            }
+        }
+        Ok(id)
     }
 }
 
@@ -421,6 +452,71 @@ mod tests {
                 JournalEvent::from_signal(&event).is_none(),
                 "unexpectedly journaled: {event:?}"
             );
+        }
+    }
+
+    /// Subprocess half of the crash test below. Guarded by the env var so a
+    /// manual `cargo test -- --ignored` run without it is a no-op.
+    #[test]
+    #[ignore = "spawned as a subprocess by crash_after_n_appends_preserves_exactly_the_committed_prefix"]
+    fn torture_helper_appends_until_abort() {
+        let Some(db_path) = std::env::var_os("SIGGY_TORTURE_DB") else {
+            return;
+        };
+        let writer = JournalWriter::open(Path::new(&db_path)).unwrap();
+        for i in 0..10i64 {
+            let mut msg = sample_message();
+            msg.timestamp = ts_utc(1_700_000_000_000 + i);
+            msg.body = Some(format!("torture {i}"));
+            writer
+                .append(&JournalEvent::from_signal(&SignalEvent::MessageReceived(msg)).unwrap())
+                .unwrap();
+        }
+        unreachable!("the {ABORT_AFTER_ENV} hook should have aborted this process");
+    }
+
+    /// The deterministic leg of the U11 torture contract: crash exactly on
+    /// the committed-but-unprocessed boundary (via the abort-after-N hook),
+    /// then assert the survivors are precisely the committed prefix - every
+    /// journaled event is present, in order, and nothing else. The random
+    /// kill -9 chaos layer and the live end-to-end oracle are the Tier-3
+    /// manual run.
+    #[test]
+    fn crash_after_n_appends_preserves_exactly_the_committed_prefix() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_file = dir.path().join("torture.db");
+        let db = crate::db::Database::open(&db_file).unwrap();
+
+        let status = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "backend::native::journal::tests::torture_helper_appends_until_abort",
+                "--exact",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env("SIGGY_TORTURE_DB", &db_file)
+            .env(ABORT_AFTER_ENV, "3")
+            .status()
+            .expect("spawn torture helper");
+        assert!(
+            !status.success(),
+            "helper must die by abort, not exit clean"
+        );
+
+        let rows = db.journal_pending().unwrap();
+        assert_eq!(
+            rows.len(),
+            3,
+            "exactly the appends committed before the crash survive"
+        );
+        for (i, (_, payload)) in rows.iter().enumerate() {
+            let event: JournalEvent = serde_json::from_str(payload).unwrap();
+            match event {
+                JournalEvent::Message(msg) => {
+                    assert_eq!(msg.body.as_deref(), Some(format!("torture {i}").as_str()));
+                }
+                other => panic!("unexpected journal payload: {other:?}"),
+            }
         }
     }
 

--- a/src/backend/native/supervisor.rs
+++ b/src/backend/native/supervisor.rs
@@ -208,10 +208,10 @@ async fn run_session(
     // Spike finding: contact sync is NOT automatic on a linked device. On
     // a fresh store, ask the primary for it (best-effort; the payload
     // arrives as Received::Contacts below).
-    if resolver.by_aci.is_empty() {
-        if let Err(e) = manager.request_contacts().await {
-            debug_log::logf(format_args!("request_contacts failed: {e}"));
-        }
+    if resolver.by_aci.is_empty()
+        && let Err(e) = manager.request_contacts().await
+    {
+        debug_log::logf(format_args!("request_contacts failed: {e}"));
     }
 
     // Directory snapshot so conversations render with names immediately

--- a/src/conversation_store.rs
+++ b/src/conversation_store.rs
@@ -361,6 +361,51 @@ impl ConversationStore {
         self.conversations.get_mut(id).unwrap()
     }
 
+    /// KTD-6 late-sync re-key (#642 U11 stage 3): fold conversation `from`
+    /// (uuid-keyed because a message arrived before contact sync supplied
+    /// the peer's number) into `to` (the canonical E.164 key), in memory
+    /// and in SQLite, so history never splits across the two keys. No-op
+    /// when `from` does not exist. `last_read_index` for the source is
+    /// dropped rather than translated - indices are positions within a
+    /// message list that just changed shape; the unread count carries the
+    /// user-visible state.
+    pub fn rekey_conversation(&mut self, db: &Database, from: &str, to: &str, name: &str) {
+        let Some(source) = self.conversations.remove(from) else {
+            return;
+        };
+        self.conversation_order.retain(|id| id != from);
+        self.last_read_index.remove(from);
+        // Target's conversations row must exist BEFORE rows move under it:
+        // messages.conversation_id carries a foreign key, and FK violations
+        // are not subject to OR IGNORE - the whole move would error.
+        self.get_or_create_conversation(to, name, source.is_group, db);
+        db_warn(db.merge_conversation(from, to), "merge_conversation");
+
+        let target = self
+            .conversations
+            .get_mut(to)
+            .expect("target created above");
+        target.messages.extend(source.messages);
+        // Stable sort: same-timestamp messages keep their relative order.
+        target.messages.sort_by_key(|m| m.timestamp_ms);
+        target.unread += source.unread;
+        target.accepted = target.accepted || source.accepted;
+        if target.expiration_timer == 0 {
+            target.expiration_timer = source.expiration_timer;
+        }
+
+        // Lookups that referenced the retired key follow the conversation.
+        if let Some(display) = self.contact_names.remove(from) {
+            self.contact_names.entry(to.to_string()).or_insert(display);
+        }
+        if let Some(handle) = self.usernames.remove(from) {
+            self.username_to_id
+                .insert(handle.to_lowercase(), to.to_string());
+            self.usernames.entry(to.to_string()).or_insert(handle);
+        }
+        self.has_more_messages.remove(from);
+    }
+
     /// Chat-pane title for a conversation: its name, with ` (@handle)`
     /// appended for 1:1 conversations whose contact has a Signal username —
     /// gated by [`Self::show_usernames`]. Skipped when the name already *is*

--- a/src/db.rs
+++ b/src/db.rs
@@ -368,6 +368,59 @@ impl Database {
         Ok(())
     }
 
+    /// Atomically fold every row of conversation `from` into `to` (#642 U11
+    /// stage 3, the KTD-6 late-sync re-key): a message that arrived before
+    /// contact sync created a uuid-keyed conversation, and the peer's E.164
+    /// is now known. Runs inside a SAVEPOINT rather than BEGIN because the
+    /// caller may already hold a drain batch transaction.
+    ///
+    /// `UPDATE OR IGNORE`: a moved row that collides with an identical twin
+    /// already under `to` (same dedup key - the envelope was delivered on
+    /// both sides of the re-key boundary) stays behind and is dropped with
+    /// the rest of the source conversation, which is exactly dedup.
+    pub fn merge_conversation(&self, from: &str, to: &str) -> Result<()> {
+        self.conn.execute_batch("SAVEPOINT rekey;")?;
+        let moved = (|| -> Result<()> {
+            self.conn.execute(
+                "UPDATE OR IGNORE messages SET conversation_id = ?2 WHERE conversation_id = ?1",
+                params![from, to],
+            )?;
+            self.conn.execute(
+                "UPDATE OR IGNORE reactions SET conversation_id = ?2 WHERE conversation_id = ?1",
+                params![from, to],
+            )?;
+            self.conn.execute(
+                "UPDATE OR IGNORE read_markers SET conversation_id = ?2 WHERE conversation_id = ?1",
+                params![from, to],
+            )?;
+            self.conn.execute(
+                "DELETE FROM messages WHERE conversation_id = ?1",
+                params![from],
+            )?;
+            self.conn.execute(
+                "DELETE FROM reactions WHERE conversation_id = ?1",
+                params![from],
+            )?;
+            self.conn.execute(
+                "DELETE FROM read_markers WHERE conversation_id = ?1",
+                params![from],
+            )?;
+            self.conn
+                .execute("DELETE FROM conversations WHERE id = ?1", params![from])?;
+            Ok(())
+        })();
+        match moved {
+            Ok(()) => {
+                self.conn.execute_batch("RELEASE rekey;")?;
+                Ok(())
+            }
+            Err(e) => {
+                let _ = self.conn.execute_batch("ROLLBACK TO rekey; RELEASE rekey;");
+                Err(e)
+            }
+        }
+    }
+
     fn migrate(&self) -> Result<()> {
         self.conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);",
@@ -1391,6 +1444,53 @@ mod tests {
     #[rstest]
     fn path_is_none_for_in_memory(db: Database) {
         assert_eq!(db.path(), None);
+    }
+
+    /// KTD-6 re-key plumbing (#642 U11 stage 3): rows move atomically, a
+    /// row colliding with an identical twin under the target dedups away,
+    /// and the SAVEPOINT nests correctly inside a drain batch transaction.
+    #[rstest]
+    fn merge_conversation_moves_dedups_and_nests_in_a_batch(db: Database) {
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let number = "+15551234567";
+        db.upsert_conversation(uuid, uuid, false).unwrap();
+        db.upsert_conversation(number, "Ada", false).unwrap();
+        let insert = |conv: &str, ts_ms: i64, body: &str| {
+            db.insert_message_full(
+                conv,
+                "Ada",
+                "2026-07-24T12:00:00+00:00",
+                body,
+                false,
+                None,
+                ts_ms,
+                uuid,
+                None,
+                None,
+                None,
+                0,
+                0,
+                0,
+            )
+            .unwrap()
+        };
+        // Unique message under the uuid conversation, plus one delivered on
+        // BOTH sides of the re-key boundary (same dedup key either side).
+        insert(uuid, 1000, "only under uuid").unwrap();
+        insert(uuid, 2000, "delivered twice").unwrap();
+        insert(number, 2000, "delivered twice").unwrap();
+
+        db.begin_batch();
+        db.merge_conversation(uuid, number).unwrap();
+        db.commit_batch();
+
+        let merged = db.load_messages_page(number, 50, 0).unwrap();
+        assert_eq!(
+            merged.len(),
+            2,
+            "unique row moved, colliding twin deduped away"
+        );
+        assert!(db.load_messages_page(uuid, 50, 0).unwrap().is_empty());
     }
 
     #[test]

--- a/src/handlers/signal.rs
+++ b/src/handlers/signal.rs
@@ -1494,6 +1494,33 @@ fn handle_contact_list(app: &mut App, contacts: Vec<Contact>) {
         let Some(key) = contact.key().map(|k| k.to_string()) else {
             continue;
         };
+        // KTD-6 race repair (#642 U11 stage 3): a message that arrived
+        // before this sync created a uuid-keyed conversation; the number
+        // is now known, so fold it into the canonical E.164 key before
+        // the name update below, or history splits across two sidebar
+        // entries. Both backends benefit; the native engine hits this on
+        // every freshly linked device (contact sync is not automatic).
+        if let Some(ref uuid) = contact.uuid
+            && contact.number.is_some()
+            && uuid != &key
+            && app.store.conversations.contains_key(uuid.as_str())
+        {
+            let display = contact
+                .name
+                .clone()
+                .filter(|n| !n.is_empty())
+                .unwrap_or_else(|| key.clone());
+            let was_active = |slot: &Option<String>| slot.as_deref() == Some(uuid.as_str());
+            let active = was_active(&app.active_conversation);
+            let prev_active = was_active(&app.prev_active_conversation);
+            app.store.rekey_conversation(&app.db, uuid, &key, &display);
+            if active {
+                app.active_conversation = Some(key.clone());
+            }
+            if prev_active {
+                app.prev_active_conversation = Some(key.clone());
+            }
+        }
         // Store name in lookup for future message resolution. A username-only
         // contact with no profile name still gets a displayable identity: the
         // @handle (#612).


### PR DESCRIPTION
## Summary

The two remaining automated legs of the U11 contract.

## KTD-6 late-sync re-key (the race test the plan carries)

A message that arrives before contact sync keys its conversation by ACI uuid (the native engine hits this on every freshly linked device - spike finding: contact sync is not automatic). When a later ContactList maps that uuid to an E.164, `handle_contact_list` now folds the uuid-keyed conversation into the canonical number key, in memory and SQLite, so history never splits across two sidebar entries.

- `ConversationStore::rekey_conversation`: moves messages (chronologically interleaved via stable sort), carries unread/accepted/expiration, migrates the contact-name and username lookups, drops the retired key from sidebar order
- `Database::merge_conversation`: SAVEPOINT-scoped so it nests inside a drain batch transaction; `UPDATE OR IGNORE` dedups rows that were delivered on both sides of the re-key boundary against the v16 unique index
- Ordering matters and is documented: the target's conversations row is created BEFORE rows move (messages carries an FK, and FK violations are not subject to OR IGNORE - caught by the new tests)
- `active_conversation` / `prev_active_conversation` follow the re-key so the open chat never dangles
- Backend-neutral: the signal-cli path benefits identically

## Crash injection + deterministic torture leg (KTD-2)

`SIGGY_TEST_JOURNAL_ABORT_AFTER=N` makes the journal writer `abort()` (no unwinding - the honest kill -9 analog) immediately after the Nth append, landing exactly on the committed-but-unprocessed boundary. The new subprocess test spawns the test binary as a child, lets it die mid-burst at N=3, then asserts the survivors are precisely the committed prefix, in order, nothing more or less. Combined with stage 2's replay/dedup tests this closes the automatable part of the Verification Contract; the random kill -9 chaos layer and the live sender-manifest oracle are the Tier-3 manual run.

## Tests

7 new: the KTD-6 race end-to-end (uuid conv -> ContactList -> merged, DB verified via fresh-connection reload), merge into an existing number conversation with chronological interleave, active-conversation follow, no-op guard, db-level merge with collision dedup inside a batch, subprocess crash test, plus the ignored subprocess helper.

- Default lane: 902 + 261 green, clippy -D warnings clean
- Native lane: 943 + 261 green, clippy -D warnings clean

## After this

U11's remaining item is Tier-3 live verification (link a real device, receive from a phone, backlog-after-restart, kill -9 during a burst) - that folds in the deferred U10 Tier-3 leg and needs the maintainer's phone. U12 (native send) is next on the plan.

Part of #642

🤖 Generated with [Claude Code](https://claude.com/claude-code)