### PR TITLE
feat(native): U12 - native 1:1 send + username resolution (part of #642)

### DIFF
--- a/src/backend/native/mod.rs
+++ b/src/backend/native/mod.rs
@@ -11,12 +11,14 @@ pub mod journal;
 pub mod linking;
 pub mod receive;
 pub mod runtime;
+pub mod send;
 pub mod store;
 pub mod supervisor;
 
 use crate::app::{App, SendRequest};
 use crate::config::Config;
 use crate::debug_log;
+use crate::handlers;
 use crate::signal::types::LinkState;
 
 use super::Backend;
@@ -26,15 +28,33 @@ use supervisor::{EngineStatus, ReceiveEngine};
 pub const ENGINE_NAME: &str = "native";
 
 /// The native engine adapter: owns the receive supervisor's engine thread
-/// once [`Backend::startup`] spawns it. Send routing (U12) will reuse the
-/// same thread.
+/// once [`Backend::startup`] spawns it; sends route over the same thread's
+/// command channel (U12).
 pub struct NativeBackend {
     engine: Option<ReceiveEngine>,
+    /// Last wire timestamp handed out (KTD-4): tokens must be strictly
+    /// increasing and unique even for two sends inside one millisecond,
+    /// both for `pending.sends` correlation and for Signal's own
+    /// (sender, timestamp) message identity.
+    last_wire_ts: i64,
 }
 
 impl NativeBackend {
     pub fn new() -> Self {
-        Self { engine: None }
+        Self {
+            engine: None,
+            last_wire_ts: 0,
+        }
+    }
+
+    /// KTD-4 wire timestamp: now, bumped past the previous send when two
+    /// land in the same millisecond. The caller-chosen value IS the wire
+    /// timestamp natively, so the #480 local→server rewrite no-ops.
+    fn next_wire_ts(&mut self) -> i64 {
+        let now = chrono::Utc::now().timestamp_millis();
+        let ts = now.max(self.last_wire_ts + 1);
+        self.last_wire_ts = ts;
+        ts
     }
 
     /// Instance-free link-state probe, same signature as
@@ -121,10 +141,89 @@ impl Backend for NativeBackend {
         false
     }
 
-    /// U12 routes the send vocabulary through the engine thread. Until
-    /// then, surface the truth instead of silently dropping the request.
-    async fn dispatch(&mut self, app: &mut App, _req: SendRequest) {
-        app.status_message = "native engine: sending not implemented yet (#642 U12)".to_string();
+    /// U12: 1:1 messages and username resolution route over the engine
+    /// thread's command channel. Everything else states its unit honestly
+    /// instead of silently dropping the request (KTD-10 spirit): groups
+    /// are U13, attachments U14, reactions/edits/deletes U15, the
+    /// receipt/typing/profile tail U16+.
+    async fn dispatch(&mut self, app: &mut App, req: SendRequest) {
+        match req {
+            SendRequest::Message {
+                recipient,
+                body,
+                is_group,
+                local_ts_ms,
+                attachment,
+                ..
+                // mentions/text_styles/quote/preview deferred to U15: the
+                // body still carries the display text, so the message
+                // sends as plain text until rich bodies land.
+            } => {
+                if is_group {
+                    app.status_message =
+                        "native engine: group sends not implemented yet (#642 U13)".to_string();
+                    handlers::signal::mark_send_failed(app, &recipient, local_ts_ms);
+                    return;
+                }
+                if attachment.is_some() {
+                    app.status_message =
+                        "native engine: attachments not implemented yet (#642 U14)".to_string();
+                    handlers::signal::mark_send_failed(app, &recipient, local_ts_ms);
+                    return;
+                }
+                if self.engine.is_none() {
+                    app.status_message = "native engine: not connected".to_string();
+                    handlers::signal::mark_send_failed(app, &recipient, local_ts_ms);
+                    return;
+                }
+                let wire_ts = self.next_wire_ts();
+                let engine = self.engine.as_ref().expect("checked above");
+                let token = crate::signal::types::SendToken::new(wire_ts.to_string());
+                debug_log::logf(format_args!(
+                    "native send: to={} wire_ts={wire_ts} local_ts={local_ts_ms}",
+                    debug_log::mask_phone(&recipient)
+                ));
+                app.pending
+                    .sends
+                    .insert(token.clone(), (recipient.clone(), local_ts_ms));
+                let command = send::SendCommand::Message {
+                    token: token.clone(),
+                    recipient: recipient.clone(),
+                    body,
+                    timestamp_ms: wire_ts as u64,
+                };
+                if engine.commands.send(command).is_err() {
+                    // Engine thread gone: no SendFailed event will ever
+                    // arrive, mark it here (#486 lesson).
+                    app.pending.sends.remove(&token);
+                    app.status_message = "native engine: send failed (engine stopped)".to_string();
+                    handlers::signal::mark_send_failed(app, &recipient, local_ts_ms);
+                }
+            }
+            SendRequest::ResolveUsername { username } => match &self.engine {
+                Some(engine) => {
+                    if engine
+                        .commands
+                        .send(send::SendCommand::ResolveUsername { username })
+                        .is_err()
+                    {
+                        app.pending.username_resolve = None;
+                        app.status_message =
+                            "Username lookup failed: native engine stopped".to_string();
+                    }
+                }
+                None => {
+                    app.pending.username_resolve = None;
+                    app.status_message = "Username lookup failed: not connected".to_string();
+                }
+            },
+            other => {
+                app.status_message = format!(
+                    "native engine: {} not implemented yet (#642)",
+                    other.kind_name()
+                );
+            }
+        }
     }
 
     async fn startup(&mut self, app: &mut App) {
@@ -263,6 +362,38 @@ mod tests {
         }
     }
 
+    /// Hand-fed channel triple around a test ReceiveEngine: (event sender,
+    /// status sender, command receiver, backend).
+    fn engine_backend() -> (
+        mpsc::UnboundedSender<EngineEvent>,
+        watch::Sender<EngineStatus>,
+        mpsc::UnboundedReceiver<send::SendCommand>,
+        NativeBackend,
+    ) {
+        let (event_tx, event_rx) = mpsc::unbounded_channel();
+        let (status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+        let (command_tx, command_rx) = mpsc::unbounded_channel();
+        let mut backend = NativeBackend::new();
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx, command_tx));
+        (event_tx, status_tx, command_rx, backend)
+    }
+
+    fn message_req(recipient: &str, body: &str, local_ts_ms: i64) -> SendRequest {
+        SendRequest::Message {
+            recipient: recipient.into(),
+            body: body.into(),
+            is_group: false,
+            local_ts_ms,
+            mentions: vec![],
+            text_styles: vec![],
+            attachment: None,
+            preview: None,
+            quote_timestamp: None,
+            quote_author: None,
+            quote_body: None,
+        }
+    }
+
     fn message_count(app: &App, conv_id: &str) -> usize {
         app.store
             .conversations
@@ -356,8 +487,9 @@ mod tests {
 
         let (event_tx, event_rx) = mpsc::unbounded_channel();
         let (_status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+        let (_command_tx, _command_rx) = mpsc::unbounded_channel();
         let mut backend = NativeBackend::new();
-        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx));
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx, _command_tx));
 
         event_tx
             .send(EngineEvent {
@@ -381,8 +513,9 @@ mod tests {
 
         let (_event_tx, event_rx) = mpsc::unbounded_channel();
         let (status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+        let (_command_tx, _command_rx) = mpsc::unbounded_channel();
         let mut backend = NativeBackend::new();
-        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx));
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx, _command_tx));
 
         status_tx.send(EngineStatus::Connected).unwrap();
         assert!(backend.drain_events(&mut app));
@@ -412,8 +545,9 @@ mod tests {
 
         let (event_tx, event_rx) = mpsc::unbounded_channel::<EngineEvent>();
         let (_status_tx, status_rx) = watch::channel(EngineStatus::Connected);
+        let (_command_tx, _command_rx) = mpsc::unbounded_channel();
         let mut backend = NativeBackend::new();
-        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx));
+        backend.engine = Some(ReceiveEngine::for_test(event_rx, status_rx, _command_tx));
         drop(event_tx); // supervisor panicked: channel closes with no Terminal
 
         backend.drain_events(&mut app);
@@ -430,5 +564,149 @@ mod tests {
         let mut app = file_backed_app(dir.path());
         let mut backend = NativeBackend::new();
         assert!(!backend.drain_events(&mut app));
+    }
+
+    // --- U12 dispatch: send routing (KTD-4) ---
+
+    #[tokio::test]
+    async fn dispatch_routes_sends_with_strictly_increasing_wire_timestamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let (_event_tx, _status_tx, mut command_rx, mut backend) = engine_backend();
+
+        // Two sends in (almost certainly) the same millisecond: KTD-4
+        // demands distinct, strictly increasing wire timestamps anyway.
+        backend
+            .dispatch(&mut app, message_req("+15550001111", "one", 111))
+            .await;
+        backend
+            .dispatch(&mut app, message_req("+15550001111", "two", 222))
+            .await;
+
+        let first = match command_rx.try_recv().unwrap() {
+            send::SendCommand::Message {
+                token,
+                body,
+                timestamp_ms,
+                ..
+            } => {
+                assert_eq!(body, "one");
+                assert_eq!(token.to_string(), timestamp_ms.to_string());
+                timestamp_ms
+            }
+            _ => panic!("expected Message command"),
+        };
+        let second = match command_rx.try_recv().unwrap() {
+            send::SendCommand::Message { timestamp_ms, .. } => timestamp_ms,
+            _ => panic!("expected Message command"),
+        };
+        assert!(
+            second > first,
+            "wire timestamps must be strictly increasing: {first} then {second}"
+        );
+        assert_eq!(
+            app.pending.sends.len(),
+            2,
+            "both sends registered for confirmation correlation"
+        );
+    }
+
+    #[tokio::test]
+    async fn dispatch_gates_groups_and_attachments_honestly() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let (_event_tx, _status_tx, mut command_rx, mut backend) = engine_backend();
+
+        let mut group = message_req("Z3JvdXBpZA==", "hi", 1);
+        if let SendRequest::Message { is_group, .. } = &mut group {
+            *is_group = true;
+        }
+        backend.dispatch(&mut app, group).await;
+        assert!(app.status_message.contains("U13"));
+
+        let mut with_attachment = message_req("+15550001111", "hi", 2);
+        if let SendRequest::Message { attachment, .. } = &mut with_attachment {
+            *attachment = Some(std::path::PathBuf::from("x.png"));
+        }
+        backend.dispatch(&mut app, with_attachment).await;
+        assert!(app.status_message.contains("U14"));
+
+        assert!(
+            command_rx.try_recv().is_err(),
+            "gated requests never reach the engine"
+        );
+        assert!(app.pending.sends.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatch_with_dead_engine_thread_fails_the_send_immediately() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let (_event_tx, _status_tx, command_rx, mut backend) = engine_backend();
+        drop(command_rx); // engine thread died
+
+        backend
+            .dispatch(&mut app, message_req("+15550001111", "hi", 1))
+            .await;
+        assert!(
+            app.pending.sends.is_empty(),
+            "no confirmation will ever arrive; the pending entry must not leak"
+        );
+        assert!(app.status_message.contains("engine stopped"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_without_engine_reports_not_connected() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let mut backend = NativeBackend::new();
+        backend
+            .dispatch(&mut app, message_req("+15550001111", "hi", 1))
+            .await;
+        assert_eq!(app.status_message, "native engine: not connected");
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_username_resolution() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let (_event_tx, _status_tx, mut command_rx, mut backend) = engine_backend();
+        backend
+            .dispatch(
+                &mut app,
+                SendRequest::ResolveUsername {
+                    username: "ada.42".into(),
+                },
+            )
+            .await;
+        assert!(matches!(
+            command_rx.try_recv().unwrap(),
+            send::SendCommand::ResolveUsername { username } if username == "ada.42"
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_names_unrouted_operations() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = file_backed_app(dir.path());
+        let (_event_tx, _status_tx, _command_rx, mut backend) = engine_backend();
+        backend
+            .dispatch(
+                &mut app,
+                SendRequest::Reaction {
+                    conv_id: "+15550001111".into(),
+                    emoji: "x".into(),
+                    is_group: false,
+                    target_author: "+15550001111".into(),
+                    target_timestamp: 1,
+                    remove: false,
+                },
+            )
+            .await;
+        assert!(
+            app.status_message.contains("reactions"),
+            "capability copy names the operation: {}",
+            app.status_message
+        );
     }
 }

--- a/src/backend/native/runtime.rs
+++ b/src/backend/native/runtime.rs
@@ -20,6 +20,13 @@ pub struct EngineThread<T> {
     handle: thread::JoinHandle<T>,
 }
 
+/// Stack size for the engine thread. Spawned threads default to 2MiB, which
+/// presage/libsignal's receive futures overflowed on the first live boot
+/// (debug builds keep their giant async state machines on the stack). The
+/// spike never saw this because it ran on the main thread's 8MiB stack.
+/// 16MiB is virtual address space, committed only as touched.
+const ENGINE_STACK_SIZE: usize = 16 * 1024 * 1024;
+
 impl<T: Send + 'static> EngineThread<T> {
     /// Spawn the dedicated thread and drive `make_future`'s output to
     /// completion on a `LocalSet`. The closure runs ON the engine thread,
@@ -32,6 +39,7 @@ impl<T: Send + 'static> EngineThread<T> {
     {
         let handle = thread::Builder::new()
             .name(name.to_string())
+            .stack_size(ENGINE_STACK_SIZE)
             .spawn(move || {
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
@@ -80,6 +88,27 @@ mod tests {
         })
         .unwrap();
         assert_eq!(engine.join().unwrap(), 42);
+    }
+
+    /// The engine thread must carry presage/libsignal's receive machinery,
+    /// whose debug-build futures burn several MiB of stack - far past the
+    /// 2MiB spawned-thread default that overflowed on first live boot
+    /// (Tier-3, #642). Recurse ~6MiB deep on the engine thread: overflow
+    /// aborts the test process, so a regression here fails loudly.
+    #[test]
+    fn engine_thread_survives_deep_stacks() {
+        #[inline(never)]
+        fn burn(depth: u32) -> u64 {
+            let mut buf = [0u8; 256 * 1024];
+            std::hint::black_box(&mut buf);
+            if depth == 0 {
+                buf[0] as u64
+            } else {
+                burn(depth - 1) + std::hint::black_box(buf[1] as u64)
+            }
+        }
+        let engine = EngineThread::spawn("test-engine-stack", || async { burn(24) }).unwrap();
+        assert_eq!(engine.join().unwrap(), 0);
     }
 
     #[test]

--- a/src/backend/native/send.rs
+++ b/src/backend/native/send.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use presage::libsignal_service::content::DataMessage;
-use presage::libsignal_service::prelude::{phonenumber, Uuid};
+use presage::libsignal_service::prelude::{Uuid, phonenumber};
 use presage::libsignal_service::protocol::{Aci, ServiceId};
 use presage::manager::{Manager, Registered};
 use presage::model::identity::OnNewIdentity;

--- a/src/backend/native/send.rs
+++ b/src/backend/native/send.rs
@@ -18,7 +18,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use presage::libsignal_service::content::DataMessage;
-use presage::libsignal_service::prelude::Uuid;
+use presage::libsignal_service::prelude::{phonenumber, Uuid};
 use presage::libsignal_service::protocol::{Aci, ServiceId};
 use presage::manager::{Manager, Registered};
 use presage::model::identity::OnNewIdentity;
@@ -213,6 +213,13 @@ async fn send_one(
 /// directly; E.164 keys resolve through the store's contact sync. An
 /// unresolvable number means contact sync has not supplied it yet - the
 /// send fails rather than guessing.
+/// Note to Self (Tier-3 finding, #642): the account's own number never
+/// appears in the synced contact list, so it must resolve from the
+/// registration data before the contacts walk gets a chance to fail it.
+fn own_aci_for_number(number: &str, own_e164: &str, own_aci: Uuid) -> Option<ServiceId> {
+    (number == own_e164).then(|| Aci::from(own_aci).into())
+}
+
 async fn resolve_recipient(
     manager: &Manager<SqliteStore, Registered>,
     key: &str,
@@ -220,6 +227,15 @@ async fn resolve_recipient(
     match classify_recipient(key) {
         RecipientKind::Aci(uuid) => Some(Aci::from(uuid).into()),
         RecipientKind::Number(number) => {
+            let data = manager.registration_data();
+            let own_e164 = data
+                .phone_number
+                .format()
+                .mode(phonenumber::Mode::E164)
+                .to_string();
+            if let Some(own) = own_aci_for_number(&number, &own_e164, data.service_ids.aci) {
+                return Some(own);
+            }
             let contacts = match manager.store().contacts().await {
                 Ok(contacts) => contacts,
                 Err(e) => {
@@ -274,6 +290,27 @@ fn emit(event_tx: &mpsc::UnboundedSender<EngineEvent>, event: SignalEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Note to Self (Tier-3 finding, #642): the account's own number never
+    /// appears in the synced contact list, so the contacts walk alone fails
+    /// every send-to-self. The own-number check must answer first.
+    #[test]
+    fn own_number_resolves_to_own_aci_without_contacts() {
+        let own_aci: Uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".parse().unwrap();
+        assert_eq!(
+            own_aci_for_number("+15551234567", "+15551234567", own_aci),
+            Some(Aci::from(own_aci).into())
+        );
+    }
+
+    #[test]
+    fn other_numbers_fall_through_to_the_contacts_walk() {
+        let own_aci: Uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee".parse().unwrap();
+        assert_eq!(
+            own_aci_for_number("+15559999999", "+15551234567", own_aci),
+            None
+        );
+    }
 
     #[test]
     fn uuid_keys_classify_as_aci() {

--- a/src/backend/native/send.rs
+++ b/src/backend/native/send.rs
@@ -1,0 +1,304 @@
+//! Native send path (#642 U12, plan KTD-4).
+//!
+//! Sends run on the engine thread beside the receive supervisor: the
+//! adapter's `dispatch` pushes a [`SendCommand`] over the engine's command
+//! channel, the loop here resolves the recipient against the store (the
+//! reverse of KTD-6's identity mapping) and drives
+//! `Manager::send_message`. Each send runs as its own `spawn_local` task
+//! with a cloned Manager, so a hung websocket never blocks later sends.
+//!
+//! Status semantics (KTD-4): the caller-chosen wire timestamp doubles as
+//! the [`SendToken`], `Ok` synthesizes `SendTimestamp` (spike finding:
+//! `Ok` means server-accepted), `Err` or a 30s timeout synthesizes
+//! `SendFailed` - and a timed-out future is deliberately NOT dropped: a
+//! late `Ok` still emits `SendTimestamp`, which upgrades the message
+//! Failed → Sent through the dedicated status route (the #486 lesson).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use presage::libsignal_service::content::DataMessage;
+use presage::libsignal_service::prelude::Uuid;
+use presage::libsignal_service::protocol::{Aci, ServiceId};
+use presage::manager::{Manager, Registered};
+use presage::model::identity::OnNewIdentity;
+use presage::store::ContentsStore;
+use presage_store_sqlite::SqliteStore;
+use tokio::sync::mpsc;
+
+use crate::debug_log;
+use crate::signal::types::{SendToken, SignalEvent, UserStatus};
+
+use super::supervisor::EngineEvent;
+
+/// KTD-4: native has no eventually-answering RPC peer; a hung websocket
+/// must not leave messages in Sending forever.
+const SEND_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The adapter → engine send vocabulary (U12: 1:1 messages and username
+/// resolution; groups are U13, attachments U14, rich bodies U15).
+pub enum SendCommand {
+    Message {
+        token: SendToken,
+        /// Conversation key: E.164 or ACI uuid (KTD-6 formats).
+        recipient: String,
+        body: String,
+        /// Wire timestamp, already uniqueness-adjusted by the adapter.
+        timestamp_ms: u64,
+    },
+    ResolveUsername {
+        username: String,
+    },
+}
+
+/// How a conversation key converts back to a wire identity (the reverse of
+/// the KTD-6 selection rule). Pure so it unit-tests without a store.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum RecipientKind {
+    Aci(Uuid),
+    Number(String),
+}
+
+pub(super) fn classify_recipient(key: &str) -> RecipientKind {
+    match key.parse::<Uuid>() {
+        Ok(uuid) => RecipientKind::Aci(uuid),
+        Err(_) => RecipientKind::Number(key.to_string()),
+    }
+}
+
+/// Long-lived command loop, spawned on the supervisor's LocalSet. Loads
+/// its own Manager lazily on the first send so a send-free session never
+/// pays for it.
+pub(super) async fn run_send_loop(
+    store_file: PathBuf,
+    mut commands: mpsc::UnboundedReceiver<SendCommand>,
+    event_tx: mpsc::UnboundedSender<EngineEvent>,
+) {
+    let mut manager: Option<Manager<SqliteStore, Registered>> = None;
+    while let Some(command) = commands.recv().await {
+        let Some(manager) = ensure_manager(&mut manager, &store_file, &command, &event_tx).await
+        else {
+            continue;
+        };
+        match command {
+            SendCommand::Message {
+                token,
+                recipient,
+                body,
+                timestamp_ms,
+            } => {
+                // Per-send Manager clone: sends are independent tasks, and
+                // one stuck 30s timeout must not serialize the rest.
+                let manager = manager.clone();
+                let event_tx = event_tx.clone();
+                tokio::task::spawn_local(send_one(
+                    manager,
+                    token,
+                    recipient,
+                    body,
+                    timestamp_ms,
+                    event_tx,
+                ));
+            }
+            SendCommand::ResolveUsername { username } => {
+                resolve_username(manager, &username, &event_tx).await;
+            }
+        }
+    }
+}
+
+/// Load the send-side Manager on first use; on failure, fail the command
+/// honestly (a Message gets its SendFailed, a lookup gets an unregistered
+/// answer) instead of wedging.
+async fn ensure_manager<'a>(
+    slot: &'a mut Option<Manager<SqliteStore, Registered>>,
+    store_file: &Path,
+    command: &SendCommand,
+    event_tx: &mpsc::UnboundedSender<EngineEvent>,
+) -> Option<&'a mut Manager<SqliteStore, Registered>> {
+    if slot.is_none() {
+        match load_manager(store_file).await {
+            Ok(manager) => *slot = Some(manager),
+            Err(e) => {
+                debug_log::logf(format_args!("native send: manager load failed: {e}"));
+                match command {
+                    SendCommand::Message { token, .. } => {
+                        emit(
+                            event_tx,
+                            SignalEvent::SendFailed {
+                                token: token.clone(),
+                            },
+                        );
+                    }
+                    SendCommand::ResolveUsername { .. } => {
+                        emit(
+                            event_tx,
+                            SignalEvent::Error(format!("Username lookup failed: {e}")),
+                        );
+                    }
+                }
+                return None;
+            }
+        }
+    }
+    slot.as_mut()
+}
+
+async fn load_manager(store_file: &Path) -> anyhow::Result<Manager<SqliteStore, Registered>> {
+    let path = store_file
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("native store path is not valid UTF-8"))?;
+    let store = SqliteStore::open(path, OnNewIdentity::Trust).await?;
+    Ok(Manager::load_registered(store).await?)
+}
+
+/// One send, one task: resolve → send with the KTD-4 timeout contract.
+async fn send_one(
+    mut manager: Manager<SqliteStore, Registered>,
+    token: SendToken,
+    recipient_key: String,
+    body: String,
+    timestamp_ms: u64,
+    event_tx: mpsc::UnboundedSender<EngineEvent>,
+) {
+    let Some(recipient) = resolve_recipient(&manager, &recipient_key).await else {
+        debug_log::logf(format_args!(
+            "native send: no wire identity for {}",
+            debug_log::mask_phone(&recipient_key)
+        ));
+        emit(&event_tx, SignalEvent::SendFailed { token });
+        return;
+    };
+    let message = DataMessage {
+        body: Some(body),
+        timestamp: Some(timestamp_ms),
+        ..Default::default()
+    };
+
+    let send = manager.send_message(recipient, message, timestamp_ms);
+    tokio::pin!(send);
+    tokio::select! {
+        result = &mut send => match result {
+            // Spike finding (#639 question 2): Ok means server-accepted;
+            // the local timestamp IS the wire timestamp, so the #480
+            // rewrite dance no-ops.
+            Ok(()) => emit(&event_tx, SignalEvent::SendTimestamp {
+                token,
+                server_ts: timestamp_ms as i64,
+            }),
+            Err(e) => {
+                debug_log::logf(format_args!("native send failed: {e}"));
+                emit(&event_tx, SignalEvent::SendFailed { token });
+            }
+        },
+        _ = tokio::time::sleep(SEND_TIMEOUT) => {
+            // KTD-4: report the timeout, but keep driving the future - a
+            // late Ok upgrades Failed → Sent exactly once via the
+            // dedicated status route (#486).
+            emit(&event_tx, SignalEvent::SendFailed { token: token.clone() });
+            match send.await {
+                Ok(()) => emit(&event_tx, SignalEvent::SendTimestamp {
+                    token,
+                    server_ts: timestamp_ms as i64,
+                }),
+                Err(e) => debug_log::logf(format_args!(
+                    "native send failed after timeout: {e}"
+                )),
+            }
+        }
+    }
+}
+
+/// Conversation key → wire ServiceId (reverse KTD-6): uuid keys convert
+/// directly; E.164 keys resolve through the store's contact sync. An
+/// unresolvable number means contact sync has not supplied it yet - the
+/// send fails rather than guessing.
+async fn resolve_recipient(
+    manager: &Manager<SqliteStore, Registered>,
+    key: &str,
+) -> Option<ServiceId> {
+    match classify_recipient(key) {
+        RecipientKind::Aci(uuid) => Some(Aci::from(uuid).into()),
+        RecipientKind::Number(number) => {
+            let contacts = match manager.store().contacts().await {
+                Ok(contacts) => contacts,
+                Err(e) => {
+                    debug_log::logf(format_args!("native send: contacts read failed: {e}"));
+                    return None;
+                }
+            };
+            for contact in contacts.flatten() {
+                if super::supervisor::contact_e164(&contact).as_deref() == Some(number.as_str()) {
+                    return Some(Aci::from(contact.uuid).into());
+                }
+            }
+            None
+        }
+    }
+}
+
+/// `/join @handle` resolution (#612): the native twin of signal-cli's
+/// getUserStatus round-trip, answered from `lookup_username`. The reply
+/// mirrors signal-cli's `u:`-prefixed recipient echo so
+/// `handle_user_status_list` matches it unchanged.
+async fn resolve_username(
+    manager: &mut Manager<SqliteStore, Registered>,
+    username: &str,
+    event_tx: &mpsc::UnboundedSender<EngineEvent>,
+) {
+    let status = match manager.lookup_username(username).await {
+        Ok(found) => UserStatus {
+            recipient: format!("u:{username}"),
+            username: Some(username.to_string()),
+            uuid: found.map(|aci| aci.service_id_string()),
+            registered: found.is_some(),
+        },
+        Err(e) => {
+            emit(
+                event_tx,
+                SignalEvent::Error(format!("Username lookup failed: {e}")),
+            );
+            return;
+        }
+    };
+    emit(event_tx, SignalEvent::UserStatusList(vec![status]));
+}
+
+fn emit(event_tx: &mpsc::UnboundedSender<EngineEvent>, event: SignalEvent) {
+    let _ = event_tx.send(EngineEvent {
+        journal_id: None,
+        event,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_keys_classify_as_aci() {
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        assert_eq!(
+            classify_recipient(uuid),
+            RecipientKind::Aci(uuid.parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn e164_keys_classify_as_number() {
+        assert_eq!(
+            classify_recipient("+15551234567"),
+            RecipientKind::Number("+15551234567".into())
+        );
+    }
+
+    #[test]
+    fn group_ids_and_garbage_fall_through_as_numbers() {
+        // A base64 group id is not a uuid; classification never panics on
+        // arbitrary keys (the dispatch layer gates groups before this).
+        assert!(matches!(
+            classify_recipient("Z3JvdXBpZGdyb3VwaWRncm91cGlkZ3JvdXBpZA=="),
+            RecipientKind::Number(_)
+        ));
+    }
+}

--- a/src/backend/native/supervisor.rs
+++ b/src/backend/native/supervisor.rs
@@ -316,10 +316,10 @@ impl IdentityResolver for StoreResolver {
     }
 }
 
-/// The account's own ACI never appears in the synced contact list (Tier-3
-/// finding, #642), so without this seed self-conversations key by uuid on
-/// receive while the send path keys them by number - splitting Note to
-/// Self across two sidebar entries.
+/// Tier-3 finding (#642): the primary syncs the own account as a contact
+/// entry WITHOUT a phone number (or not at all), so without this the
+/// resolver keys self-conversations by uuid on receive while the send path
+/// keys them by number - splitting Note to Self across two sidebar entries.
 fn seed_own_identity(
     by_aci: &mut HashMap<String, (Option<String>, Option<String>)>,
     own_aci: &str,
@@ -368,6 +368,26 @@ fn non_empty(s: &str) -> Option<String> {
 /// Emit ContactList + GroupList from the store so `App` names
 /// conversations and populates mention maps. Not journaled: re-emitted at
 /// every session start and on every Contacts sync.
+/// Directory self entry (Tier-3 finding, #642): the app-level ContactList
+/// handler needs the (own aci, own number) pair to fold a uuid-keyed Note
+/// to Self conversation into the canonical E.164 key. The primary syncs
+/// the own account as a contact WITHOUT a phone number, so fill the number
+/// on the existing entry rather than skipping it; append when absent.
+fn ensure_self_entry(contacts_out: &mut Vec<Contact>, own_aci: &str, own_e164: &str) {
+    match contacts_out
+        .iter_mut()
+        .find(|c| c.uuid.as_deref() == Some(own_aci))
+    {
+        Some(own) => own.number = Some(own_e164.to_string()),
+        None => contacts_out.push(Contact {
+            number: Some(own_e164.to_string()),
+            name: None,
+            uuid: Some(own_aci.to_string()),
+            username: None,
+        }),
+    }
+}
+
 async fn emit_directory(
     store: &SqliteStore,
     resolver: &StoreResolver,
@@ -389,18 +409,7 @@ async fn emit_directory(
             });
         }
     }
-    // Self entry (Tier-3 finding, #642): signal-cli's listContacts includes
-    // the own account, and the app-level ContactList handler needs the
-    // (own aci, own number) pair to fold a uuid-keyed Note to Self
-    // conversation into the canonical E.164 key.
-    if !contacts_out.iter().any(|c| c.uuid.as_deref() == Some(own_aci)) {
-        contacts_out.push(Contact {
-            number: Some(own_e164.to_string()),
-            name: None,
-            uuid: Some(own_aci.to_string()),
-            username: None,
-        });
-    }
+    ensure_self_entry(&mut contacts_out, own_aci, own_e164);
     if !contacts_out.is_empty() {
         let _ = event_tx.send(EngineEvent {
             journal_id: None,
@@ -458,6 +467,34 @@ mod tests {
         assert_eq!(backoff(5), Duration::from_secs(30));
         // No attempt cap: hour-1000 still retries at the 30s ceiling.
         assert_eq!(backoff(100_000), Duration::from_secs(30));
+    }
+
+    /// Tier-3 live finding: the primary syncs the own account as a contact
+    /// entry WITH NO phone number. The directory self entry must fill the
+    /// number on that existing entry - a skip-if-present guard leaves
+    /// number=None and the app-level re-key never fires (the second half
+    /// of the Note to Self split, #642).
+    #[test]
+    fn self_entry_fills_the_number_on_an_existing_numberless_contact() {
+        let mut contacts = vec![Contact {
+            number: None,
+            name: Some("John".to_string()),
+            uuid: Some("self-aci".to_string()),
+            username: None,
+        }];
+        ensure_self_entry(&mut contacts, "self-aci", "+15551234567");
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(contacts[0].number.as_deref(), Some("+15551234567"));
+        assert_eq!(contacts[0].name.as_deref(), Some("John"));
+    }
+
+    #[test]
+    fn self_entry_is_appended_when_contacts_lack_the_own_account() {
+        let mut contacts = Vec::new();
+        ensure_self_entry(&mut contacts, "self-aci", "+15551234567");
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(contacts[0].uuid.as_deref(), Some("self-aci"));
+        assert_eq!(contacts[0].number.as_deref(), Some("+15551234567"));
     }
 
     /// Note to Self splits (Tier-3 finding, #642): the account's own ACI is

--- a/src/backend/native/supervisor.rs
+++ b/src/backend/native/supervisor.rs
@@ -60,11 +60,14 @@ pub struct EngineEvent {
     pub event: SignalEvent,
 }
 
-/// Handle the adapter holds: the event queue, the status watch, and the
-/// engine thread keeping both alive.
+/// Handle the adapter holds: the event queue, the status watch, the send
+/// command channel (U12), and the engine thread keeping them all alive.
 pub struct ReceiveEngine {
     pub events: mpsc::UnboundedReceiver<EngineEvent>,
     pub status: watch::Receiver<EngineStatus>,
+    /// Adapter → engine send path (#642 U12). A closed receiver means the
+    /// engine thread is gone; `dispatch` fails the send honestly.
+    pub commands: mpsc::UnboundedSender<super::send::SendCommand>,
     /// `None` only in tests that fake the channels; production always
     /// carries the thread handle so the supervisor outlives frames.
     #[allow(dead_code)]
@@ -77,10 +80,12 @@ impl ReceiveEngine {
     pub fn for_test(
         events: mpsc::UnboundedReceiver<EngineEvent>,
         status: watch::Receiver<EngineStatus>,
+        commands: mpsc::UnboundedSender<super::send::SendCommand>,
     ) -> Self {
         Self {
             events,
             status,
+            commands,
             thread: None,
         }
     }
@@ -92,12 +97,22 @@ impl ReceiveEngine {
 pub fn spawn(store_file: PathBuf, journal_db: Option<PathBuf>) -> Result<ReceiveEngine> {
     let (event_tx, event_rx) = mpsc::unbounded_channel();
     let (status_tx, status_rx) = watch::channel(EngineStatus::Connecting);
+    let (command_tx, command_rx) = mpsc::unbounded_channel();
     let thread = EngineThread::spawn("siggy-native-receive", move || async move {
+        // The send loop shares the LocalSet with the receive supervisor
+        // (one engine thread, one Manager model each - plan KTD-8); it
+        // exits on its own when the command sender drops with the adapter.
+        tokio::task::spawn_local(super::send::run_send_loop(
+            store_file.clone(),
+            command_rx,
+            event_tx.clone(),
+        ));
         run_supervisor(store_file, journal_db, event_tx, status_tx).await;
     })?;
     Ok(ReceiveEngine {
         events: event_rx,
         status: status_rx,
+        commands: command_tx,
         thread: Some(thread),
     })
 }
@@ -300,7 +315,7 @@ async fn load_resolver(store: &SqliteStore) -> StoreResolver {
                 let Ok(contact) = contact else { continue };
                 by_aci.insert(
                     contact.uuid.to_string(),
-                    (e164(&contact), non_empty(&contact.name)),
+                    (contact_e164(&contact), non_empty(&contact.name)),
                 );
             }
         }
@@ -311,7 +326,7 @@ async fn load_resolver(store: &SqliteStore) -> StoreResolver {
 
 /// KTD-6 format lock: numbers cross the boundary in E.164 exactly as
 /// signal-cli renders them, never phonenumber's display formats.
-fn e164(contact: &presage::model::contacts::Contact) -> Option<String> {
+pub(super) fn contact_e164(contact: &presage::model::contacts::Contact) -> Option<String> {
     use presage::libsignal_service::prelude::phonenumber::Mode;
     contact
         .phone_number
@@ -339,7 +354,7 @@ async fn emit_directory(
     if let Ok(contacts) = store.contacts().await {
         for contact in contacts.flatten() {
             contacts_out.push(Contact {
-                number: e164(&contact),
+                number: contact_e164(&contact),
                 name: non_empty(&contact.name),
                 uuid: Some(contact.uuid.to_string()),
                 // presage's contact model has no username field at the

--- a/src/backend/native/supervisor.rs
+++ b/src/backend/native/supervisor.rs
@@ -214,11 +214,20 @@ async fn run_session(
         Err(e) => return classify_manager_error(e),
     };
     let own_aci = manager.registration_data().service_ids.aci.to_string();
+    let own_e164 = {
+        use presage::libsignal_service::prelude::phonenumber::Mode;
+        manager
+            .registration_data()
+            .phone_number
+            .format()
+            .mode(Mode::E164)
+            .to_string()
+    };
 
     // A cloned store handle for directory reads after `receive_messages`
     // mutably borrows the manager.
     let store_handle = manager.store().clone();
-    let mut resolver = load_resolver(&store_handle).await;
+    let mut resolver = load_resolver(&store_handle, &own_aci, &own_e164).await;
 
     // Spike finding: contact sync is NOT automatic on a linked device. On
     // a fresh store, ask the primary for it (best-effort; the payload
@@ -231,7 +240,7 @@ async fn run_session(
 
     // Directory snapshot so conversations render with names immediately
     // (native twin of the startup listContacts/listGroups round-trip).
-    emit_directory(&store_handle, &resolver, event_tx).await;
+    emit_directory(&store_handle, &resolver, &own_aci, &own_e164, event_tx).await;
 
     let stream = match manager.receive_messages().await {
         Ok(stream) => stream,
@@ -246,8 +255,8 @@ async fn run_session(
             // Payload landed in the store; refresh the resolver and
             // re-emit the directory so late contact sync names existing
             // conversations (KTD-6; the uuid→E164 re-key is stage 3).
-            resolver = load_resolver(&store_handle).await;
-            emit_directory(&store_handle, &resolver, event_tx).await;
+            resolver = load_resolver(&store_handle, &own_aci, &own_e164).await;
+            emit_directory(&store_handle, &resolver, &own_aci, &own_e164, event_tx).await;
             continue;
         }
         for event in receive::map_received(&item, &own_aci, &resolver) {
@@ -307,7 +316,20 @@ impl IdentityResolver for StoreResolver {
     }
 }
 
-async fn load_resolver(store: &SqliteStore) -> StoreResolver {
+/// The account's own ACI never appears in the synced contact list (Tier-3
+/// finding, #642), so without this seed self-conversations key by uuid on
+/// receive while the send path keys them by number - splitting Note to
+/// Self across two sidebar entries.
+fn seed_own_identity(
+    by_aci: &mut HashMap<String, (Option<String>, Option<String>)>,
+    own_aci: &str,
+    own_e164: &str,
+) {
+    let entry = by_aci.entry(own_aci.to_string()).or_insert((None, None));
+    entry.0 = Some(own_e164.to_string());
+}
+
+async fn load_resolver(store: &SqliteStore, own_aci: &str, own_e164: &str) -> StoreResolver {
     let mut by_aci = HashMap::new();
     match store.contacts().await {
         Ok(contacts) => {
@@ -321,6 +343,7 @@ async fn load_resolver(store: &SqliteStore) -> StoreResolver {
         }
         Err(e) => debug_log::logf(format_args!("store contacts read failed: {e}")),
     }
+    seed_own_identity(&mut by_aci, own_aci, own_e164);
     StoreResolver { by_aci }
 }
 
@@ -348,6 +371,8 @@ fn non_empty(s: &str) -> Option<String> {
 async fn emit_directory(
     store: &SqliteStore,
     resolver: &StoreResolver,
+    own_aci: &str,
+    own_e164: &str,
     event_tx: &mpsc::UnboundedSender<EngineEvent>,
 ) {
     let mut contacts_out = Vec::new();
@@ -363,6 +388,18 @@ async fn emit_directory(
                 username: None,
             });
         }
+    }
+    // Self entry (Tier-3 finding, #642): signal-cli's listContacts includes
+    // the own account, and the app-level ContactList handler needs the
+    // (own aci, own number) pair to fold a uuid-keyed Note to Self
+    // conversation into the canonical E.164 key.
+    if !contacts_out.iter().any(|c| c.uuid.as_deref() == Some(own_aci)) {
+        contacts_out.push(Contact {
+            number: Some(own_e164.to_string()),
+            name: None,
+            uuid: Some(own_aci.to_string()),
+            username: None,
+        });
     }
     if !contacts_out.is_empty() {
         let _ = event_tx.send(EngineEvent {
@@ -421,6 +458,34 @@ mod tests {
         assert_eq!(backoff(5), Duration::from_secs(30));
         // No attempt cap: hour-1000 still retries at the 30s ceiling.
         assert_eq!(backoff(100_000), Duration::from_secs(30));
+    }
+
+    /// Note to Self splits (Tier-3 finding, #642): the account's own ACI is
+    /// never in the synced contact list, so an unseeded resolver keys
+    /// self-conversations by uuid while the send path keys them by number.
+    #[test]
+    fn own_identity_seeds_the_resolver_even_with_no_contacts() {
+        let mut by_aci = HashMap::new();
+        seed_own_identity(&mut by_aci, "self-aci", "+15551234567");
+        let resolver = StoreResolver { by_aci };
+        assert_eq!(
+            resolver.number_for_aci("self-aci").as_deref(),
+            Some("+15551234567")
+        );
+        assert_eq!(resolver.name_for_aci("self-aci"), None);
+    }
+
+    #[test]
+    fn own_identity_seed_keeps_an_existing_contact_name() {
+        let mut by_aci = HashMap::new();
+        by_aci.insert("self-aci".to_string(), (None, Some("Me".to_string())));
+        seed_own_identity(&mut by_aci, "self-aci", "+15551234567");
+        let resolver = StoreResolver { by_aci };
+        assert_eq!(
+            resolver.number_for_aci("self-aci").as_deref(),
+            Some("+15551234567")
+        );
+        assert_eq!(resolver.name_for_aci("self-aci").as_deref(), Some("Me"));
     }
 
     #[test]

--- a/src/domain/send.rs
+++ b/src/domain/send.rs
@@ -11,10 +11,11 @@ use std::path::PathBuf;
 use crate::signal::types::{LinkPreview, StyleType};
 
 /// A request from the UI to the main loop to send something.
-// Under the native feature only the U9 stub adapter exists, which ignores
-// request payloads, so field-read analysis flags most of the vocabulary.
-// Every field is read again when U12 implements native dispatch; drop the
-// allow then.
+// Under the native feature the U12 adapter routes Message/ResolveUsername
+// but the rest of the vocabulary is still capability-gated, so field-read
+// analysis flags those variants' payloads. Fields become read again as
+// U13-U15 land each family; drop the allow when the vocabulary is fully
+// routed.
 #[cfg_attr(feature = "native-backend", allow(dead_code))]
 pub enum SendRequest {
     Message {
@@ -153,4 +154,67 @@ pub enum SendRequest {
         about: String,
         about_emoji: String,
     },
+}
+
+impl SendRequest {
+    /// Short human-readable name of the operation, for capability copy
+    /// ("native engine: reactions not implemented yet") when a backend
+    /// cannot route a variant (KTD-10 honest-gaps rule, #642 U12).
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            SendRequest::Message { .. } => "messages",
+            SendRequest::Reaction { .. } => "reactions",
+            SendRequest::Edit { .. } => "edits",
+            SendRequest::RemoteDelete { .. } => "deletes",
+            SendRequest::Typing { .. } => "typing indicators",
+            SendRequest::ReadReceipt { .. } => "read receipts",
+            SendRequest::UpdateExpiration { .. } => "disappearing-message timers",
+            SendRequest::CreateGroup { .. }
+            | SendRequest::AddGroupMembers { .. }
+            | SendRequest::RemoveGroupMembers { .. }
+            | SendRequest::RenameGroup { .. }
+            | SendRequest::LeaveGroup { .. } => "group management",
+            SendRequest::MessageRequestResponse { .. } => "message requests",
+            SendRequest::Block { .. } | SendRequest::Unblock { .. } => "blocking",
+            SendRequest::Pin { .. } | SendRequest::Unpin { .. } => "pins",
+            SendRequest::PollCreate { .. }
+            | SendRequest::PollVote { .. }
+            | SendRequest::PollTerminate { .. } => "polls",
+            SendRequest::ListIdentities => "identity listing",
+            SendRequest::ResolveUsername { .. } => "username lookup",
+            SendRequest::TrustIdentity { .. } => "identity trust",
+            SendRequest::UpdateProfile { .. } => "profile updates",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Exercised here (default lane) because only the native adapter's
+    /// capability copy consumes it in production code paths.
+    #[test]
+    fn kind_names_cover_the_vocabulary_families() {
+        assert_eq!(SendRequest::ListIdentities.kind_name(), "identity listing");
+        assert_eq!(
+            SendRequest::Reaction {
+                conv_id: String::new(),
+                emoji: String::new(),
+                is_group: false,
+                target_author: String::new(),
+                target_timestamp: 0,
+                remove: false,
+            }
+            .kind_name(),
+            "reactions"
+        );
+        assert_eq!(
+            SendRequest::LeaveGroup {
+                group_id: String::new()
+            }
+            .kind_name(),
+            "group management"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The native engine can now send. `dispatch` routes 1:1 messages and username lookups over the engine thread's new command channel; the send loop shares the receive supervisor's LocalSet (one engine thread, plan KTD-8).

## KTD-4 status semantics

- **Wire timestamp = SendToken.** The adapter generates `max(now_ms, last + 1)`, so two sends inside one millisecond get distinct, strictly increasing timestamps - required both for `pending.sends` correlation and for Signal's own (sender, timestamp) message identity. Since the caller-chosen timestamp IS the wire timestamp natively, the #480 local-to-server rewrite becomes a no-op by construction.
- **Ok -> SendTimestamp.** Spike finding (#639 question 2): presage's `Ok` means server-accepted, strong enough to drive the existing sent-status pipeline.
- **Err or 30s timeout -> SendFailed**, and the timed-out future is deliberately NOT dropped: each send runs as its own `spawn_local` task with a cloned Manager, keeps driving after the timeout fires, and a late `Ok` still emits `SendTimestamp` - upgrading the message Failed -> Sent through the dedicated status route (the #486 lesson). Per-send tasks also mean one hung websocket never serializes later sends.

## Recipient resolution (reverse KTD-6)

uuid conversation keys convert straight to ACI; E.164 keys resolve through the store's synced contacts; an unresolvable number fails the send rather than guessing (contact sync hasn't supplied it yet - the exact situation `request_contacts` at session start exists for). `ResolveUsername` answers from presage's `lookup_username` with signal-cli's `u:`-prefixed `UserStatus` echo, so `handle_user_status_list` (#612) works unchanged.

## Honest capability gates (KTD-10)

Groups name U13, attachments name U14, and every other unrouted family names itself through the new `SendRequest::kind_name()` ("native engine: reactions not implemented yet (#642)"). A dead engine thread fails the send immediately and cleans its pending entry instead of leaving Sending forever. Rich bodies (mentions/styles/quote/preview) defer to U15, documented in dispatch: bodies carry the display text meanwhile, so messages send as plain text.

## Tests

10 new: strictly-increasing same-millisecond wire timestamps, token/timestamp identity, group and attachment gating (no command reaches the engine), dead-engine cleanup, not-connected copy, username routing, capability copy naming, recipient classification (uuid / E.164 / group-id fallthrough), kind_name coverage.

- Native lane: 953 + 261 green, clippy -D warnings clean
- Default lane: 903 + 261 green, clippy -D warnings clean

## After this

U11+U12 are code-complete: the Tier-3 live run (link, two-way 1:1 conversation with checkmarks progressing, backlog-after-restart, kill -9 burst) now covers linking, receive, and send in one session.

Part of #642

## Tier-3 live run (2026-08-19, macOS, linked to a real primary)

All exit criteria pass: link via QR, two-way 1:1 with checkmarks progressing Sent -> Delivered -> Read, restart-after-offline delivers backlog exactly once, and a kill -9 during a burst lost zero messages. The run surfaced four bugs, each fixed test-first on this branch:

- **49c0aef** - engine thread stack overflow on first boot: presage's receive futures exceed the 2MiB spawned-thread default (the spike ran on the main thread's 8MiB and never saw it). Engine threads now get 16MiB; regression test recurses ~6MiB deep on the engine thread.
- **a15766e** - Note to Self send failed: the contacts walk cannot resolve the own number. Own-number sends now answer from registration data.
- **c928a78** - self-messages split into a uuid-keyed conversation: the receive resolver, built from contacts, did not know the own identity. Seeded with (own ACI -> own E.164); directory snapshot carries a self entry so the U11 stage-3 re-key folds an already-split conversation back into the number key.
- **3021336** - correction to the above: the primary syncs the own account as a contact WITHOUT a phone number, so the self entry must fill the number on the existing entry rather than skip it. Verified live: the split conversation merges on boot.

Deferred findings from the run (not this PR's scope): the native store has no single-instance guard (a second process opens it and fights for the websocket), and the oneshot CLI flags (--send/--receive/--list) still shell out to signal-cli under the native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
